### PR TITLE
Add test coverage for js objects auto-generated by wasm

### DIFF
--- a/sdk/tests/account-data.ts
+++ b/sdk/tests/account-data.ts
@@ -1,0 +1,13 @@
+/// Test vectors created from a run of SnarkOS local network
+
+const seed = new Uint8Array([94, 91, 52, 251, 240, 230, 226, 35, 117, 253, 224, 210, 175, 13, 205, 120, 155, 214, 7, 169, 66, 62, 206, 50, 188, 40, 29, 122, 40, 250, 54, 18]);
+const message = Uint8Array.from([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]);
+const privateKeyString = "APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
+const viewKeyString = "AViewKey1mSnpFFC8Mj4fXbK5YiWgZ3mjiV8CxA79bYNa8ymUpTrw"
+const addressString = "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px"
+const ciphertextString = "record1qyqspnp6w0fmrr66xsx5rwh4cp2qy7c3rp0ra0rf8rqd0t8u30d28nqxqyqsqqmnjvj7a8cs2es783xmd8sc2u46essh2f7w6vm26s4cks865lq0qzszm3clnh2vlpazmcjhan74nq0rr6hrtagwnw0grkrzuevg2x8sjjy02jy";
+const foreignCiphertextString = "record1qqj3a67efazf0awe09grqqg44htnh9vaw7l729vl309c972x7ldquqq2k2cax8s7qsqqyqtpgvqqyqsq4seyrzvfa98fkggzccqr68af8e9m0q8rzeqh8a8aqql3a854v58sgrygdv4jn9s8ckwfd48vujrmv0rtfasqh8ygn88ch34ftck8szspvfpsqqszqzvxx9t8s9g66teeepgxmvnw5ymgapcwt2lpy9d5eus580k08wpq544jcl437wjv206u5pxst6few9ll4yhufwldgpx80rlwq8nhssqywmfsd85skg564vqhm3gxsp8q6r30udmqxrxmxx2v8xycdg8pn5ps3dhfvv"
+const foreignViewKeyString = "AViewKey1ghtvuJQQzQ31xSiVh6X1PK8biEVhQBygRGV4KdYmq4JT"
+const expectedDecryptedRecordString = "{\n  owner: aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px.private,\n  gates: 550000000000000u64.private,\n  _nonce: 4324037486175223501017904251644658173467860078798396792350707407904752217504group.public\n}";
+
+export { seed, message, privateKeyString, viewKeyString, addressString, ciphertextString, foreignCiphertextString, foreignViewKeyString, expectedDecryptedRecordString };

--- a/sdk/tests/account.test.ts
+++ b/sdk/tests/account.test.ts
@@ -1,14 +1,6 @@
 import { Account } from '../src'
 import { PrivateKey, ViewKey, Address } from '@aleohq/wasm';
