### PR TITLE
Add extra endpoints to the aleo node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,9 +175,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bech32"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5738be7561b0eeb501ef1d5c5db3f24e01ceb55fededd9b00039aada34966ad"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bencher"
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "byteorder"
@@ -381,9 +381,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
 dependencies = [
  "libc",
 ]
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encode_unicode"
@@ -637,9 +637,9 @@ checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -647,33 +647,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -953,9 +953,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.131"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libz-sys"
@@ -1229,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking_lot"
@@ -1270,18 +1270,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -1667,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1713,18 +1713,18 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -1733,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
@@ -1807,7 +1807,7 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 [[package]]
 name = "snarkvm"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "anyhow",
  "clap",
@@ -1821,10 +1821,10 @@ dependencies = [
  "serde_json",
  "snarkvm-circuit",
  "snarkvm-compiler",
- "snarkvm-console",
- "snarkvm-fields",
+ "snarkvm-console 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
  "snarkvm-parameters",
- "snarkvm-utilities",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
  "thiserror",
  "ureq",
  "walkdir",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1856,18 +1856,48 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "snarkvm-curves",
- "snarkvm-fields",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
  "snarkvm-parameters",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-algorithms"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "crossbeam-channel",
+ "curl",
+ "derivative",
+ "digest 0.10.3",
+ "hashbrown",
+ "hex",
+ "itertools",
+ "lazy_static",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "sha2",
+ "smallvec",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-circuit"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -1881,38 +1911,38 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
- "snarkvm-console-account",
+ "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-types",
- "snarkvm-console-algorithms",
- "snarkvm-fields",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
- "snarkvm-console-collections",
+ "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "indexmap",
  "itertools",
@@ -1920,45 +1950,45 @@ dependencies = [
  "num-traits",
  "once_cell",
  "snarkvm-circuit-environment-witness",
- "snarkvm-console-network",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
  "snarkvm-circuit-types",
- "snarkvm-console-network",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
- "snarkvm-console-program",
- "snarkvm-utilities",
+ "snarkvm-console-program 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -1973,85 +2003,85 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
  "snarkvm-circuit-types-group",
  "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-address",
+ "snarkvm-console-types-address 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-environment",
- "snarkvm-console-types-boolean",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
  "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-group",
+ "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
- "snarkvm-console-types-integers",
+ "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
  "snarkvm-circuit-types-integers",
- "snarkvm-console-types-string",
+ "snarkvm-console-types-string 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
 name = "snarkvm-compiler"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "anyhow",
  "colored",
@@ -2063,13 +2093,13 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm-algorithms",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
  "snarkvm-circuit",
- "snarkvm-console",
- "snarkvm-curves",
- "snarkvm-fields",
+ "snarkvm-console 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
  "snarkvm-parameters",
- "snarkvm-utilities",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
  "time",
  "tracing",
 ]
@@ -2077,14 +2107,37 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-program 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+]
+
+[[package]]
+name = "snarkvm-console"
+version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
- "snarkvm-console-account",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network",
- "snarkvm-console-program",
- "snarkvm-console-types",
+ "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-program 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-account"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "base58",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2093,8 +2146,20 @@ version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
  "base58",
