### PR TITLE
Update instructions for Sublime syntax.

### DIFF
--- a/sublime/Aleo/Aleo.sublime-syntax
+++ b/sublime/Aleo/Aleo.sublime-syntax
@@ -46,7 +46,7 @@ contexts:
       scope: visibility.aleo
 
   instructions:
-    - match: '\b(add|and|call|cast|commit|div|hash|input|key|mul|or|output|sub|ternary|pow|value)\b'
+    - match: '\b(abs|abs.w|add|add.w|and|assert.eq|assert.neq|call|cast|commit.bhp256|commit.bhp512|commit.bhp768|commit.bhp1024|commit.ped64|commit.ped128|div|div.w|double|gt|gte|hash.bhp256|hash.bhp512|hash.bhp768|hash.bhp1024|hash.ped64|hash.ped128|hash.psd2|hash.psd4|hash.psd8|inv|input|is.eq|is.neq|lt|lte|key|mod|mul|mul.w|nand|neg|nor|not|or|output|pow|pow.w|rem|rem.w|shl|shl.w|srh|shr.w|sqrt|sub|sub.w|square|ternary|value|xor)\b'
       scope: instruction.aleo
 
   numbers:


### PR DESCRIPTION
Add the missing instructions from the HackMD doc.

The following instructions are in this file but not in the HackMD doc, and have
been left in this file:
- call
- cast
- input
- key
- output
- value
