### PR TITLE
Clarify name equivalence of circuit types.

### DIFF
--- a/documentation/developer/language/09_circuits.md
+++ b/documentation/developer/language/09_circuits.md
@@ -7,6 +7,7 @@ Circuits are a powerful complex data type in Leo.
 Circuit names should be CamelCase.
 Circuits can have one or more members. 
 Circuits are initialized by their defined name followed by their members in curly braces `{ }`.
+Circuit types with the same members but different names are different types.
 
 ## Circuit member values
 Circuit members can be defined as primitive values with explicit type.  


### PR DESCRIPTION
This was discussed on Slack.

The addition clarifies that Leo uses name equivalence of (circuit) types, not structural equivalence.