### PR TITLE
Fix benchmark CI tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "rand",
+ "rand_chacha",
  "reqwest",
  "serde_json",
  "snarkvm",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,16 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2018"
 
+[[bench]]
+name = "account"
+path = "benches/account.rs"
+harness = false
+
+[[bench]]
+name = "private-key-encryption-at-rest"
+path = "benches/private_key_encryption.rs"
+harness = false
+
 [dependencies.anyhow]
 version = "1.0.68"
 
@@ -53,6 +63,9 @@ optional = true
 
 [dev-dependencies.bencher]
 version = "0.1.5"
+
+[dev-dependencies.rand_chacha]
+version = "0.3.1"
 
 [features]
 default = [ "blocking", "snarkvm", "snarkvm-wasm" ]

--- a/rust/benches/account.rs
+++ b/rust/benches/account.rs
@@ -1,0 +1,51 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Aleo library.
+
+// The Aleo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Aleo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
+
+#[macro_use]
+extern crate bencher;
+use snarkvm_wasm::{
+    account::{Address, PrivateKey},
+    network::Testnet3,
+};
+
+use bencher::Bencher;
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
+use std::convert::TryFrom;
+
+pub const SEED: u64 = 1231275789u64;
+
+// Bench private key generation
+fn testnet3_private_key_new(bench: &mut Bencher) {
+    let rng = &mut ChaChaRng::seed_from_u64(SEED);
+
+    bench.iter(|| {
+        let _private_key = PrivateKey::<Testnet3>::new(rng).unwrap();
+    })
+}
+
+// Bench address generation
+fn testnet3_address_from_private_key(bench: &mut Bencher) {
+    let rng = &mut ChaChaRng::seed_from_u64(SEED);
+    let private_key = PrivateKey::<Testnet3>::new(rng).unwrap();
+
+    bench.iter(|| {
+        let _address = Address::<Testnet3>::try_from(private_key).unwrap();
+    })
+}
+
+benchmark_group!(testnet3, testnet3_private_key_new, testnet3_address_from_private_key);
+benchmark_main!(testnet3);

--- a/rust/benches/private_key_encryption.rs
+++ b/rust/benches/private_key_encryption.rs
@@ -1,0 +1,66 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Aleo library.
+
+// The Aleo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Aleo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
+
+#[macro_use]
+extern crate bencher;
+
+use aleo_rust::Encryptor;
+use snarkvm_wasm::{account::PrivateKey, network::Testnet3};
+
+use bencher::Bencher;
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
+
+pub const SEED: u64 = 1231275789u64;
+
+// Bench private key encryption
+fn testnet3_private_key_encryption(bench: &mut Bencher) {
+    let rng = &mut ChaChaRng::seed_from_u64(SEED);
+    let private_key = PrivateKey::<Testnet3>::new(rng).unwrap();
+    bench.iter(|| {
+        Encryptor::<Testnet3>::encrypt_private_key_with_secret(&private_key, "password").unwrap();
+    })
+}
+
+// Bench private key decryption
+fn testnet3_private_key_decryption(bench: &mut Bencher) {
+    let rng = &mut ChaChaRng::seed_from_u64(SEED);
+    let private_key = PrivateKey::<Testnet3>::new(rng).unwrap();
+    let private_key_ciphertext =
+        Encryptor::<Testnet3>::encrypt_private_key_with_secret(&private_key, "password").unwrap();
+    bench.iter(|| {
+        Encryptor::decrypt_private_key_with_secret(&private_key_ciphertext, "password").unwrap();
+    })
+}
+
+// Bench private key encryption and decryption roundtrip
+fn testnet3_private_key_encryption_decryption_roundtrip(bench: &mut Bencher) {
+    let rng = &mut ChaChaRng::seed_from_u64(SEED);
+    let private_key = PrivateKey::<Testnet3>::new(rng).unwrap();
+    bench.iter(|| {
+        let private_key_ciphertext =
+            Encryptor::<Testnet3>::encrypt_private_key_with_secret(&private_key, "password").unwrap();
+        Encryptor::decrypt_private_key_with_secret(&private_key_ciphertext, "password").unwrap();
+    })
+}
+
+benchmark_group!(
+    testnet3,
+    testnet3_private_key_encryption,
+    testnet3_private_key_decryption,
+    testnet3_private_key_encryption_decryption_roundtrip
+);
+benchmark_main!(testnet3);


### PR DESCRIPTION
## Motivation

Removal of benchmarks broke the benchmark CI - this adds benchmarks back into the rust sdk.

## Test Plan
* Edit github actions to ensure benchmark collection is being done
* Ensure github actions are fixed