### PR TITLE
[Feature] Add execute feature to Aleo CLI 

### DIFF
--- a/.circleci/aleo-new.sh
+++ b/.circleci/aleo-new.sh
@@ -1,3 +1,12 @@
+# Test `aleo execute`
+# Ensure execute runs and does not search for a record when a record is specified for the fee
+$ALEO execute hello.aleo main 4u32 5u32 -c ciphertext1qvqgkey2cxklg4g5qjn4h3alvx2z33dwga380ma2fajz2kjxqjpmqyd79h6lr6ck8rgwkr9ekvh2phws6j5njsu6jz9tkk09hd3w2p5vzyc8ppprvj49nnaf7c9hhvq5vsltpjx48zlmlps6mg6xu0sef0xpz4ccrdc --password password -r "{ owner: aleo18x0yenrkceapvt85e6aqw2v8hq37hpt4ew6k6cgum6xlpmaxt5xqwnkuja.private, gates: 1099999999999864u64.private, _nonce: 3859911413360468505092363429199432421222291175370483298628506550397056121761group.public }" --fee 0.005 || exit
+# Ensure execute runs successfully with a private key ciphertext and password
+$ALEO execute hello.aleo main 4u32 5u32 -c ciphertext1qvqgkey2cxklg4g5qjn4h3alvx2z33dwga380ma2fajz2kjxqjpmqyd79h6lr6ck8rgwkr9ekvh2phws6j5njsu6jz9tkk09hd3w2p5vzyc8ppprvj49nnaf7c9hhvq5vsltpjx48zlmlps6mg6xu0sef0xpz4ccrdc --password password || exit
+# Ensure execute runs successfully with a private key
+$ALEO execute hello.aleo main 4u32 5u32 -k APrivateKey1zkp8ofTUBgVXF1wn83AZNYyWBJUowHtAAmWAXk1ck5kKiXw || exit
+
+# Test `aleo new, build, and run` to ensure that the universal parameters are downloaded correctly
 echo "Downloading parameters. This may take a few minutes..."
 
 # Create a new foo Leo project.
@@ -20,8 +29,5 @@ done
 # Try to run `aleo run`
 $ALEO run hello 1u32 2u32 || exit
 
-# Try to run `aleo execute`
-$ALEO aleo execute hello.aleo main 4u32 5u32 -c ciphertext1qvqgkey2cxklg4g5qjn4h3alvx2z33dwga380ma2fajz2kjxqjpmqyd79h6lr6ck8rgwkr9ekvh2phws6j5njsu6jz9tkk09hd3w2p5vzyc8ppprvj49nnaf7c9hhvq5vsltpjx48zlmlps6mg6xu0sef0xpz4ccrdc --password password
-$ALEO execute credits.aleo mint aleo196s3phrm295gsnkp64zpfjdefjk4fx0n3tl9xzjn4kjf038swg8qvamf5v 1000000u64 -c ciphertext1qvqgkey2cxklg4g5qjnkhyn9ed6whjlxtqr4txpmp0ws7sxglsmt2zws9ey2s7eq2xk5jz9kkvh2phws6j5njsu6zqvdzs4uq9qkmm4tpntfyztfgg45glltweu2cue38hqulwg8a9e9eps6mg6xu0sef0xpz4ca4x7 --password password -e http://localhost:3030
 # Remove the foo program.
 cd .. && rm -rf foo

--- a/.circleci/aleo-new.sh
+++ b/.circleci/aleo-new.sh
@@ -17,8 +17,11 @@ DONE=$?
 sleep 0.5
 done
 
-# Try to run `aleo run`.
+# Try to run `aleo run`
 $ALEO run hello 1u32 2u32 || exit
 