- "snarkvm-console-network",
- "snarkvm-console-types",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-algorithms"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "blake2s_simd",
+ "smallvec",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2104,9 +2169,20 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74e
 dependencies = [
  "blake2s_simd",
  "smallvec",
- "snarkvm-console-types",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-collections"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "aleo-std",
+ "rayon",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2116,8 +2192,27 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74e
 dependencies = [
  "aleo-std",
  "rayon",
- "snarkvm-console-algorithms",
- "snarkvm-console-types",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-network"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "lazy_static",
+ "serde",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2129,14 +2224,32 @@ dependencies = [
  "itertools",
  "lazy_static",
  "serde",
- "snarkvm-algorithms",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network-environment",
- "snarkvm-console-types",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-network-environment"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "anyhow",
+ "bech32",
+ "itertools",
+ "nom",
+ "num-traits",
+ "rand",
+ "rand_xorshift",
+ "serde",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2152,9 +2265,26 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "serde",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-program"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "enum_index",
+ "enum_index_derive",
+ "indexmap",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "serde_json",
+ "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2169,9 +2299,24 @@ dependencies = [
  "num-traits",
  "once_cell",
  "serde_json",
- "snarkvm-console-account",
- "snarkvm-console-network",
- "snarkvm-console-types",
+ "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-types"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-address 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-string 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2179,14 +2324,25 @@ name = "snarkvm-console-types"
 version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-address",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-group",
- "snarkvm-console-types-integers",
- "snarkvm-console-types-scalar",
- "snarkvm-console-types-string",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-address 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-string 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-types-address"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2194,10 +2350,18 @@ name = "snarkvm-console-types-address"
 version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-group",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-types-boolean"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2205,7 +2369,16 @@ name = "snarkvm-console-types-boolean"
 version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
- "snarkvm-console-network-environment",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-types-field"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2213,8 +2386,19 @@ name = "snarkvm-console-types-field"
 version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-types-group"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2222,10 +2406,20 @@ name = "snarkvm-console-types-group"
 version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-types-integers"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2233,9 +2427,19 @@ name = "snarkvm-console-types-integers"
 version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-types-scalar"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2243,9 +2447,20 @@ name = "snarkvm-console-types-scalar"
 version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-console-types-string"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
 ]
 
 [[package]]
@@ -2253,10 +2468,23 @@ name = "snarkvm-console-types-string"
 version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-integers",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+]
+
+[[package]]
+name = "snarkvm-curves"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "rand",
+ "rustc_version",
+ "serde",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "thiserror",
 ]
 
 [[package]]
@@ -2267,8 +2495,25 @@ dependencies = [
  "rand",
  "rustc_version",
  "serde",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-fields"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "derivative",
+ "itertools",
+ "num-traits",
+ "rand",
+ "rayon",
+ "serde",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
  "thiserror",
 ]
 
@@ -2285,14 +2530,14 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-parameters"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13#f7f5b139dda9b74ea1fc10c25b75b3a79461d3f5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2307,8 +2552,24 @@ dependencies = [
  "rand",
  "serde_json",
  "sha2",
- "snarkvm-curves",
- "snarkvm-utilities",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-r1cs"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "fxhash",
+ "indexmap",
+ "itertools",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
  "thiserror",
 ]
 
@@ -2322,9 +2583,27 @@ dependencies = [
  "fxhash",
  "indexmap",
  "itertools",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-utilities"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "num-bigint",
+ "num_cpus",
+ "rand",
+ "rand_xorshift",
+ "rayon",
+ "serde",
+ "snarkvm-utilities-derives 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
  "thiserror",
 ]
 
@@ -2342,8 +2621,20 @@ dependencies = [
  "rand_xorshift",
  "rayon",
  "serde",
- "snarkvm-utilities-derives",
+ "snarkvm-utilities-derives 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
  "thiserror",
+]
+
+[[package]]
+name = "snarkvm-utilities-derives"
+version = "0.7.5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -2367,11 +2658,11 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "serde",
- "snarkvm-console",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-console 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=f7f5b13)",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,7 +1807,7 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 [[package]]
 name = "snarkvm"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "clap",
@@ -1821,10 +1821,10 @@ dependencies = [
  "serde_json",
  "snarkvm-circuit",
  "snarkvm-compiler",
- "snarkvm-console 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "snarkvm-parameters",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "thiserror",
  "ureq",
  "walkdir",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1856,11 +1856,11 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "snarkvm-parameters",
- "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "thiserror",
 ]
 
@@ -1897,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -1911,38 +1911,38 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
- "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-types",
- "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
- "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "indexmap",
  "itertools",
