### PR TITLE
Print transaction ID of the deployment

### DIFF
--- a/cli/commands/deploy.rs
+++ b/cli/commands/deploy.rs
@@ -35,12 +35,13 @@ impl Deploy {
         let package = Package::<Network>::open(&path)?;
 
         // Deploy the package.
-        package.deploy::<Aleo>(Some("https://www.aleo.network/testnet3/deploy".to_string()))?;
+        let response = package.deploy::<Aleo>(Some("https://www.aleo.network/testnet3/deploy".to_string()))?;
         println!();
 
         // Prepare the path string.
         let path_string = format!("(in \"{}\")", path.display());
 
+        println!("  Transaction ID: {}\n", response.transaction_id().bold());
         // Log the deploy as successful.
         Ok(format!(
             "✅ Deployed '{}' {}",


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The user of the Aleo CLI tool needs to know the transaction ID associated with the deployment of their programs. This PR includes a print of the transaction id of the deployment given by the deployment response.