+# Try to run `aleo execute`
+$ALEO aleo execute hello.aleo main 4u32 5u32 -c ciphertext1qvqgkey2cxklg4g5qjn4h3alvx2z33dwga380ma2fajz2kjxqjpmqyd79h6lr6ck8rgwkr9ekvh2phws6j5njsu6jz9tkk09hd3w2p5vzyc8ppprvj49nnaf7c9hhvq5vsltpjx48zlmlps6mg6xu0sef0xpz4ccrdc --password password
+$ALEO execute credits.aleo mint aleo196s3phrm295gsnkp64zpfjdefjk4fx0n3tl9xzjn4kjf038swg8qvamf5v 1000000u64 -c ciphertext1qvqgkey2cxklg4g5qjnkhyn9ed6whjlxtqr4txpmp0ws7sxglsmt2zws9ey2s7eq2xk5jz9kkvh2phws6j5njsu6zqvdzs4uq9qkmm4tpntfyztfgg45glltweu2cue38hqulwg8a9e9eps6mg6xu0sef0xpz4ca4x7 --password password -e http://localhost:3030
 # Remove the foo program.
 cd .. && rm -rf foo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "rand_chacha",
  "rpassword",
  "rusty-hook",
- "self_update",
+ "self_update 0.35.0",
  "serde",
  "serde_json",
  "snarkvm",
