### PR TITLE
Adds support for deploying program imports on node start

### DIFF
--- a/cli/helpers/server.rs
+++ b/cli/helpers/server.rs
@@ -153,7 +153,7 @@ impl<N: Network> Server<N> {
                     .or(records_unspent)
                     .or(transaction_broadcast);
                 // Start the server.
-                println!("\n🌐 Server is running at http://0.0.0.0:4180");
+                println!("\n🌐 Server is running at http://0.0.0.0:4180\n");
                 warp::serve(routes).run(([0, 0, 0, 0], 4180)).await;
             }));
 

--- a/examples/external_call/README.md
+++ b/examples/external_call/README.md
@@ -1,0 +1,38 @@
+# external_call.aleo
+
+This program demonstrates how external calls work in Aleo.
+
+In the [imports](./imports) folder, there are four basic programs:
+- [difference.aleo](./imports/difference.aleo)
+- [product.aleo](./imports/product.aleo)
+- [quotient.aleo](./imports/quotient.aleo)
+- [sum.aleo](./imports/sum.aleo)
+
+The [`main` function in `external_call.aleo`](./main.aleo) performs 4 external calls:
+```ts
+// Creates a transition that evaluates `r0 * r1`.
+call product.aleo/product r0 r1 into r2;
+
+// Creates a transition that evaluates `r2 / r1`.
+call quotient.aleo/quotient r2 r1 into r3;
+
+// Creates a transition that evaluates `r3 + r0`.
+call sum.aleo/sum r3 r0 into r4;
+
+// Creates a transition that evaluates `r4 - r3`.
+call difference.aleo/difference r4 r3 into r5;
+```
+
+## Build Guide
+
+To compile this Aleo program, run:
+```bash
+aleo build
+```
+
+## Usage
+
+To perform the external call, run:
+```bash
+aleo run main 5u32 95u32
+```

--- a/examples/external_call/imports/difference.aleo
+++ b/examples/external_call/imports/difference.aleo
@@ -1,0 +1,9 @@
+// The 'difference.aleo' program.
+program difference.aleo;
+
+// Returns `r0 - r1`.
+function difference:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    sub r0 r1 into r2;
+    output r2 as u32.private;

--- a/examples/external_call/imports/product.aleo
+++ b/examples/external_call/imports/product.aleo
@@ -1,0 +1,9 @@
+// The 'product.aleo' program.
+program product.aleo;
+
+// Returns `r0 * r1`.
+function product:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    mul r0 r1 into r2;
+    output r2 as u32.private;

--- a/examples/external_call/imports/quotient.aleo
+++ b/examples/external_call/imports/quotient.aleo
@@ -1,0 +1,9 @@
+// The 'quotient.aleo' program.
+program quotient.aleo;
+
+// Returns `r0 / r1`.
+function quotient:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    div r0 r1 into r2;
+    output r2 as u32.private;

--- a/examples/external_call/imports/sum.aleo
+++ b/examples/external_call/imports/sum.aleo
@@ -1,0 +1,9 @@
+// The 'sum.aleo' program.
+program sum.aleo;
+
+// Returns `r0 + r1`.
+function sum:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    add r0 r1 into r2;
+    output r2 as u32.private;

--- a/examples/external_call/main.aleo
+++ b/examples/external_call/main.aleo
@@ -1,0 +1,37 @@
+// Import the 'difference.aleo' program.
+import difference.aleo;
+// Import the 'product.aleo' program.
+import product.aleo;
+// Import the 'quotient.aleo' program.
+import quotient.aleo;
+// Import the 'sum.aleo' program.
+import sum.aleo;
+
+// The 'external_call.aleo' program.
+program external_call.aleo;
+
+// Performs a sequence of arithmetic calls
+// to demonstrate external calls in Aleo.
+function main:
+    // Input the first value.
+    input r0 as u32.public;
+    // Input the second value.
+    input r1 as u32.private;
+
+    // Creates a transition that evaluates `r0 * r1`.
+    call product.aleo/product r0 r1 into r2;
+
+    // Creates a transition that evaluates `r2 / r1`.
+    call quotient.aleo/quotient r2 r1 into r3;
+
+    // Creates a transition that evaluates `r3 + r0`.
+    call sum.aleo/sum r3 r0 into r4;
+
+    // Creates a transition that evaluates `r4 - r3`.
+    call difference.aleo/difference r4 r3 into r5;
+
+    // Ensure `r5 == r0`.
+    assert.eq r5 r0;
+    
+    // Return `r5`.
+    output r5 as u32.private;

--- a/examples/external_call/program.json
+++ b/examples/external_call/program.json
@@ -1,0 +1,10 @@
+{
+    "program": "external_call.aleo",
+    "version": "0.0.0",
+    "description": "",
+    "development": {
+        "private_key": "APrivateKey1zkp2p4ieFsUJZ2EkudZEsxJTfw81T3qjdKjdbdWcJWKXapG",
+        "address": "aleo1f72p3g82eur6x8ysd4u6hl8rmt8un6eelpzrdsvfkp663wf6uuzs2v8cfk"
+    },
+    "license": "MIT"
+}


### PR DESCRIPTION
## Motivation

Fixes #303

This PR adds support for deploying program imports on `aleo node start`.

This PR also an `external_call` toy example in the `examples` folder.