### PR TITLE
Add Rust SDK Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,7 @@ storage*/
 
 ## OS Files
 **.DS_Store
+**.*.DS_Store
+rust/src/.DS_Store
+rust/src/program/.DS_Store
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,10 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aleo"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aleo-rust",
- "aleo-wasm",
  "anyhow",
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "aleo-rust"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bencher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo"
-version = "0.3.5"
+version = "0.3.6"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Aleo"
 homepage = "https://aleo.org"
@@ -35,18 +35,11 @@ name = "aleo"
 path = "cli/main.rs"
 
 [features]
-default = [ "aleo-rust" ]
-wasm = [ "aleo-wasm" ]
+default = [ ]
 
 [dependencies.aleo-rust]
 path = "rust"
 version = "0.3.5"
-optional = true
-
-[dependencies.aleo-wasm]
-path = "wasm"
-version = "0.3.5"
-optional = true
 
 [dependencies.anyhow]
 version = "1.0"

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -16,18 +16,12 @@
 
 #![forbid(unsafe_code)]
 
-#[cfg(not(feature = "wasm"))]
 #[macro_use]
 extern crate thiserror;
 
-#[cfg(not(feature = "wasm"))]
 pub mod commands;
-#[cfg(not(feature = "wasm"))]
 pub mod errors;
-#[cfg(not(feature = "wasm"))]
 pub mod helpers;
 
-#[cfg(not(feature = "wasm"))]
 pub type CurrentNetwork = snarkvm::prelude::Testnet3;
-#[cfg(not(feature = "wasm"))]
 pub type Aleo = snarkvm::circuit::AleoV0;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -14,12 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
 
-#[cfg(not(feature = "wasm"))]
 use aleo::{commands::CLI, helpers::Updater};
-#[cfg(not(feature = "wasm"))]
 use clap::Parser;
 
-#[cfg(not(feature = "wasm"))]
 fn main() -> anyhow::Result<()> {
     // Parse the given arguments.
     let cli = CLI::parse();
@@ -31,9 +28,4 @@ fn main() -> anyhow::Result<()> {
         Err(error) => println!("⚠️  {error}\n"),
     }
     Ok(())
-}
-
-#[cfg(feature = "wasm")]
-fn main() {
-    println!("The rust CLI application cannot be run when using the wasm feature flag");
 }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.5"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Rust SDK for managing Aleo acccounts and programs"
 homepage = "https://aleo.org"