@@ -1713,6 +1713,23 @@ dependencies = [
 
 [[package]]
 name = "self_update"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e18819cd93c4799f93cd4cf0ac069ed0e615fea3af28ec78df71e0ea890628a"
+dependencies = [
+ "hyper",
+ "indicatif",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "self_update"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca4e4e6f29fddb78b3e7a6e5a395e8274d4aca2d36b2278a297fa49673a5b7c7"
@@ -1841,7 +1858,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "self_update",
+ "self_update 0.36.0",
  "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
@@ -2426,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c2fc59610557d3f4e8c215d43bdb90748aec810ba0b04e6fa7d1b6543ece"
+checksum = "f8ae117741aead5d67d7ef5c7a7b60b0df6c7bb0a735563d4a069a2f788b756a"
 dependencies = [
  "getrandom",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [ "rust", "wasm" ]
 version = "0.9.14"
 
 [workspace.dependencies.snarkvm-wasm]
-version = "0.9.13"
+version = "0.9.14"
 default-features = false
 
 [lib]

--- a/cli/commands/execute.rs
+++ b/cli/commands/execute.rs
@@ -21,7 +21,6 @@ use snarkvm::prelude::{Ciphertext, Identifier, Plaintext, PrivateKey, ProgramID,
 use anyhow::{anyhow, ensure, Result};
 use clap::Parser;
 use colored::Colorize;
-use std::path::PathBuf;
 
 /// Executes an Aleo program function
 #[derive(Debug, Parser)]
@@ -41,9 +40,6 @@ pub struct Execute {
     /// Execution fee in credits, defaults to 0
     #[clap(long)]
     fee: Option<f64>,
-    /// Local program directory to use
-    #[clap(short, long)]
-    directory: Option<PathBuf>,
     /// The record to spend the fee from
     #[clap(short, long)]
     record: Option<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>,
@@ -101,7 +97,7 @@ impl Execute {
             self.private_key,
             self.ciphertext.clone(),
             Some(api_client.clone()),
-            self.directory,
+            None,
         )?;
         program_manager.find_program(&self.program_id)?;
 
@@ -125,7 +121,7 @@ impl Execute {
         };
 
         // Execute the program function
-        println!("Executing program: {}", program_string.bright_blue());
+        println!("Executing function {} from program: {}", function_string.bright_blue(), program_string.bright_blue());
         let result = program_manager.execute_program(
             self.program_id,
             self.function,
@@ -145,8 +141,8 @@ impl Execute {
         } else {
             println!(
                 "Execution of function {} from {} successful!",
-                function_string.red().bold(),
-                program_string.red().bold()
+                function_string.green().bold(),
+                program_string.green().bold()
             );
             println!("Transaction ID:");
         }
@@ -221,22 +217,5 @@ mod tests {
         ]);
 
         assert!(execute_bad_peer.unwrap().parse().is_err());
-
-        // Assert execute fails if a bad path is specified
-        let execute_bad_path = Execute::try_parse_from([
-            "aleo",
-            "hello.aleo",
-            "main",
-            "1337u32",
-            "42u32",
-            "-k",
-            &recipient_private_key.to_string(),
-            "-e",
-            "http://localhost:3030",
-            "-d",
-            "/this/path/does/not/exist",
-        ]);
-
-        assert!(execute_bad_path.unwrap().parse().is_err());
     }
 }

--- a/cli/commands/execute.rs
+++ b/cli/commands/execute.rs
@@ -1,0 +1,242 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Aleo library.
+
+// The Aleo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Aleo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::CurrentNetwork;
+use aleo_rust::{AleoAPIClient, Encryptor, ProgramManager, RecordFinder};
+use snarkvm::prelude::{Ciphertext, Identifier, Plaintext, PrivateKey, ProgramID, Record, Value};
+
+use anyhow::{anyhow, ensure, Result};
+use clap::Parser;
+use colored::Colorize;
+use std::path::PathBuf;
+
+/// Executes an Aleo program function
+#[derive(Debug, Parser)]
+pub struct Execute {
+    /// The program identifier
+    #[clap(parse(try_from_str))]
+    program_id: ProgramID<CurrentNetwork>,
+    /// The function name
+    #[clap(parse(try_from_str))]
+    function: Identifier<CurrentNetwork>,
+    /// The function inputs
+    #[clap(parse(try_from_str))]
+    inputs: Vec<Value<CurrentNetwork>>,
+    /// Aleo Network peer to broadcast the transaction to
+    #[clap(short, long)]
+    endpoint: Option<String>,
+    /// Execution fee in credits, defaults to 0
+    #[clap(long)]
+    fee: Option<f64>,
+    /// Local program directory to use
+    #[clap(short, long)]
+    directory: Option<PathBuf>,
+    /// The record to spend the fee from
+    #[clap(short, long)]
+    record: Option<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>,
+    /// Private key used to generate the execution
+    #[clap(short='k', long, conflicts_with_all = &["ciphertext", "password"])]
+    private_key: Option<PrivateKey<CurrentNetwork>>,
+    /// Private key ciphertext used to generate the execution (requires password to decrypt)
+    #[clap(short, long, conflicts_with = "private-key", requires = "password")]
+    ciphertext: Option<Ciphertext<CurrentNetwork>>,
+    /// Password to decrypt the private key
+    #[clap(long, conflicts_with = "private-key", requires = "ciphertext")]
+    password: Option<String>,
+}
+
+impl Execute {
+    pub fn parse(self) -> Result<String> {
+        // Check for config errors
+        ensure!(
+            !(self.private_key.is_none() && self.ciphertext.is_none()),
+            "Private key or private key ciphertext required to execute a function"
+        );
+
+        // Convert execution fee to gates
+        let fee_credits = self.fee.unwrap_or(0f64);
+        let fee_gates = (fee_credits * 1000000.0) as u64;
+
+        // Get strings for the program and function for logging
+        let program_string = self.program_id.to_string();
+        let function_string = self.function.to_string();
+
+        println!(
+            "{}",
+            format!(
+                "Attempting to execute function '{}' from program '{}' with a fee of {} credits",
+                &function_string, &program_string, fee_credits
+            )
+            .bright_blue()
+        );
+
+        // Setup the API client to use configured peer or default to https://vm.aleo.org/api/testnet3
+        let api_client = self
+            .endpoint
+            .map_or_else(
+                || {
+                    println!("Using default peer: {}", "https://vm.aleo.org/api/testnet3");
+                    Ok(AleoAPIClient::<CurrentNetwork>::testnet3())
+                },
+                |peer| AleoAPIClient::<CurrentNetwork>::new(&peer, "testnet3"),
+            )
+            .map_err(|e| anyhow!("{:?}", e))?;
+
+        // Create the program manager and find the program
+        println!("Attempting to find program: {}", program_string.bright_blue());
+        let mut program_manager = ProgramManager::<CurrentNetwork>::new(
+            self.private_key,
+            self.ciphertext.clone(),
+            Some(api_client.clone()),
+            self.directory,
+        )?;
+        program_manager.find_program(&self.program_id)?;
+
+        // Find a fee record to pay the fee if necessary
+        let fee_record = if fee_gates > 0 {
+            if self.record.is_none() {
+                println!("Searching for a record to spend the execution fee from, this may take a while..");
+                let private_key = if let Some(private_key) = self.private_key {
+                    private_key
+                } else {
+                    let ciphertext = self.ciphertext.as_ref().unwrap();
+                    Encryptor::decrypt_private_key_with_secret(ciphertext, self.password.as_ref().unwrap())?
+                };
+                let record_finder = RecordFinder::new(api_client);
+                Some(record_finder.find_one_record(&private_key, fee_gates)?)
+            } else {
+                self.record
+            }
+        } else {
+            None
+        };
+
+        // Execute the program function
+        println!("Executing program: {}", program_string.bright_blue());
+        let result = program_manager.execute_program(
+            self.program_id,
+            self.function,
+            self.inputs.iter(),
+            fee_gates,
+            fee_record,
+            self.password.as_deref(),
+        );
+
+        // Inform the user of the result of the program execution
+        if result.is_err() {
+            println!(
+                "Execution of function {} from {} failed with error:",
+                function_string.red().bold(),
+                program_string.red().bold()
+            );
+        } else {
+            println!(
+                "Execution of function {} from {} successful!",
+                function_string.red().bold(),
+                program_string.red().bold()
+            );
+            println!("Transaction ID:");
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm::prelude::TestRng;
+
+    #[test]
+    fn test_execution_config_errors() {
+        // Generate key material
+        let recipient_private_key = PrivateKey::<CurrentNetwork>::new(&mut TestRng::default()).unwrap();
+        let ciphertext = Some(Encryptor::encrypt_private_key_with_secret(&recipient_private_key, "password").unwrap());
+
+        // Assert execute fails without a private key or private key ciphertext
+        let execute_missing_key_material = Execute::try_parse_from(["aleo", "hello.aleo", "main", "1337u32", "42u32"]);
+
+        assert!(execute_missing_key_material.unwrap().parse().is_err());
+
+        // Assert execute fails if both a private key and ciphertext are provided
+        let execute_conflicting_inputs = Execute::try_parse_from([
+            "aleo",
+            "hello.aleo",
+            "main",
+            "1337u32",
+            "42u32",
+            "-k",
+            &recipient_private_key.to_string(),
+            "--ciphertext",
+            &ciphertext.as_ref().unwrap().to_string(),
+            "--password",
+            "password",
+        ]);
+
+        assert_eq!(execute_conflicting_inputs.unwrap_err().kind(), clap::ErrorKind::ArgumentConflict);
+
+        // Assert execute fails if a ciphertext is provided without a password
+        let ciphertext = Some(Encryptor::encrypt_private_key_with_secret(&recipient_private_key, "password").unwrap());
+        let execute_no_password = Execute::try_parse_from([
+            "aleo",
+            "hello.aleo",
+            "main",
+            "1337u32",
+            "42u32",
+            "--ciphertext",
+            &ciphertext.as_ref().unwrap().to_string(),
+        ]);
+
+        assert_eq!(execute_no_password.unwrap_err().kind(), clap::ErrorKind::MissingRequiredArgument);
+
+        // Assert execute fails if only a password is provided
+        let execute_password_only =
+            Execute::try_parse_from(["aleo", "hello.aleo", "main", "1337u32", "42u32", "--password", "password"]);
+
+        assert_eq!(execute_password_only.unwrap_err().kind(), clap::ErrorKind::MissingRequiredArgument);
+
+        // Assert execute fails if invalid peer is specified
+        let execute_bad_peer = Execute::try_parse_from([
+            "aleo",
+            "hello.aleo",
+            "main",
+            "1337u32",
+            "42u32",
+            "-k",
+            &recipient_private_key.to_string(),
+            "-e",
+            "localhost:3030",
+        ]);
+
+        assert!(execute_bad_peer.unwrap().parse().is_err());
+
+        // Assert execute fails if a bad path is specified
+        let execute_bad_path = Execute::try_parse_from([
+            "aleo",
+            "hello.aleo",
+            "main",
+            "1337u32",
+            "42u32",
+            "-k",
+            &recipient_private_key.to_string(),
+            "-e",
+            "http://localhost:3030",
+            "-d",
+            "/this/path/does/not/exist",
+        ]);
+
+        assert!(execute_bad_path.unwrap().parse().is_err());
+    }
+}

--- a/cli/commands/execute.rs
+++ b/cli/commands/execute.rs
@@ -88,7 +88,7 @@ impl Execute {
             .endpoint
             .map_or_else(
                 || {
-                    println!("Using default peer: {}", "https://vm.aleo.org/api/testnet3");
+                    println!("Using default peer: https://vm.aleo.org/api/testnet3");
                     Ok(AleoAPIClient::<CurrentNetwork>::testnet3())
                 },
                 |peer| AleoAPIClient::<CurrentNetwork>::new(&peer, "testnet3"),

--- a/cli/commands/mod.rs
+++ b/cli/commands/mod.rs
@@ -26,6 +26,9 @@ pub use clean::*;
 mod deploy;
 pub use deploy::*;
 
+mod execute;
+pub use execute::*;
+
 mod new;
 pub use new::*;
 
@@ -65,6 +68,8 @@ pub enum Command {
     Clean(Clean),
     #[clap(name = "deploy")]
     Deploy(Deploy),
+    #[clap(name = "execute")]
+    Execute(Execute),
     #[clap(name = "new")]
     New(New),
     // #[clap(subcommand)]
@@ -85,6 +90,7 @@ impl Command {
             Self::Build(command) => command.parse(),
             Self::Clean(command) => command.parse(),
             Self::Deploy(command) => command.parse(),
+            Self::Execute(command) => command.parse(),
             Self::New(command) => command.parse(),
             // Self::Node(command) => command.parse(),
             Self::Run(command) => command.parse(),

--- a/cli/commands/run.rs
+++ b/cli/commands/run.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 
 pub const LOCALE: &num_format::Locale = &num_format::Locale::en;
 
-/// Executes an Aleo program function.
+/// Executes an Aleo program function locally
 #[derive(Debug, Parser)]
 pub struct Run {
     /// The function name.

--- a/cli/commands/transfer.rs
+++ b/cli/commands/transfer.rs
@@ -16,7 +16,7 @@
 
 use crate::CurrentNetwork;
 use aleo_rust::{AleoAPIClient, Encryptor, ProgramManager, RecordFinder};
-use snarkvm::prelude::{Address, Ciphertext, Plaintext, PrivateKey, Record, Testnet3};
+use snarkvm::prelude::{Address, Ciphertext, Plaintext, PrivateKey, Record};
 
 use anyhow::{anyhow, ensure, Result};
 use clap::Parser;
@@ -90,8 +90,12 @@ impl Transfer {
             .map_err(|e| anyhow!("{:?}", e))?;
 
         // Create the program manager
-        let program_manager =
-            ProgramManager::<Testnet3>::new(self.private_key, self.ciphertext.clone(), Some(api_client.clone()), None)?;
+        let program_manager = ProgramManager::<CurrentNetwork>::new(
+            self.private_key,
+            self.ciphertext.clone(),
+            Some(api_client.clone()),
+            None,
+        )?;
 
         // Find the input records from the Aleo Network if not provided
         let private_key = if let Some(private_key) = self.private_key {

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -54,7 +54,7 @@ version = "0.9.14"
 [dependencies.snarkvm-synthesizer]
 features = [ "parallel" ]
 optional = true
-version = "0.9.13"
+version = "0.9.14"
 
 [dependencies.snarkvm]
 optional = true

--- a/rust/src/program/deploy.rs
+++ b/rust/src/program/deploy.rs
@@ -210,7 +210,7 @@ mod tests {
                 .unwrap();
 
         // Wait for the transactions to show up on chain
-        thread::sleep(std::time::Duration::from_secs(10));
+        thread::sleep(std::time::Duration::from_secs(30));
         let deployment_fee = 200000001;
         let fee_record = record_finder.find_one_record(&recipient_private_key, deployment_fee).unwrap();
         program_manager.deploy_program("credits_import_test.aleo", deployment_fee, fee_record, None).unwrap();

--- a/rust/src/program/execute.rs
+++ b/rust/src/program/execute.rs
@@ -42,8 +42,10 @@ impl<N: Network> ProgramManager<N> {
             "❌ Network client not set. A network client must be set before execution in order to send an execution transaction to the Aleo network"
         );
 
-        // Check program has a valid name
+        // Check program and function has a valid name
         let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
+        let function_id = function.try_into().map_err(|_| anyhow!("Invalid function name"))?;
+        let function_name = function_id.to_string();
 
         // Get the program from chain, error if it doesn't exist
         let program = self
@@ -63,7 +65,7 @@ impl<N: Network> ProgramManager<N> {
             inputs,
             fee_record,
             &program,
-            function,
+            function_id,
             query.to_string(),
         )?;
 
@@ -73,9 +75,9 @@ impl<N: Network> ProgramManager<N> {
 
         // Tell the user about the result of the execution before returning it
         if execution.is_ok() {
-            println!("✅ Execution transaction for {program_id:?} broadcast successfully");
+            println!("✅ Execution of function {function_name:?} from program {program_id:?}' broadcast successfully");
         } else {
-            println!("❌ Execution transaction for {program_id:?} failed to broadcast");
+            println!("❌ Execution of function {function_name:?} from program {program_id:?} failed to broadcast");
         }
 
         execution

--- a/rust/src/program/helpers/records.rs
+++ b/rust/src/program/helpers/records.rs
@@ -65,9 +65,7 @@ impl<N: Network> RecordFinder<N> {
         amounts: Vec<u64>,
         private_key: &PrivateKey<N>,
     ) -> Result<Vec<Record<N, Plaintext<N>>>> {
-        let records = self.find_unspent_records_on_chain(Some(&amounts), None, private_key);
-        println!("records: {:?}", records);
-        records
+        self.find_unspent_records_on_chain(Some(&amounts), None, private_key)
     }
 
     pub fn find_unspent_records_on_chain(

--- a/rust/src/program/helpers/records.rs
+++ b/rust/src/program/helpers/records.rs
@@ -21,7 +21,7 @@ use snarkvm_console::{
     program::{Plaintext, Record},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 
 pub struct RecordFinder<N: Network> {
     api_client: AleoAPIClient<N>,
@@ -43,7 +43,8 @@ impl<N: Network> RecordFinder<N> {
         fee: u64,
         private_key: &PrivateKey<N>,
     ) -> Result<(Record<N, Plaintext<N>>, Record<N, Plaintext<N>>)> {
-        self.find_record_amounts(vec![amount, fee], private_key).map(|records| (records[0].clone(), records[1].clone()))
+        let records = self.find_record_amounts(vec![amount, fee], private_key)?;
+        if records.len() < 2 { bail!("Insufficient funds") } else { Ok((records[0].clone(), records[1].clone())) }
     }
 
     /// Resolve a record with a specific value. If successful it will return a record with a gate


### PR DESCRIPTION
## Motivation

Now that the SDK has the ability to provide transfer, deploy, and execute functionality to arbitrary software stacks, it's desirable to make it available via the Aleo cli.

This PR adds the `execute` function to the cli

## Test Plan
* Tests on config options are present
* Tests testing executions are added to `aleo-executable` test