-
-/// Test vectors created from a run of SnarkOS local network
-const seed = new Uint8Array([94, 91, 52, 251, 240, 230, 226, 35, 117, 253, 224, 210, 175, 13, 205, 120, 155, 214, 7, 169, 66, 62, 206, 50, 188, 40, 29, 122, 40, 250, 54, 18]);
-const privateKey = "APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
-const viewKey = "AViewKey1mSnpFFC8Mj4fXbK5YiWgZ3mjiV8CxA79bYNa8ymUpTrw"
-const address = "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px"
-const ciphertext = "record1qyqspnp6w0fmrr66xsx5rwh4cp2qy7c3rp0ra0rf8rqd0t8u30d28nqxqyqsqqmnjvj7a8cs2es783xmd8sc2u46essh2f7w6vm26s4cks865lq0qzszm3clnh2vlpazmcjhan74nq0rr6hrtagwnw0grkrzuevg2x8sjjy02jy";
-const foreignCiphertext = "record1qqj3a67efazf0awe09grqqg44htnh9vaw7l729vl309c972x7ldquqq2k2cax8s7qsqqyqtpgvqqyqsq4seyrzvfa98fkggzccqr68af8e9m0q8rzeqh8a8aqql3a854v58sgrygdv4jn9s8ckwfd48vujrmv0rtfasqh8ygn88ch34ftck8szspvfpsqqszqzvxx9t8s9g66teeepgxmvnw5ymgapcwt2lpy9d5eus580k08wpq544jcl437wjv206u5pxst6few9ll4yhufwldgpx80rlwq8nhssqywmfsd85skg564vqhm3gxsp8q6r30udmqxrxmxx2v8xycdg8pn5ps3dhfvv"
-const expectedDecryptedRecord = "{\n  owner: aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px.private,\n  gates: 550000000000000u64.private,\n  _nonce: 4324037486175223501017904251644658173467860078798396792350707407904752217504group.public\n}";
+import { seed, message, privateKeyString, viewKeyString, addressString, ciphertextString, foreignCiphertextString, expectedDecryptedRecordString } from './account-data';
 
 describe('Account', () => {
     describe('constructors', () => {
@@ -37,10 +29,10 @@ describe('Account', () => {
             expect(account.viewKey()).toBeInstanceOf(ViewKey);
             expect(account.address()).toBeInstanceOf(Address);
             // Test that expected output is generated
-            expect(account.privateKey().to_string()).toEqual(privateKey);
-            expect(account.viewKey().to_string()).toEqual(viewKey);
-            expect(account.address().to_string()).toEqual(address);
-            expect(account.toString()).toEqual(address);
+            expect(account.privateKey().to_string()).toEqual(privateKeyString);
+            expect(account.viewKey().to_string()).toEqual(viewKeyString);
+            expect(account.address().to_string()).toEqual(addressString);
+            expect(account.toString()).toEqual(addressString);
         });
 
         test('throws an error if parameters are invalid', () => {
@@ -49,7 +41,7 @@ describe('Account', () => {
 
         test('creates an account object from a valid private key string', () => {
             // Generate account from valid private key string
-            const account = new Account( {privateKey: privateKey});
+            const account = new Account( {privateKey: privateKeyString});
             // Test object member type consistency
             expect(account.pk).toBeInstanceOf(PrivateKey);
             expect(account.vk).toBeInstanceOf(ViewKey);
@@ -59,45 +51,45 @@ describe('Account', () => {
             expect(account.viewKey()).toBeInstanceOf(ViewKey);
             expect(account.address()).toBeInstanceOf(Address);
             // Test that expected output is generated
-            expect(account.privateKey().to_string()).toEqual(privateKey);
-            expect(account.viewKey().to_string()).toEqual(viewKey);
-            expect(account.address().to_string()).toEqual(address);
-            expect(account.toString()).toEqual(address);
+            expect(account.privateKey().to_string()).toEqual(privateKeyString);
+            expect(account.viewKey().to_string()).toEqual(viewKeyString);
+            expect(account.address().to_string()).toEqual(addressString);
+            expect(account.toString()).toEqual(addressString);
         });
     });
 
     describe('View Key Record Decryption', () => {
         test('decrypts a record in ciphertext form', () => {
-            const account = new Account({privateKey: privateKey});
+            const account = new Account({privateKey: privateKeyString});
             const decrypt_spy = jest.spyOn(account.vk, 'decrypt');
             // Decrypt record the private key owns
-            const decryptedRecord = account.decryptRecord(ciphertext);
+            const decryptedRecord = account.decryptRecord(ciphertextString);
             // Ensure the underlying wasm is being called with the right data
-            expect(decrypt_spy).toHaveBeenCalledWith(ciphertext);
+            expect(decrypt_spy).toHaveBeenCalledWith(ciphertextString);
             // Ensure it decrypts to the correct data
-            expect(decryptedRecord).toBe(expectedDecryptedRecord);
+            expect(decryptedRecord).toBe(expectedDecryptedRecordString);
         });
 
         test('doesnt decrypt records from other accounts', () => {
             function tryDecrypt() {
                 try {
-                    return account.decryptRecord(foreignCiphertext);
+                    return account.decryptRecord(foreignCiphertextString);
                 } catch (err) {
                     expect(String(err)).toMatch("RuntimeError: unreachable");
                     throw("Record didn't decrypt")
                 }
             }
-            const account = new Account({privateKey: privateKey});
+            const account = new Account({privateKey: privateKeyString});
             const decrypt_spy = jest.spyOn(account.vk, 'decrypt');
             // Ensure a foreign record decryption attempt throws
             expect(tryDecrypt).toThrow();
             // Ensure the underlying wasm is being called with the right data
-            expect(decrypt_spy).toHaveBeenCalledWith(foreignCiphertext);
+            expect(decrypt_spy).toHaveBeenCalledWith(foreignCiphertextString);
         });
 
         test('decrypts an array of records in ciphertext form', () => {
-            const account = new Account({privateKey: privateKey});
-            const ciphertexts = [ciphertext, ciphertext];
+            const account = new Account({privateKey: privateKeyString});
+            const ciphertexts = [ciphertextString, ciphertextString];
             const decrypt_spy = jest.spyOn(account.vk, 'decrypt');
             const decryptedRecords = account.decryptRecords(ciphertexts);
             // Ensure the right number of calls were called and right inputs were passed
@@ -105,7 +97,7 @@ describe('Account', () => {
             expect(decrypt_spy).toHaveBeenCalledWith(ciphertexts[0]);
             expect(decrypt_spy).toHaveBeenCalledWith(ciphertexts[1]);
             // Ensure the records were decrypted to the correct data
-            expect(decryptedRecords).toEqual([expectedDecryptedRecord, expectedDecryptedRecord]);
+            expect(decryptedRecords).toEqual([expectedDecryptedRecordString, expectedDecryptedRecordString]);
         });
     });
 
@@ -113,7 +105,6 @@ describe('Account', () => {
 
         test("verifies the signature on a message", () => {
             const account = new Account();
-            const message = Uint8Array.from([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]);
             const other_message = Uint8Array.from([104, 101, 108, 108, 111, 32, 120, 121, 114, 108, 99]);
             const sign_spy = jest.spyOn(account.pk, 'sign');
             const signature = account.sign(message);

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -1,0 +1,316 @@
+import { Address, PrivateKey, ViewKey, PrivateKeyCiphertext, Signature, RecordCiphertext, RecordPlaintext } from "@aleohq/wasm";
+import { seed, message, privateKeyString, viewKeyString, addressString, ciphertextString, foreignViewKeyString, expectedDecryptedRecordString } from './account-data';
+
+describe('WASM Objects', () => {
+    describe('Address', () => {
+        it('can be constructed from a private key', () => {
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            const address = Address.from_private_key(privateKey);
+            // Ensure the address is an instance of Address
+            expect(address).toBeInstanceOf(Address);
+            // Ensure the address string matches the expected value
+            expect(address.to_string()).toMatch(addressString);
+        });
+
+        it('can be constructed from view key', () => {
+            const viewKey = ViewKey.from_string(viewKeyString);
+            const address = Address.from_view_key(viewKey);
+            // Ensure the address is an instance of Address
+            expect(address).toBeInstanceOf(Address);
+            // Ensure the address string matches the expected value
+            expect(address.to_string()).toMatch(addressString);
+        });
+
+        it('can be constructed from an address string', () => {
+            const address = Address.from_string(addressString);
+            // Ensure the address is an instance of Address
+            expect(address).toBeInstanceOf(Address);
+            // Ensure the address string matches the expected value
+            expect(address.to_string()).toMatch(addressString);
+        });
+
+        it('can verify a message signed by the correct private key', () => {
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            const signature = privateKey.sign(message);
+            const address = Address.from_private_key(privateKey);
+            const result = address.verify(message, signature);
+            // Ensure the result is a boolean
+            expect(typeof result).toBe('boolean');
+            // Ensure the signature verified
+            expect(result).toBe(true);
+        });
+
+        it('cannot verify a message signed by the wrong private key', () => {
+            const privateKey = new PrivateKey();
+            const otherPrivateKey = new PrivateKey();
+            const signature = otherPrivateKey.sign(message);
+            const address = Address.from_private_key(privateKey);
+            const result = address.verify(message, signature);
+            // Ensure the result is a boolean
+            expect(typeof result).toBe('boolean');
+            // Ensure the signature failed to verify
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('PrivateKey', () => {
+        it ('creates new accounts from sampling an rng for the initial seed', () => {
+            const privateKey = new PrivateKey();
+            // Ensure the private key is a PrivateKey instance
+            expect(privateKey).toBeInstanceOf(PrivateKey);
+
+            const privateKey2 = new PrivateKey();
+            // Ensure the private key is a PrivateKey instance
+            expect(privateKey2).toBeInstanceOf(PrivateKey);
+            // Ensure the private keys are different
+            expect(privateKey.to_string()).not.toBe(privateKey2.to_string());
+        });
+
+        it('constructs properly from a seed', () => {
+            const privateKey = PrivateKey.from_seed_unchecked(seed);
+            // Ensure the private key is a PrivateKey instance
+            expect(privateKey).toBeInstanceOf(PrivateKey);
+            // Ensure the private key is the correct value
+            expect(privateKey.to_string()).toMatch(privateKeyString);
+        });
+
+        it('constructs properly from a private key string', () => {
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            // Ensure the private key is a PrivateKey instance
+            expect(privateKey).toBeInstanceOf(PrivateKey);
+            // Ensure the private key is the correct value
+            expect(privateKey.to_string()).toMatch(privateKeyString);
+        });
+
+        it('derives the correct view key and address', () => {
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            const viewKey = privateKey.to_view_key();
+            const address = privateKey.to_address();
+            // Ensure the view key and address are the correct types
+            expect(viewKey).toBeInstanceOf(ViewKey);
+            expect(address).toBeInstanceOf(Address);
+            // Ensure the view key and address are the correct values
+            expect(viewKey.to_string()).toMatch(viewKeyString);
+            expect(address.to_string()).toMatch(addressString);
+        });
+
+        it('can construct directly to ciphertext and then decrypt to a private key', () => {
+            const secret = 'mypassword';
+            const ciphertext = PrivateKey.new_encrypted(secret);
+            // Ensure the ciphertext is a PrivateKeyCiphertext instance
+            expect(ciphertext).toBeInstanceOf(PrivateKeyCiphertext);
+            const privateKeyFromCiphertext = PrivateKey.fromPrivateKeyCiphertext(ciphertext, secret);
+            // Ensure the decrypted private key is a PrivateKey instance
+            expect(privateKeyFromCiphertext).toBeInstanceOf(PrivateKey);
+        });
+
+        it('encrypts and decrypts to and from ciphertext', () => {
+            const secret = 'mypassword';
+            const privateKey = new PrivateKey();
+            const ciphertext = privateKey.toCiphertext(secret);
+
+            // Ensure the ciphertext is a PrivateKeyCiphertext instance
+            expect(ciphertext).toBeInstanceOf(PrivateKeyCiphertext);
+            const privateKeyFromCiphertext = PrivateKey.fromPrivateKeyCiphertext(ciphertext, secret);
+            // Ensure the decrypted private key is a PrivateKey instance
+            expect(privateKeyFromCiphertext).toBeInstanceOf(PrivateKey);
+            // Ensure the decrypted private key is the same as the original
+            expect(privateKeyFromCiphertext.to_string()).toBe(privateKey.to_string());
+        });
+
+        it('properly assesses equality and inequality', () => {
+            const privateKey1 = new PrivateKey();
+            const privateKey2 = PrivateKey.from_string(privateKeyString);
+            const privateKey3 = PrivateKey.from_string(privateKeyString);
+
+            // Ensure the different private keys are not equal
+            expect((privateKey1 === privateKey2)).toBeFalsy();
+            // Ensure the same private keys are equal
+            expect((privateKey2 === privateKey2)).toBeTruthy();
+            expect(privateKey2.to_string()).toBe(privateKey3.to_string());
+        });
+
+        it('has different ciphertexts for the same password, but decrypts to the same key', () => {
+            const secret = 'mypassword';
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            const ciphertext = privateKey.toCiphertext(secret);
+            const ciphertext2 = privateKey.toCiphertext(secret);
+            // Ensure the ciphertexts are different
+            expect(ciphertext).not.toBe(ciphertext2);
+
+            const decryptedPrivateKey = PrivateKey.fromPrivateKeyCiphertext(ciphertext, secret);
+            const decryptedPrivateKey2 = PrivateKey.fromPrivateKeyCiphertext(ciphertext2, secret);
+            // Ensure the decrypted private keys are both PrivateKey instances
+            expect(decryptedPrivateKey).toBeInstanceOf(PrivateKey);
+            expect(decryptedPrivateKey2).toBeInstanceOf(PrivateKey);
+            // Ensure the decrypted private keys are the same as the original
+            expect(decryptedPrivateKey.to_string()).toBe(privateKeyString);
+            expect(decryptedPrivateKey2.to_string()).toBe(privateKeyString);
+            expect(decryptedPrivateKey.to_string()).toBe(decryptedPrivateKey2.to_string());
+        });
+    });
+
+    describe('ViewKey', () => {
+        it('constructs properly from a string', () => {
+            const viewKey = ViewKey.from_string(viewKeyString);
+            // Ensure the view key is a ViewKey instance
+            expect(viewKey).toBeInstanceOf(ViewKey);
+            // Ensure the view key is the correct value
+            expect(viewKey.to_string()).toMatch(viewKeyString);
+        });
+
+        it('derives the correct address', () => {
+            const viewKey = ViewKey.from_string(viewKeyString);
+            const address = viewKey.to_address();
+            // Ensure the address is an Address instance
+            expect(address).toBeInstanceOf(Address);
+            // Ensure the address is the correct value
+            expect(address.to_string()).toMatch(addressString);
+        });
+
+        it('properly assesses equality and inequality', () => {
+            const viewKey1 = new ViewKey();
+            const viewKey2 = ViewKey.from_string(viewKeyString);
+            const viewKey3 = ViewKey.from_string(viewKeyString);
+
+            // Ensure the different view keys are not equal
+            expect((viewKey1 === viewKey2)).toBeFalsy();
+            // Ensure the same view keys are equal
+            expect((viewKey2 === viewKey2)).toBeTruthy();
+            expect(viewKey2.to_string()).toBe(viewKey3.to_string());
+        });
+
+        it('can decrypt a record generated by the account', () => {
+            const viewKey = ViewKey.from_string(viewKeyString);
+            const decryptedRecord = viewKey.decrypt(ciphertextString);
+            // Ensure it decrypts to the correct data
+            expect(decryptedRecord).toBe(expectedDecryptedRecordString);
+        });
+    });
+
+    describe('Signature', () => {
+        it('can verify a message signed by the correct private key', () => {
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            const address = Address.from_private_key(privateKey);
+            const signature = Signature.sign(privateKey, message);
+            const result = signature.verify(address, message);
+            // Ensure the result is a boolean
+            expect(typeof result).toBe('boolean');
+            // Ensure the signature verified
+            expect(result).toBe(true);
+        });
+
+        it('cannot verify a message signed by the wrong private key', () => {
+            const privateKey = new PrivateKey();
+            const address = Address.from_private_key(privateKey);
+            const otherPrivateKey = new PrivateKey();
+
+            const signature = Signature.sign(otherPrivateKey, message);
+            const result = signature.verify(address, message);
+
+            // Ensure the result is a boolean
+            expect(typeof result).toBe('boolean');
+            // Ensure the signature failed to verify
+            expect(result).toBe(false);
+        });
+
+        it('can go to and from string', () => {
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            const signature = Signature.sign(privateKey, message);
+            const signatureString = signature.to_string();
+            const signatureFromString = Signature.from_string(signatureString);
+            // Ensure the signature is a Signature instance
+            expect(signature).toBeInstanceOf(Signature);
+            // Ensure from_string returns a Signature instance
+            expect(signatureFromString).toBeInstanceOf(Signature);
+            // Ensure the signature to_string matches the expected values
+            expect(signature.to_string()).toBe(signatureString);
+            expect(signatureFromString.to_string()).toBe(signatureString);
+        });
+    });
+
+    describe('PrivateKeyCipherText', () => {
+        it('should encrypt and decrypt a private key to and from ciphertext', () => {
+            const secret = 'mypassword';
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            const ciphertext = PrivateKeyCiphertext.encryptPrivateKey(privateKey, secret);
+            const decryptedKey = ciphertext.decryptToPrivateKey(secret);
+            // Ensure the decrypted key is a PrivateKey instance and is the same as the original
+            expect(decryptedKey).toBeInstanceOf(PrivateKey);
+            expect(decryptedKey.to_string()).toBe(privateKeyString);
+        });
+
+        it('should fail to decrypt with a bad secret', () => {
+            const secret = 'mypassword';
+            const badSecret = 'badpassword';
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            const ciphertext = PrivateKeyCiphertext.encryptPrivateKey(privateKey, secret);
+            try {
+                ciphertext.decryptToPrivateKey(badSecret);
+                // Should not get here
+                expect(true).toBe(false);
+            } catch (e) {
+                // Should error out
+                expect(true).toBe(true);
+            }
+        });
+
+        it('should not create ciphertexts that match for the same password, but should decrypt to the same key', () => {
+            const secret = 'mypassword';
+            const privateKey = PrivateKey.from_string(privateKeyString);
+            const ciphertext = PrivateKeyCiphertext.encryptPrivateKey(privateKey, secret);
+            const ciphertext2 = PrivateKeyCiphertext.encryptPrivateKey(privateKey, secret);
+            // Ensure the ciphertexts are different
+            expect(ciphertext).not.toBe(ciphertext2);
+
+            const decryptedKey = ciphertext.decryptToPrivateKey(secret);
+            const decryptedKey2 = ciphertext2.decryptToPrivateKey(secret);
+            // Ensure the decrypted are both private key instances and have the same key
+            expect(decryptedKey).toBeInstanceOf(PrivateKey);
+            expect(decryptedKey2).toBeInstanceOf(PrivateKey);
+            expect(decryptedKey.to_string()).toBe(privateKeyString);
+            expect(decryptedKey2.to_string()).toBe(privateKeyString);
+        });
+    });
+
+    describe('RecordCiphertext', () => {
+        const viewKey = ViewKey.from_string(viewKeyString);
+        const foreignViewKey = ViewKey.from_string(foreignViewKeyString);
+
+        it('can be created from and output to a string', () => {
+            const ciphertext = RecordCiphertext.fromString(ciphertextString);
+            // Ensure the string matches the string the record was created from
+            expect(ciphertext.toString()).toEqual(ciphertextString);
+        });
+
+        it('can be decrypted and identified as owner with a valid view key', () => {
+            const ciphertext = RecordCiphertext.fromString(ciphertextString);
+            const plaintext = ciphertext.decrypt(viewKey);
+            const isOwner = ciphertext.isOwner(viewKey);
+            // Ensure the record ciphertext is decrypted correctly
+            expect(plaintext.toString()).toEqual(expectedDecryptedRecordString);
+            // Ensure the view key is identified as the owner of the record
+            expect(isOwner).toBe(true);
+        });
+
+        it('cant be decrypted nor identified as owner with a foreign view key', () => {
+            const ciphertext = RecordCiphertext.fromString(ciphertextString);
+            // Ensure the record ciphertext cannot be decrypted with a foreign view key
+            expect(ciphertext.isOwner(foreignViewKey)).toBe(false);
+            // Ensure the record ciphertext cannot be decrypted with a foreign view key
+            expect(() => ciphertext.decrypt(foreignViewKey)).toThrow();
+        });
+    });
+
+    describe('RecordPlaintext', () => {
+        it('can be created from a string gives the correct number of gates, and can export to a string', () => {
+            const plaintext = RecordPlaintext.fromString(expectedDecryptedRecordString);
+            // Ensure the string matches the string the record was created from
+            expect(plaintext.toString()).toEqual(expectedDecryptedRecordString);
+            console.log("Gates: " + plaintext.gates().toString());
+            console.log("Record: " + plaintext.toString());
+            // Ensure the record has the correct number of gates
+            expect(plaintext.gates()).toEqual(BigInt(550000000000000));
+        });
+    });
+});


### PR DESCRIPTION
## Motivation

This PR addresses the need to have complete test coverage on the Aleo SDK by adding test coverage to the all auto-generated `wasm` functions within typescript SDK. These tests provide %100 test coverage to all exported functions within the `aleo-wasm` package on npm.

## Related PRs
#470 