### PR TITLE
[Fix] Fix benchmark CI test

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       - uses: actions/cache@v2
@@ -85,7 +85,7 @@ jobs:
       # Run benchmark and stores the output to a file
       - name: Benchmark
         run: |
-          cargo +nightly bench --all | tee output.txt
+          cargo bench --all | tee output.txt
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data


### PR DESCRIPTION
## Motivation

Currently this test in the `testnet3` repo is using nightly rust, and is currently encountering a compiler error. This changes the `rust` channel used in the ci test to `stable` to avoid intermittent CI outages due to unstable features