### PR TITLE
Update reference to Leo in crates.io

### DIFF
--- a/documentation/developer/getting_started/01_installation.md
+++ b/documentation/developer/getting_started/01_installation.md
@@ -53,7 +53,7 @@ We recommend installing Rust using [rustup](https://www.rustup.rs/). You can ins
 We recommend installing Leo this way. In your terminal, run:
 
 ```bash
-cargo install leo
+cargo install leo-lang
 ```
 
 Now to use Leo, in your terminal, run:


### PR DESCRIPTION
It looks like `leo` is obsolete (https://crates.io/crates/leo), while the newer one is `leo-lang` (https://crates.io/crates/leo-lang).