### PR TITLE
Remove license_template_path format feature

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -9,7 +9,6 @@ use_try_shorthand = true
 
 # Nightly configurations
 imports_layout = "HorizontalVertical"
-license_template_path = ".resources/license_header"
 imports_granularity = "Crate"
 overflow_delimited_expr = true
 reorder_impl_items = true


### PR DESCRIPTION
This removes the `license_template_path` option from .rustfmt.toml since this nightly feature has been [recently removed](https://github.com/rust-lang/rustfmt/issues/5103) and it's currently making the fmt git hook fail, preventing commits.