### PR TITLE
use oncecell in record builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,8 +71,10 @@ version = "0.2.0"
 dependencies = [
  "aleo-account",
  "aleo-environment",
+ "derivative",
  "hex",
  "itertools",
+ "once_cell",
  "rand 0.8.3",
  "rand_chacha 0.3.0",
  "snarkvm-algorithms",
@@ -1193,9 +1195,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"

--- a/rust/record/Cargo.toml
+++ b/rust/record/Cargo.toml
@@ -39,11 +39,17 @@ default-features = false
 version = "0.5.4"
 default-features = false
 
+[dependencies.derivative]
+version = "2.2.0"
+
 [dependencies.hex]
 version = "0.4.3"
 
 [dependencies.itertools]
 version = "0.10.0"
+
+[dependencies.once_cell]
+version = "1.8.0"
 
 [dependencies.rand]
 version = "0.8.0"

--- a/rust/record/src/errors.rs
+++ b/rust/record/src/errors.rs
@@ -47,6 +47,9 @@ pub enum RecordError {
     #[error("Attempted to set `value: {}` on a dummy record", _0)]
     DummyMustBeZero(u64),
 
+    #[error("Attempted to set record builder argument {} twice", _0)]
+    DuplicateArgument(String),
+
     #[error("{}", _0)]
     EncryptionError(#[from] EncryptionError),
 

--- a/rust/record/src/lib.rs
+++ b/rust/record/src/lib.rs
@@ -13,6 +13,8 @@
 
 // You should have received a copy of the GNU General Public License
 // along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
+#[macro_use]
+extern crate derivative;
 
 #[macro_use]
 extern crate thiserror;

--- a/rust/record/src/record_builder.rs
+++ b/rust/record/src/record_builder.rs
@@ -26,22 +26,24 @@ use snarkvm_dpc::{
 };
 use snarkvm_utilities::{to_bytes, variable_length_integer::variable_length_integer, FromBytes, ToBytes, UniformRand};
 
+use once_cell::sync::OnceCell;
 use rand::{CryptoRng, Rng};
 
-/// A builder struct for the Aleo record data type.
-#[derive(Debug)]
+/// A builder struct for the record data type.
+#[derive(Derivative)]
+#[derivative(Default(bound = "E: Environment"), Debug(bound = "E: Environment"))]
 pub struct RecordBuilder<E: Environment> {
-    pub(crate) owner: Option<Address>,
-    pub(crate) is_dummy: Option<bool>,
-    pub(crate) value: Option<u64>,
-    pub(crate) payload: Option<<Record<E> as RecordScheme>::Payload>,
+    pub(crate) owner: OnceCell<Address>,
+    pub(crate) is_dummy: OnceCell<bool>,
+    pub(crate) value: OnceCell<u64>,
+    pub(crate) payload: OnceCell<<Record<E> as RecordScheme>::Payload>,
 
-    pub(crate) birth_program_id: Option<Vec<u8>>,
-    pub(crate) death_program_id: Option<Vec<u8>>,
+    pub(crate) birth_program_id: OnceCell<Vec<u8>>,
+    pub(crate) death_program_id: OnceCell<Vec<u8>>,
 
-    pub(crate) serial_number_nonce: Option<<Record<E> as RecordScheme>::SerialNumberNonce>,
-    pub(crate) commitment: Option<<Record<E> as RecordScheme>::Commitment>,
-    pub(crate) commitment_randomness: Option<<Record<E> as RecordScheme>::CommitmentRandomness>,
+    pub(crate) serial_number_nonce: OnceCell<<Record<E> as RecordScheme>::SerialNumberNonce>,
+    pub(crate) commitment: OnceCell<<Record<E> as RecordScheme>::Commitment>,
+    pub(crate) commitment_randomness: OnceCell<<Record<E> as RecordScheme>::CommitmentRandomness>,
 
     pub(crate) errors: Vec<RecordError>,
 }
@@ -59,7 +61,11 @@ impl<E: Environment> RecordBuilder<E> {
     /// Returns a new record builder and sets field `owner: Address`.
     ///
     pub fn owner<A: Into<Address>>(mut self, owner: A) -> Self {
-        self.owner = Some(owner.into());
+        let owner = owner.into();
+        let owner_string = format!("owner: {}", owner);
+        if self.owner.set(owner).is_err() {
+            self.errors.push(RecordError::DuplicateArgument(owner_string));
+        }
         self
     }
 
@@ -67,7 +73,10 @@ impl<E: Environment> RecordBuilder<E> {
     /// Returns a new record builder and sets field `value: u64`.
     ///
     pub fn value(mut self, value: u64) -> Self {
-        self.value = Some(value);
+        if self.value.set(value).is_err() {
+            self.errors
+                .push(RecordError::DuplicateArgument(format!("value: {}", value)))
+        }
         self
     }
 
@@ -75,7 +84,11 @@ impl<E: Environment> RecordBuilder<E> {
     /// Returns a new record builder and sets field `payload: Payload`.
     ///
     pub fn payload(mut self, payload: <Record<E> as RecordScheme>::Payload) -> Self {
-        self.payload = Some(payload);
+        let payload_string = hex::encode(&to_bytes![payload].unwrap()[..]);
+        if self.payload.set(payload).is_err() {
+            self.errors
+                .push(RecordError::DuplicateArgument(format!("payload: {}", payload_string)))
+        }
         self
     }
 
@@ -83,7 +96,13 @@ impl<E: Environment> RecordBuilder<E> {
     /// Returns a new record builder and sets field `birth_program_id: Vec<u8>`.
     ///
     pub fn birth_program_id(mut self, birth_program_id: Vec<u8>) -> Self {
-        self.birth_program_id = Some(birth_program_id);
+        let birth_program_id_string = hex::encode(&to_bytes![birth_program_id].unwrap()[..]);
+        if self.birth_program_id.set(birth_program_id).is_err() {
+            self.errors.push(RecordError::DuplicateArgument(format!(
+                "birth_program_id: {}",
+                birth_program_id_string
+            )))
+        }
         self
     }
 
@@ -91,7 +110,13 @@ impl<E: Environment> RecordBuilder<E> {
     /// Returns a new record builder and sets field `death_program_id: Vec<u8>`.
     ///
     pub fn death_program_id(mut self, death_program_id: Vec<u8>) -> Self {
-        self.death_program_id = Some(death_program_id);
+        let death_program_id_string = hex::encode(&to_bytes![death_program_id].unwrap()[..]);
+        if self.death_program_id.set(death_program_id).is_err() {
+            self.errors.push(RecordError::DuplicateArgument(format!(
+                "death_program_id: {}",
+                death_program_id_string
+            )))
+        }
         self
     }
 
@@ -99,7 +124,12 @@ impl<E: Environment> RecordBuilder<E> {
     /// Returns a new record builder and sets field `serial_number_nonce: SerialNumberNonce`.
     ///
     pub fn serial_number_nonce(mut self, serial_number_nonce: <Record<E> as RecordScheme>::SerialNumberNonce) -> Self {
-        self.serial_number_nonce = Some(serial_number_nonce);
+        if self.serial_number_nonce.set(serial_number_nonce).is_err() {
+            self.errors.push(RecordError::DuplicateArgument(format!(
+                "serial_number_nonce: {}",
+                hex::encode(&to_bytes![serial_number_nonce].unwrap()[..])
+            )))
+        }
         self
     }
 
@@ -122,15 +152,20 @@ impl<E: Environment> RecordBuilder<E> {
             <E::Components as DPCComponents>::SerialNumberNonceCRH::hash(&parameters.serial_number_nonce, &crh_input)
                 .unwrap();
 
-        self.serial_number_nonce = Some(sn_nonce);
-        self
+        self.serial_number_nonce(sn_nonce)
     }
 
     ///
     /// Returns a new record builder and sets field `commitment: RecordCommitment`.
     ///
     pub fn commitment(mut self, commitment: <Record<E> as RecordScheme>::Commitment) -> Self {
-        self.commitment = Some(commitment);
+        let commitment_string = hex::encode(&to_bytes![commitment].unwrap()[..]);
+        if self.commitment.set(commitment).is_err() {
+            self.errors.push(RecordError::DuplicateArgument(format!(
+                "commitment: {}",
+                commitment_string
+            )))
+        }
         self
     }
 
@@ -141,7 +176,13 @@ impl<E: Environment> RecordBuilder<E> {
         mut self,
         commitment_randomness: <Record<E> as RecordScheme>::CommitmentRandomness,
     ) -> Self {
-        self.commitment_randomness = Some(commitment_randomness);
+        let commitment_randomness_string = hex::encode(&to_bytes![commitment_randomness].unwrap()[..]);
+        if self.commitment_randomness.set(commitment_randomness).is_err() {
+            self.errors.push(RecordError::DuplicateArgument(format!(
+                "commitment_randomness: {}",
+                commitment_randomness_string
+            )))
+        }
         self
     }
 
@@ -174,37 +215,37 @@ impl<E: Environment> RecordBuilder<E> {
         }
 
         // Get owner
-        let owner = match self.owner {
+        let owner = match self.owner.get() {
             Some(value) => value,
             None => return Err(RecordError::MissingField("owner".to_string())),
         };
 
         // Get value
-        let value = match self.value {
+        let value = match self.value.get() {
             Some(value) => value,
             None => return Err(RecordError::MissingField("value".to_string())),
         };
 
         // Get payload
-        let payload = match self.payload {
+        let payload = match self.payload.get() {
             Some(payload) => payload,
             None => return Err(RecordError::MissingField("payload".to_string())),
         };
 
         // Get birth_program_id
-        let birth_program_id = match self.birth_program_id {
+        let birth_program_id = match self.birth_program_id.get() {
             Some(birth_program_id) => birth_program_id,
             None => return Err(RecordError::MissingField("birth_program_id".to_string())),
         };
 
         // Get death_program_id
-        let death_program_id = match self.death_program_id {
+        let death_program_id = match self.death_program_id.get() {
             Some(death_program_id) => death_program_id,
             None => return Err(RecordError::MissingField("death_program_id".to_string())),
         };
 
         // Get serial_number_nonce
-        let serial_number_nonce = match self.serial_number_nonce {
+        let serial_number_nonce = match self.serial_number_nonce.get() {
             Some(serial_number_nonce) => serial_number_nonce,
             None => return Err(RecordError::MissingField("serial_number_nonce".to_string())),
         };
@@ -223,13 +264,13 @@ impl<E: Environment> RecordBuilder<E> {
         .unwrap();
 
         // Derive is_dummy
-        let is_dummy = (value == 0)
-            && (payload == <Record<E> as RecordScheme>::Payload::default())
-            && (birth_program_id == noop_program_id)
-            && (death_program_id == noop_program_id);
+        let is_dummy = (*value == 0)
+            && (*payload == <Record<E> as RecordScheme>::Payload::default())
+            && (*birth_program_id == noop_program_id)
+            && (*death_program_id == noop_program_id);
 
         // Get commitment_randomness
-        let commitment_randomness = match self.commitment_randomness {
+        let commitment_randomness = match self.commitment_randomness.get() {
             Some(commitment_randomness) => commitment_randomness,
             None => return Err(RecordError::MissingRandomness),
         };
@@ -250,12 +291,12 @@ impl<E: Environment> RecordBuilder<E> {
         let commitment = <E::Components as DPCComponents>::RecordCommitment::commit(
             &system_parameters.record_commitment,
             &commitment_input,
-            &commitment_randomness,
+            commitment_randomness,
         )?;
 
         // Check the given record commitment is valid if the user provided it.
-        if let Some(given_commitment) = self.commitment {
-            if given_commitment != commitment {
+        if let Some(given_commitment) = self.commitment.get() {
+            if *given_commitment != commitment {
                 return Err(RecordError::InvalidCommitment);
             }
         }
@@ -282,22 +323,5 @@ impl<E: Environment> RecordBuilder<E> {
         Ok(Record {
             record: FromBytes::read(&to_bytes![record_bytes]?[..])?,
         })
-    }
-}
-
-impl<E: Environment> Default for RecordBuilder<E> {
-    fn default() -> Self {
-        Self {
-            owner: None,
-            is_dummy: None,
-            value: None,
-            payload: None,
-            birth_program_id: None,
-            death_program_id: None,
-            serial_number_nonce: None,
-            commitment: None,
-            commitment_randomness: None,
-            errors: vec![],
-        }
     }
 }


### PR DESCRIPTION
Record builder now calls `.set()` when setting record builder struct fields.
Consecutive calls to `.set()` will add a `Duplicate` error to the record builder errors. 

Record builder now calls `.get()` on each struct field during `.build()` method.
This does not change the logic of the build method.

This PR also adds the derivative crate as a dependency to automatically derive the default and debug methods for the record struct.