### PR TITLE
[Fix] Update SnarkVM Libraries to 10.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ default-features = false
 version = "0.10.3"
 
 [workspace.dependencies.snarkvm-console]
-version = "0.10.2"
+version = "0.10.3"
 
 [workspace.dependencies.snarkvm-wasm]
-version = "0.10.2"
+version = "0.10.3"
 default-features = false
 
 [lib]


### PR DESCRIPTION
## Motivation

Update all SnarkVM libraries to 10.3