### PR TITLE
Quick fix to `cargo install` command

### DIFF
--- a/documentation/developer/getting_started/01_installation.md
+++ b/documentation/developer/getting_started/01_installation.md
@@ -53,7 +53,7 @@ We recommend installing Rust using [rustup](https://www.rustup.rs/). You can ins
 We recommend installing Leo this way. In your terminal, run:
 
 ```bash
-cargo install leo
+cargo install leo-lang
 ```
 
 Now to use Leo, in your terminal, run:


### PR DESCRIPTION
This PR changes `cargo install leo` to `cargo install leo-lang` in the docs. Thank you!

Let me know if this is the right place to make this change, or if i need to do it somewhere else.