### PR TITLE
[Release] Bump Aleo SDK version to v0.4.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
 jobs:
   rust_stable:
     docker:
-      - image: cimg/rust:1.67
+      - image: cimg/rust:1.70
     resource_class: xlarge
     steps:
       - run_serial:
@@ -102,7 +102,7 @@ jobs:
 
   wasm:
     docker:
-      - image: cimg/rust:1.67
+      - image: cimg/rust:1.70
     resource_class: 2xlarge
     steps:
       - checkout
@@ -113,7 +113,8 @@ jobs:
           command: |
             curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
             export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm install node
+            nvm install 18.16.0
+            nvm use 18.16.0
             curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
             cd wasm && wasm-pack test --node --lib
             # cargo test --target wasm32-unknown-unknown
@@ -121,14 +122,14 @@ jobs:
             npm install --global typescript
             npm install --global yarn
             cd ../sdk && yarn install
-            yarn build
+            sleep 5
             yarn test
       - clear_environment:
           cache_key: aleo-wasm-cache
 
   check-fmt:
     docker:
-      - image: cimg/rust:1.67
+      - image: cimg/rust:1.70
     resource_class: xlarge
     steps:
       - checkout
@@ -145,7 +146,7 @@ jobs:
 
   check-clippy:
     docker:
-      - image: cimg/rust:1.67
+      - image: cimg/rust:1.70
     resource_class: 2xlarge
     steps:
       - checkout
@@ -162,7 +163,7 @@ jobs:
 
   aleo-deploy-and-execute:
     docker:
-      - image: cimg/rust:1.67
+      - image: cimg/rust:1.70
     resource_class: xlarge
     steps:
       - checkout
@@ -175,7 +176,8 @@ jobs:
             sudo apt install git-all
             curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
             export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm install node
+            nvm install 18.16.0
+            nvm use 18.16.0
             curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
             cd wasm
             wasm-pack build --target nodejs -- --features serial --no-default-features
@@ -195,12 +197,12 @@ jobs:
             cargo test test_deploy -- --ignored --nocapture --test-threads=1
             cargo test test_execution -- --ignored --nocapture --test-threads=1
             cd ../sdk && yarn install
-            yarn build
+            sleep 5
             yarn integration
 
   aleo-executable:
     docker:
-      - image: cimg/rust:1.67
+      - image: cimg/rust:1.70
     resource_class: xlarge
     steps:
       - checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aleo"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aleo-rust",
  "anyhow",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "aleo-development-server"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aleo-rust",
  "anyhow",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "aleo-rust"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "bencher",
@@ -156,7 +156,7 @@ checksum = "7e4f181fc1a372e8ceff89612e5c9b13f72bff5b066da9f8d6827ae65af492c4"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aleo-rust",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo"
-version = "0.4.2"
+version = "0.4.3"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Aleo"
 homepage = "https://aleo.org"
@@ -21,7 +21,7 @@ edition = "2021"
 members = [ "rust", "wasm", "rust/develop"]
 
 [workspace.dependencies.aleo-rust]
-version = "0.4.2"
+version = "0.4.3"
 path = "rust"
 default-features = false
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-rust"
-version = "0.4.2"
+version = "0.4.3"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Rust SDK for managing Aleo programs and communicating with the Aleo network"
 homepage = "https://aleo.org"

--- a/rust/develop/Cargo.toml
+++ b/rust/develop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-development-server"
-version = "0.4.2"
+version = "0.4.3"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A REST API server for local or remote Aleo development"
 homepage = "https://aleo.org"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aleohq/sdk",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Aleo Team <hello@aleo.org>"
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/AleoHQ/sdk#readme",
   "dependencies": {
-    "@aleohq/wasm": "0.4.1",
+    "@aleohq/wasm": "0.4.3",
     "axios": "^1.1.3",
     "jsdoc": "^3.6.11",
     "unfetch": "^5.0.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/AleoHQ/sdk#readme",
   "dependencies": {
-    "@aleohq/wasm": "0.4.3",
+    "@aleohq/wasm": "0.4.2",
     "axios": "^1.1.3",
     "jsdoc": "^3.6.11",
     "unfetch": "^5.0.0"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "aleo-wasm"
-version = "0.4.2"
+version = "0.4.3"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
-description = "Toolkit for exporting key Aleo functionality and cryptography to WebAssembly"
+description = "WebAssembly based toolkit for developing zero knowledge applications with Aleo"
 homepage = "https://aleo.org"
 repository = "https://github.com/AleoHQ/sdk"
 keywords = [


### PR DESCRIPTION
## Motivation

This PR bumps the Aleo SDK version 0.4.3 which provides tools for performing deployment and execution directly on the web.

## Changelog
* Add program execution & deployment methods to the `aleo-wasm`
* Add methods for caching program proving & verifying key key material
* Add program deployment & execution to [aleo.tools](https://aleo.tools)
* Update the aleo SDK to support the latest changes to the program execution model provided in SnarkVM v0.11.7
