### PR TITLE
[Fix] Fix benchmark ci test

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - testnet3
+      - fix/benchmark-fix
 
 jobs:
   deploy:
@@ -71,7 +72,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       - uses: actions/cache@v2
@@ -85,7 +86,7 @@ jobs:
       # Run benchmark and stores the output to a file
       - name: Benchmark
         run: |
-          cargo +nightly bench --all | tee output.txt
+          cargo bench --all | tee output.txt
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data


### PR DESCRIPTION
## Motivation

The benchmark test is currently broken due to a compiler bug in the nightly build of rust, this PR fixes the benchmark test by changing the branch to the stable branch.

## Test Plan
* All CI is green