+readme = "README.md"
 repository = "https://github.com/AleoHQ/aleo"
 keywords = [
   "aleo",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "aleo-rust"
-version = "0.3.5"
+version = "0.3.6"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
-description = "Rust SDK for managing Aleo acccounts and programs"
+description = "Rust SDK for managing Aleo programs and communicating with the Aleo network"
 homepage = "https://aleo.org"
 readme = "README.md"
 repository = "https://github.com/AleoHQ/aleo"

--- a/rust/README.md
+++ b/rust/README.md
@@ -25,11 +25,14 @@ The key usages of the Aleo API client are:
 ### Example Usage
 ```rust
 use aleo_rust::AleoAPIClient;
-use snarkvm_console::account::PrivateKey;
+use snarkvm_console::{
+    account::PrivateKey,
+    network::Testnet3, 
+};
 use rand::thread_rng;
 
 // Create a client that interacts with the testnet3 program
-let api_client = AleoAPIClient::testnet3();
+let api_client = AleoAPIClient::<Testnet3>testnet3();
 
 // FIND A PROGRAM ON THE ALEO NETWORK
 let hello = api_client.get_program("hello.aleo").unwrap();
@@ -85,7 +88,7 @@ let mut program_manager = ProgramManager::<Testnet3>::new(None, Some(private_key
 
 // Execute the function `main` of the hello.aleo program with the arguments 5u32 and 3u32.
 // Specify 0 for the fee and provide a password to decrypt the private key stored in the program manager
-program_manager.execute_program("hello.aleo", "main", [5u32, 3u32].into_iter(), 0, None, Some("password")).unwrap();
+program_manager.execute_program("hello.aleo", "main", ["5u32", "3u32"].into_iter(), 0, None, Some("password")).unwrap();
 
 // ------------------
 // DEPLOY PROGRAM STEPS

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,137 @@
+# Aleo Rust SDK
+
+[![github]](https://github.com/AleoHQ/aleo)&ensp;[![crates-io]](https://crates.io/crates/aleo-rust)&ensp;[![docs-rs]](https://docs.rs/aleo-rust/latest/aleo_rust/)
+
+[github]: https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github
+[crates-io]: https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust
+[docs-rs]: https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
+
+The Aleo Rust SDK provides a set of tools for deploying and executing programs as well as tools for communicating with the Aleo Network.
+Aleo Network Interaction
+
+## Aleo Network Interaction
+Users of the SDK can interact with the Aleo network via the AleoAPIClient struct. 
+
+The Aleo Network has nodes within the network which provide a REST API for interacting with the network. The 
+AleoAPIClient struct provides a 1:1 mapping of those REST API endpoints as well as several convenience methods for 
+interacting with the network.
+
+The key usages of the Aleo API client are:
+* Finding records to spend in value transfers, program executions and program deployments
+* Locating programs deployed on the network
+* Sending transactions to the network
+* Inspecting chain data such as block content, transaction content, etc.
+
+### Example Usage
+```rust
+use aleo_rust::AleoAPIClient;
+use snarkvm_console::account::PrivateKey;
+use rand::thread_rng;
+
+// Create a client that interacts with the testnet3 program
+let api_client = AleoAPIClient::testnet3();
+
+// FIND A PROGRAM ON THE ALEO NETWORK
+let hello = api_client.get_program("hello.aleo").unwrap();
+println!("Hello program: {hello:?}");
+
+// FIND RECORDS THAT BELONG TO A PRIVATE KEY
+let mut rng = thread_rng();
+// Create a private key (in practice, this would be an existing user's private key)
+let private_key = PrivateKey::new(&mut rng).unwrap();
+// Get the latest block height
+let end_height = api_client.latest_height().unwrap();
+// Look back 1000 blocks
+let start_height = end_height - 1000u32;
+// Find records with these gate amounts (requires an account with a balance)
+let amounts_to_find = vec![100u64, 200u64];
+let records = api_client.get_unspent_records(&private_key, (start_height..end_height), None, Some(&amounts_to_find)).unwrap();
+```
+
+## Program Execution and Deployment
+The Aleo ProgramManager provides a set of tools for deploying and executing programs locally and on the Aleo Network. The 
+RecordFinder struct is used in conjunction with the program manager to find records to spend in value transfers and 
+program execution/deployments fees.
+
+The program deployment and execution flow are shown in the example below.
+
+### Example Usage
+```rust
+use aleo_rust::{AleoAPIClient, Encryptor, ProgramManager, RecordFinder};
+use snarkvm_console::{
+  account::{Address, PrivateKey},
+  network::Testnet3,
+};
+use snarkvm_synthesizer::Program;
+use rand::thread_rng;
+use std::str::FromStr;
+
+// Create the necessary components to create the program manager
+let mut rng = thread_rng();
+// Create an api client to query the network state
+let api_client = AleoAPIClient::<Testnet3>::testnet3();
+// Create a private key (in practice, this would be a user's private key)
+let private_key = PrivateKey::<Testnet3>::new(&mut rng).unwrap();
+// Encrypt the private key with a password
+let private_key_ciphertext = Encryptor::<Testnet3>::encrypt_private_key_with_secret(&private_key, "password").unwrap();
+
+// Create the program manager
+// (Note: An optional local directory can be provided to manage local program data)
+let mut program_manager = ProgramManager::<Testnet3>::new(None, Some(private_key_ciphertext), Some(api_client), None).unwrap();
+
+// ------------------
+// EXECUTE PROGRAM STEPS
+// ------------------
+
+// Execute the function `main` of the hello.aleo program with the arguments 5u32 and 3u32.
+// Specify 0 for the fee and provide a password to decrypt the private key stored in the program manager
+program_manager.execute_program("hello.aleo", "main", [5u32, 3u32].into_iter(), 0, None, Some("password")).unwrap();
+
+// ------------------
+// DEPLOY PROGRAM STEPS
+// ------------------
+
+// Note - Deployment requires a mandatory deployment fee, so an account with an existing
+// balance is required to deploy a program
+
+// Create a program name (note: change this to something unique)
+let program_name = "yourownprogram.aleo";
+// Create a test program
+let test_program = format!("program {};\n\nfunction main:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n", program_name);
+// Create a program object from the program string
+let program = Program::from_str(&test_program).unwrap();
+// Add the program to the program manager (this can also be done by providing a path to
+// the program on disk when the program manager is created)
+program_manager.add_program(&program).unwrap();
+// Create a record finder to find records to fund the deployment fee
+let record_finder = RecordFinder::<Testnet3>::new(AleoAPIClient::testnet3());
+// Set the fee for the deployment transaction (in units of gates)
+let fee_gates = 300000;
+// Find a record to fund the deployment fee (requires an account with a balance)
+let record = record_finder.find_one_record(&private_key, fee_gates).unwrap();
+// Deploy the program to the network
+program_manager.deploy_program(program_name, fee_gates, record, Some("password")).unwrap();
+
+// Wait several minutes.. then check the program exists on the network
+let api_client = AleoAPIClient::<Testnet3>::testnet3();
+let program_on_chain = api_client.get_program(program_name).unwrap();
+let program_on_chain_name = program_on_chain.id().to_string();
+assert_eq!(&program_on_chain_name, program_name);
+
+// ------------------
+// TRANSFER STEPS
+// ------------------
+
+// Create a recipient (in practice, the recipient would send their address to the sender)
+let recipient_key = PrivateKey::<Testnet3>::new(&mut rng).unwrap();
+let recipient_address = Address::try_from(recipient_key).unwrap();
+// Create amount and fee (both in units of gates)
+let amount = 30000;
+let fee = 100;
+// Find records to fund the transfer
+let (amount_record, fee_record) = record_finder.find_amount_and_fee_records(amount, fee, &private_key).unwrap();
+// Create a transfer
+program_manager.transfer(amount, fee, recipient_address, Some("password"), amount_record, Some(fee_record)).unwrap();
+```
+This API is currently under active development and is expected to change in order to provide a more streamlined 
+experience for program execution and deployment.

--- a/rust/README.md
+++ b/rust/README.md
@@ -7,16 +7,15 @@
 [docs-rs]: https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
 
 The Aleo Rust SDK provides a set of tools for deploying and executing programs as well as tools for communicating with the Aleo Network.
-Aleo Network Interaction
 
 ## Aleo Network Interaction
-Users of the SDK can interact with the Aleo network via the AleoAPIClient struct. 
+Users of the SDK can interact with the Aleo network via the AleoAPIClient struct.
 
 The Aleo Network has nodes within the network which provide a REST API for interacting with the network. The 
 AleoAPIClient struct provides a 1:1 mapping of those REST API endpoints as well as several convenience methods for 
 interacting with the network.
 
-The key usages of the Aleo API client are:
+Some key usages of the Aleo API client are:
 * Finding records to spend in value transfers, program executions and program deployments
 * Locating programs deployed on the network
 * Sending transactions to the network
@@ -136,5 +135,5 @@ let (amount_record, fee_record) = record_finder.find_amount_and_fee_records(amou
 // Create a transfer
 program_manager.transfer(amount, fee, recipient_address, Some("password"), amount_record, Some(fee_record)).unwrap();
 ```
-This API is currently under active development and is expected to change in order to provide a more streamlined 
+This API is currently under active development and is expected to change in the future in order to provide a more streamlined 
 experience for program execution and deployment.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,13 +39,16 @@
 //! * Inspecting chain data such as block content, transaction content, etc.
 //!
 //! ### Example Usage
-//!   ```
+//! ```no_run
 //!   use aleo_rust::AleoAPIClient;
-//!   use snarkvm_console::account::PrivateKey;
+//!   use snarkvm_console::{
+//!       account::PrivateKey,
+//!       network::Testnet3,
+//!   };
 //!   use rand::thread_rng;
 //!
 //!   // Create a client that interacts with the testnet3 program
-//!   let api_client = AleoAPIClient::testnet3();
+//!   let api_client = AleoAPIClient::<Testnet3>::testnet3();
 //!
 //!   // FIND A PROGRAM ON THE ALEO NETWORK
 //!   let hello = api_client.get_program("hello.aleo").unwrap();
@@ -75,7 +78,7 @@
 //! The program deployment and execution flow are shown in the example below.
 //!
 //! ### Example Usage
-//! ```
+//! ```no_run
 //!   use aleo_rust::{AleoAPIClient, Encryptor, ProgramManager, RecordFinder};
 //!   use snarkvm_console::{
 //!       account::{Address, PrivateKey},
@@ -104,7 +107,7 @@
 //!
 //!   // Execute the function `main` of the hello.aleo program with the arguments 5u32 and 3u32.
 //!   // Specify 0 for the fee and provide a password to decrypt the private key stored in the program manager
-//!   program_manager.execute_program("hello.aleo", "main", [5u32, 3u32].into_iter(), 0, None, Some("password")).unwrap();
+//!   program_manager.execute_program("hello.aleo", "main", ["5u32", "3u32"].into_iter(), 0, None, Some("password")).unwrap();
 //!
 //!   // ------------------
 //!   // DEPLOY PROGRAM STEPS

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,6 +14,149 @@
 // You should have received a copy of the GNU General Public License
 // along with the Aleo library. If not, see <https://www.gnu.org/licenses/>.
 
+//! [![github]](https://github.com/AleoHQ/aleo)&ensp;[![crates-io]](https://crates.io/crates/aleo-rust)&ensp;[![docs-rs]](https://docs.rs/aleo-rust/latest/aleo_rust/)
+//!
+//! [github]: https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github
+//! [crates-io]: https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust
+//! [docs-rs]: https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
+//!
+//! <br/>
+//! The Aleo Rust SDK provides a set of tools for deploying and executing programs as well as
+//! tools for communicating with the Aleo Network.
+//!
+//! # Aleo Network Interaction
+//!
+//! Users of the SDK can interact with the Aleo network via the [AleoAPIClient] struct.
+//!
+//! The Aleo Network has nodes within the network which provide a REST API for interacting with
+//! the network. The AleoAPIClient struct provides a 1:1 mapping of those REST API endpoints as well
+//! as several convenience methods for interacting with the network.
+//!
+//! The key usages of the Aleo API client are:
+//! * Finding records to spend in value transfers, program executions and program deployments
+//! * Locating programs deployed on the network
+//! * Sending transactions to the network
+//! * Inspecting chain data such as block content, transaction content, etc.
+//!
+//! ### Example Usage
+//!   ```
+//!   use aleo_rust::AleoAPIClient;
+//!   use snarkvm_console::account::PrivateKey;
+//!   use rand::thread_rng;
+//!
+//!   // Create a client that interacts with the testnet3 program
+//!   let api_client = AleoAPIClient::testnet3();
+//!
+//!   // FIND A PROGRAM ON THE ALEO NETWORK
+//!   let hello = api_client.get_program("hello.aleo").unwrap();
+//!   println!("Hello program: {hello:?}");
+//!
+//!   // FIND RECORDS THAT BELONG TO A PRIVATE KEY
+//!   let mut rng = thread_rng();
+//!   // Create a private key (in practice, this would be an existing user's private key)
+//!   let private_key = PrivateKey::new(&mut rng).unwrap();
+//!   // Get the latest block height
+//!   let end_height = api_client.latest_height().unwrap();
+//!   // Look back 1000 blocks
+//!   let start_height = end_height - 1000u32;
+//!   // Find records with these gate amounts (requires an account with a balance)
+//!   let amounts_to_find = vec![100u64, 200u64];
+//!   let records = api_client.get_unspent_records(&private_key, (start_height..end_height), None, Some(&amounts_to_find)).unwrap();
+//!
+//!   ```
+//! # Program Execution and Deployment
+//!
+//! The Aleo [ProgramManager] provides a set of tools for deploying and executing programs locally
+//! and on the Aleo Network.
+//!
+//! The [RecordFinder] struct is used in conjunction with the ProgramManager to find records to
+//! spend in value transfers and program execution/deployments fees.
+//!
+//! The program deployment and execution flow are shown in the example below.
+//!
+//! ### Example Usage
+//! ```
+//!   use aleo_rust::{AleoAPIClient, Encryptor, ProgramManager, RecordFinder};
+//!   use snarkvm_console::{
+//!       account::{Address, PrivateKey},
+//!       network::Testnet3,
+//!   };
+//!   use snarkvm_synthesizer::Program;
+//!   use rand::thread_rng;
+//!   use std::str::FromStr;
+//!
+//!   // Create the necessary components to create the program manager
+//!   let mut rng = thread_rng();
+//!   // Create an api client to query the network state
+//!   let api_client = AleoAPIClient::<Testnet3>::testnet3();
+//!   // Create a private key (in practice, this would be a user's private key)
+//!   let private_key = PrivateKey::<Testnet3>::new(&mut rng).unwrap();
+//!   // Encrypt the private key with a password
+//!   let private_key_ciphertext = Encryptor::<Testnet3>::encrypt_private_key_with_secret(&private_key, "password").unwrap();
+//!
+//!   // Create the program manager
+//!   // (Note: An optional local directory can be provided to manage local program data)
+//!   let mut program_manager = ProgramManager::<Testnet3>::new(None, Some(private_key_ciphertext), Some(api_client), None).unwrap();
+//!
+//!   // ------------------
+//!   // EXECUTE PROGRAM STEPS
+//!   // ------------------
+//!
+//!   // Execute the function `main` of the hello.aleo program with the arguments 5u32 and 3u32.
+//!   // Specify 0 for the fee and provide a password to decrypt the private key stored in the program manager
+//!   program_manager.execute_program("hello.aleo", "main", [5u32, 3u32].into_iter(), 0, None, Some("password")).unwrap();
+//!
+//!   // ------------------
+//!   // DEPLOY PROGRAM STEPS
+//!   // ------------------
+//!
+//!   // Note - Deployment requires a mandatory deployment fee, so an account with an existing
+//!   // balance is required to deploy a program
+//!
+//!   // Create a program name (note: change this to something unique)
+//!   let program_name = "yourownprogram.aleo";
+//!   // Create a test program
+//!   let test_program = format!("program {};\n\nfunction main:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n", program_name);
+//!   // Create a program object from the program string
+//!   let program = Program::from_str(&test_program).unwrap();
+//!   // Add the program to the program manager (this can also be done by providing a path to
+//!   // the program on disk when the program manager is created)
+//!   program_manager.add_program(&program).unwrap();
+//!   // Create a record finder to find records to fund the deployment fee
+//!   let record_finder = RecordFinder::<Testnet3>::new(AleoAPIClient::testnet3());
+//!   // Set the fee for the deployment transaction (in units of gates)
+//!   let fee_gates = 300000;
+//!   // Find a record to fund the deployment fee (requires an account with a balance)
+//!   let record = record_finder.find_one_record(&private_key, fee_gates).unwrap();
+//!   // Deploy the program to the network
+//!   program_manager.deploy_program(program_name, fee_gates, record, Some("password")).unwrap();
+//!
+//!   // Wait several minutes.. then check the program exists on the network
+//!   let api_client = AleoAPIClient::<Testnet3>::testnet3();
+//!   let program_on_chain = api_client.get_program(program_name).unwrap();
+//!   let program_on_chain_name = program_on_chain.id().to_string();
+//!   assert_eq!(&program_on_chain_name, program_name);
+//!
+//!   // ------------------
+//!   // TRANSFER STEPS
+//!   // ------------------
+//!
+//!   // Create a recipient (in practice, the recipient would send their address to the sender)
+//!   let recipient_key = PrivateKey::<Testnet3>::new(&mut rng).unwrap();
+//!   let recipient_address = Address::try_from(recipient_key).unwrap();
+//!   // Create amount and fee (both in units of gates)
+//!   let amount = 30000;
+//!   let fee = 100;
+//!   // Find records to fund the transfer
+//!   let (amount_record, fee_record) = record_finder.find_amount_and_fee_records(amount, fee, &private_key).unwrap();
+//!   // Create a transfer
+//!   program_manager.transfer(amount, fee, recipient_address, Some("password"), amount_record, Some(fee_record)).unwrap();
+//!
+//!   ```
+//! This API is currently under active development and is expected to change in order to provide
+//! a more streamlined experience for program execution and deployment.
+//!
+
 pub mod account;
 pub use account::*;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -32,7 +32,7 @@
 //! the network. The AleoAPIClient struct provides a 1:1 mapping of those REST API endpoints as well
 //! as several convenience methods for interacting with the network.
 //!
-//! The key usages of the Aleo API client are:
+//! Some key usages of the Aleo API client are:
 //! * Finding records to spend in value transfers, program executions and program deployments
 //! * Locating programs deployed on the network
 //! * Sending transactions to the network
@@ -156,8 +156,8 @@
 //!   program_manager.transfer(amount, fee, recipient_address, Some("password"), amount_record, Some(fee_record)).unwrap();
 //!
 //!   ```
-//! This API is currently under active development and is expected to change in order to provide
-//! a more streamlined experience for program execution and deployment.
+//! This API is currently under active development and is expected to change in the future in order
+//! to provide a more streamlined experience for program execution and deployment.
 //!
 
 pub mod account;


### PR DESCRIPTION
## Motivation

The Rust SDK has functional Transfer, Deploy, and Execute functionality, but no documentation as of yet as to how to use these functions. This PR adds that Rustdoc documentation and a Readme file in order to provide consumers of the SDK with helpful documentation on how to use it to Execute and Deploy programs

## Test Plan
* Rustdoc build tests are automatically run by cargo test and have passed