@@ -1950,45 +1950,45 @@ dependencies = [
  "num-traits",
  "once_cell",
  "snarkvm-circuit-environment-witness",
- "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-r1cs 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
  "snarkvm-circuit-types",
- "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
- "snarkvm-console-program 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-program 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2003,85 +2003,85 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
  "snarkvm-circuit-types-group",
  "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-address 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-address 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
- "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
- "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
  "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
- "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
- "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
  "snarkvm-circuit-types-integers",
- "snarkvm-console-types-string 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types-string 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
 name = "snarkvm-compiler"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "colored",
@@ -2093,13 +2093,13 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "snarkvm-circuit",
- "snarkvm-console 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "snarkvm-parameters",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "time",
  "tracing",
 ]
@@ -2107,14 +2107,14 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
- "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-program 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-program 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2133,11 +2133,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "base58",
- "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2153,13 +2153,13 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "blake2s_simd",
  "smallvec",
- "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2177,12 +2177,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "rayon",
- "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2199,20 +2199,20 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "itertools",
  "lazy_static",
  "serde",
- "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-algorithms 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-collections 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2247,9 +2247,9 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "serde",
- "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2282,9 +2282,9 @@ dependencies = [
  "num-traits",
  "once_cell",
  "serde_json",
- "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-account 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-network 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2307,16 +2307,16 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
- "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-address 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-string 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-address 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-string 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2337,12 +2337,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
- "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-group 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2359,9 +2359,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
- "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2375,10 +2375,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
- "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2393,12 +2393,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
- "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-scalar 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2415,11 +2415,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
- "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2435,11 +2435,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
- "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2455,12 +2455,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
- "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-console-network-environment 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-boolean 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-field 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-console-types-integers 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
 ]
 
 [[package]]
@@ -2477,13 +2477,13 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "rand",
  "rustc_version",
  "serde",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "thiserror",
 ]
 
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2513,7 +2513,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "thiserror",
 ]
 
