### PR TITLE
Update Aleo SDK WASM

### DIFF
--- a/rust/account/src/account.rs
+++ b/rust/account/src/account.rs
@@ -15,11 +15,17 @@
 // along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkvm_wasm::{
-    account::{Address as AleoAddress, PrivateKey as AleoPrivateKey, ViewKey as AleoViewKey},
+    account::{
+        Address as AleoAddress,
+        PrivateKey as AleoPrivateKey,
+        Signature as AleoSignature,
+        ViewKey as AleoViewKey,
+    },
     network::Testnet3,
 };
 
 pub type CurrentNetwork = Testnet3;
 pub type Address = AleoAddress<CurrentNetwork>;
 pub type PrivateKey = AleoPrivateKey<CurrentNetwork>;
+pub type Signature = AleoSignature<CurrentNetwork>;
 pub type ViewKey = AleoViewKey<CurrentNetwork>;

--- a/rust/account/src/account.rs
+++ b/rust/account/src/account.rs
@@ -22,6 +22,7 @@ use snarkvm_wasm::{
         ViewKey as AleoViewKey,
     },
     network::Testnet3,
+    program::{Ciphertext as AleoCiphertext, Record as AleoRecord},
 };
 
 pub type CurrentNetwork = Testnet3;
@@ -29,3 +30,4 @@ pub type Address = AleoAddress<CurrentNetwork>;
 pub type PrivateKey = AleoPrivateKey<CurrentNetwork>;
 pub type Signature = AleoSignature<CurrentNetwork>;
 pub type ViewKey = AleoViewKey<CurrentNetwork>;
+pub type RecordCiphertext = AleoRecord<CurrentNetwork, AleoCiphertext<CurrentNetwork>>;

--- a/wasm/src/account/mod.rs
+++ b/wasm/src/account/mod.rs
@@ -16,3 +16,6 @@
 
 pub mod private_key;
 pub use private_key::*;
+
+pub mod signature;
+pub use signature::*;

--- a/wasm/src/account/mod.rs
+++ b/wasm/src/account/mod.rs
@@ -17,5 +17,8 @@
 pub mod private_key;
 pub use private_key::*;
 
+pub mod view_key;
+pub use view_key::*;
+
 pub mod signature;
 pub use signature::*;

