### PR TITLE
Exports `Network` and `Aleo`.

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -23,8 +23,8 @@ pub mod commands;
 pub mod errors;
 pub mod helpers;
 
-pub(crate) type Network = snarkvm::prelude::Testnet3;
-pub(crate) type Aleo = snarkvm::circuit::AleoV0;
+pub type Network = snarkvm::prelude::Testnet3;
+pub type Aleo = snarkvm::circuit::AleoV0;
 
 #[cfg(feature = "account")]
 pub use aleo_account as account;


### PR DESCRIPTION
This PR exports the `Network` and `Aleo` types from the Aleo SDK. This is necessary to parameterize checks in Leo.