@@ -2537,7 +2537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2552,24 +2552,24 @@ dependencies = [
  "rand",
  "serde_json",
  "sha2",
- "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "cfg-if",
  "fxhash",
  "indexmap",
  "itertools",
- "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
- "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
+ "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "thiserror",
 ]
 
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2603,7 +2603,7 @@ dependencies = [
  "rand_xorshift",
  "rayon",
  "serde",
- "snarkvm-utilities-derives 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api)",
+ "snarkvm-utilities-derives 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75)",
  "thiserror",
 ]
 
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?branch=extend-ledger-api#d49bc0bd23bf42cd2dededefd15c17f0393f7e10"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2791,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "libc",
  "num_threads",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ version = "1"
 [dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "f7f5b13"
+branch = "extend-ledger-api"
 features = ["aleo-cli", "circuit", "console", "parallel"]
 
 [dependencies.thiserror]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ version = "1"
 [dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-branch = "extend-ledger-api"
+rev = "1db1f75"
 features = ["aleo-cli", "circuit", "console", "parallel"]
 
 [dependencies.thiserror]

--- a/cli/helpers/server.rs
+++ b/cli/helpers/server.rs
@@ -152,6 +152,12 @@ impl<N: Network> Server<N> {
             .and(with(ledger.clone()))
             .and_then(Self::get_transactions);
 
+        // GET /testnet3/transaction/{hash}
+        let get_transaction_by_hash = warp::get()
+            .and(warp::path!("testnet3" / "transaction" / String))
+            .and(with(ledger.clone()))
+            .and_then(Self::get_transaction_by_hash);
+
         // GET /testnet3/block/{height}
         let get_block = warp::get()
             .and(warp::path!("testnet3" / "block" / u32))
@@ -209,6 +215,7 @@ impl<N: Network> Server<N> {
             .or(records_unspent)
             .or(transaction_broadcast)
             .or(get_transactions)
+            .or(get_transaction_by_hash)
     }
 }
 
@@ -236,6 +243,11 @@ impl<N: Network> Server<N> {
     /// Returns the transactions for the given block height.
     async fn get_transactions(height: u32, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
         Ok(reply::json(&ledger.ledger.read().get_transactions(height).or_reject()?))
+    }
+
+    /// Returns the transactions for the given block height.
+    async fn get_transaction_by_hash(hash: String, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
+        Ok(reply::json(&ledger.ledger.read().get_transaction_by_hash(&hash).or_reject()?))
     }
 
     /// Returns the state path for the given commitment.

--- a/cli/helpers/server.rs
+++ b/cli/helpers/server.rs
@@ -246,7 +246,7 @@ impl<N: Network> Server<N> {
     }
 
     /// Returns the transactions for the given block height.
-    async fn get_transaction_by_hash(hash: String, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
+    async fn get_transaction(transaction_id: N::TransactionID, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
         Ok(reply::json(
             &ledger.ledger.read().get_transaction_by_hash(&hash).or_reject()?,
         ))

--- a/cli/helpers/server.rs
+++ b/cli/helpers/server.rs
@@ -146,6 +146,11 @@ impl<N: Network> Server<N> {
             .and(with(ledger.clone()))
             .and_then(Self::latest_block);
 
+        let get_transactions = warp::get()
+            .and(warp::path!("testnet3" / "transactions" / u32))
+            .and(with(ledger.clone()))
+            .and_then(Self::get_transactions);
+
         // GET /testnet3/block/{height}
         let get_block = warp::get()
             .and(warp::path!("testnet3" / "block" / u32))
@@ -202,6 +207,7 @@ impl<N: Network> Server<N> {
             .or(records_spent)
             .or(records_unspent)
             .or(transaction_broadcast)
+            .or(get_transactions)
     }
 }
 
@@ -224,6 +230,11 @@ impl<N: Network> Server<N> {
     /// Returns the block for the given block height.
     async fn get_block(height: u32, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
         Ok(reply::json(&ledger.ledger.read().get_block(height).or_reject()?))
+    }
+
+    /// Returns the transactions for the given block height.
+    async fn get_transactions(height: u32, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
+        Ok(reply::json(&ledger.ledger.read().get_transactions(height).or_reject()?))
     }
 
     /// Returns the state path for the given commitment.

--- a/cli/helpers/server.rs
+++ b/cli/helpers/server.rs
@@ -247,7 +247,9 @@ impl<N: Network> Server<N> {
 
     /// Returns the transactions for the given block height.
     async fn get_transaction_by_hash(hash: String, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
-        Ok(reply::json(&ledger.ledger.read().get_transaction_by_hash(&hash).or_reject()?))
+        Ok(reply::json(
+            &ledger.ledger.read().get_transaction_by_hash(&hash).or_reject()?,
+        ))
     }
 
     /// Returns the state path for the given commitment.

--- a/cli/helpers/server.rs
+++ b/cli/helpers/server.rs
@@ -248,7 +248,7 @@ impl<N: Network> Server<N> {
     /// Returns the transactions for the given block height.
     async fn get_transaction(transaction_id: N::TransactionID, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
         Ok(reply::json(
-            &ledger.ledger.read().get_transaction_by_hash(&hash).or_reject()?,
+            &ledger.ledger.read().get_transaction(transaction_id).or_reject()?,
         ))
     }
 

--- a/cli/helpers/server.rs
+++ b/cli/helpers/server.rs
@@ -146,6 +146,7 @@ impl<N: Network> Server<N> {
             .and(with(ledger.clone()))
             .and_then(Self::latest_block);
 
+        // GET /testnet3/transactions/{height}
         let get_transactions = warp::get()
             .and(warp::path!("testnet3" / "transactions" / u32))
             .and(with(ledger.clone()))


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

We need extra endpoints for integration and testing

New endpoints:

- `get_transactions` (Lists transactions for a given block by height)
- `get_transaction_by_hash` (Retrieves a transaction by hash/transaction id)

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

## Related PRs

This depends on this PR being merged beforehand
https://github.com/AleoHQ/snarkVM/pull/996