--- a/wasm/src/account/signature.rs
+++ b/wasm/src/account/signature.rs
@@ -1,0 +1,89 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the Aleo library.
+
+// The Aleo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Aleo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
+
+use aleo_account::{Address, Signature as SignatureNative};
+
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct Signature {
+    pub(crate) signature: SignatureNative,
+}
+
+#[wasm_bindgen]
+impl Signature {
+    #[wasm_bindgen]
+    pub fn from_string(signature: &str) -> Self {
+        let signature = SignatureNative::from_str(signature).unwrap();
+
+        Self { signature }
+    }
+
+    #[wasm_bindgen]
+    pub fn verify(&self, address: &str, message: &[u8]) -> bool {
+        let address_obj = Address::from_str(address).unwrap();
+
+        self.signature.verify_bytes(&address_obj, &message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use aleo_account::PrivateKey;
+    use rand::{rngs::StdRng, SeedableRng};
+    use std::convert::TryFrom;
+    use wasm_bindgen_test::*;
+
+    const ITERATIONS: u64 = 100;
+
+    #[wasm_bindgen_test]
+    pub fn test_verify_good_signature() {
+        for _ in 0..ITERATIONS {
+            let private_key = PrivateKey::new(&mut StdRng::from_entropy()).unwrap();
+            let message: [u8; 32] = [1; 32];
+            let address = Address::try_from(&private_key).unwrap().to_string();
+
+            let signature_string = SignatureNative::sign_bytes(&private_key, &message, &mut StdRng::from_entropy())
+                .unwrap()
+                .to_string();
+            let signature = Signature::from_string(&signature_string);
+
+            // Check the private_key derived from the view key.
+            assert_eq!(true, signature.verify(&address, &message));
+        }
+    }
+
+    #[wasm_bindgen_test]
+    pub fn test_verify_bad_signature() {
+        for _ in 0..ITERATIONS {
+            let private_key = PrivateKey::new(&mut StdRng::from_entropy()).unwrap();
+            let message: [u8; 32] = [1; 32];
+            let bad_message: [u8; 32] = [2; 32];
+            let address = Address::try_from(&private_key).unwrap().to_string();
+
+            let signature_string = SignatureNative::sign_bytes(&private_key, &message, &mut StdRng::from_entropy())
+                .unwrap()
+                .to_string();
+            let signature = Signature::from_string(&signature_string);
+
+            // Check the private_key derived from the view key.
+            assert_eq!(false, signature.verify(&address, &bad_message));
+        }
+    }
+}

--- a/wasm/src/account/view_key.rs
+++ b/wasm/src/account/view_key.rs
@@ -1,0 +1,94 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the Aleo library.
+
+// The Aleo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Aleo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
+
+use aleo_account::{PrivateKey, RecordCiphertext, ViewKey as ViewKeyNative};
+
+use std::{convert::TryFrom, str::FromStr};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct ViewKey {
+    pub(crate) view_key: ViewKeyNative,
+}
+
+#[wasm_bindgen]
+impl ViewKey {
+    #[wasm_bindgen]
+    pub fn from_private_key(private_key: &str) -> Self {
+        let private_key = PrivateKey::from_str(private_key).unwrap();
+        let view_key = ViewKeyNative::try_from(private_key).unwrap();
+        Self { view_key }
+    }
+
+    #[wasm_bindgen]
+    pub fn from_string(view_key: &str) -> Self {
+        let view_key = ViewKeyNative::from_str(view_key).unwrap();
+        Self { view_key }
+    }
+
+    #[wasm_bindgen]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(&self) -> String {
+        self.view_key.to_string()
+    }
+
+    #[wasm_bindgen]
+    pub fn decrypt(&self, ciphertext: &str) -> Result<String, String> {
+        let ciphertext = RecordCiphertext::from_str(ciphertext).map_err(|error| error.to_string())?;
+        match ciphertext.decrypt(&self.view_key) {
+            Ok(plaintext) => Ok(serde_json::to_string(&plaintext).map_err(|error| error.to_string())?),
+            Err(_) => Err("Incorrect view key".to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use wasm_bindgen_test::*;
+
+    const CORRECT_VIEW_KEY: &str = "AViewKey1dcqVNvMqYGoVtaQJW1YnmH23XABeeQTq9d6XmYUmo7CW";
+    const INCORRECT_VIEW_KEY: &str = "AViewKey1i3fn5SECcVBtQMCVtTPSvdApoMYmg3ToJfNDfgHJAuoD";
+
+    #[wasm_bindgen_test]
+    pub fn test_from_private_key() {
+        let given_private_key = "APrivateKey1zkp4RyQ8Utj7aRcJgPQGEok8RMzWwUZzBhhgX6rhmBT8dcP";
+        let given_view_key = "AViewKey1i3fn5SECcVBtQMCVtTPSvdApoMYmg3ToJfNDfgHJAuoD";
+
+        let view_key = ViewKey::from_private_key(given_private_key);
+
+        assert_eq!(given_view_key, view_key.to_string());
+    }
+
+    #[wasm_bindgen_test]
+    pub fn test_decrypt_success() {
+        let ciphertext = "record1qyqspplg2ud9gguy8ud9wjmee3cf2vztxcjxe2ernf8m7ru5wvsqkdqxqyqsq7y540qmemqx3675pufewwmywsudzrpstjx3fd38c6d8uz4r4mgpqqqt2q2jjczxp2y6986zdqz3mr5jmhggmge3exc72vgw2kgr4gea2zgzhrz8q";
+        let view_key = ViewKey::from_string(CORRECT_VIEW_KEY);
+        let plaintext = view_key.decrypt(ciphertext);
+        let expected_plaintext = "\"{\\n  owner: aleo1snwe5h89dv6hv2q2pl3v8l9cweeuwrgejmlnwza6ndacygznlu9sjt8pgv.private,\\n  gates: 1u64.private,\\n  _nonce: 4447510634654730534613001085815220248957154008834207042015711498717088580021group.public\\n}\"";
+        assert!(plaintext.is_ok());
+        assert_eq!(expected_plaintext, plaintext.unwrap())
+    }
+
+    #[wasm_bindgen_test]
+    pub fn test_decrypt_fails() {
+        let ciphertext = "record1qyqspplg2ud9gguy8ud9wjmee3cf2vztxcjxe2ernf8m7ru5wvsqkdqxqyqsq7y540qmemqx3675pufewwmywsudzrpstjx3fd38c6d8uz4r4mgpqqqt2q2jjczxp2y6986zdqz3mr5jmhggmge3exc72vgw2kgr4gea2zgzhrz8q";
+        let incorrect_private_key = ViewKey::from_string(INCORRECT_VIEW_KEY);
+        let plaintext = incorrect_private_key.decrypt(ciphertext);
+        assert!(plaintext.is_err());
+    }
+}


### PR DESCRIPTION
## Motivation

We're building a wallet and need an sdk to integrate with Aleo. We've published this to npm: https://www.npmjs.com/package/@demox-labs/aleo-sdk

This is intended to be a catch all for the requested changes for the Aleo WASM SDK 

More features are needed but we have currently added:
* Account generation from seed (https://github.com/AleoHQ/aleo/pull/361)
* Signatures from private key
* Decrypt records (taken from https://github.com/Entropy1729/aleo/pull/5)

## Test Plan

Unit tests have been added and can be run using `wasm-pack test --node`

We're currently using this library in our wallet. 

## Related PRs

* Decrypt records: https://github.com/Entropy1729/aleo/pull/5
* Generate account deterministically: https://github.com/AleoHQ/aleo/pull/361
