### PR TITLE
Fixes typo in 02_records.md

### DIFF
--- a/documentation/aleo/concepts/02_records.md
+++ b/documentation/aleo/concepts/02_records.md
@@ -46,7 +46,7 @@ The **record value** specifies the amount of Aleo credits stored in the record.
 [ RECORD BYTE ARRAY ]
 ```
 
-The **record payload** is a  that encodes arbitrary application information.
+The **record payload** encodes arbitrary application information.
 
 ### Birth Program ID
 


### PR DESCRIPTION
* change "is a that encodes" -> "encodes"