### PR TITLE
[Fix] Fix record searching logic

### DIFF
--- a/rust/src/api/blocking.rs
+++ b/rust/src/api/blocking.rs
@@ -241,8 +241,9 @@ impl<N: Network> AleoAPIClient<N> {
                         position.map(|index| records.remove(index))
                     })
                     .collect::<Vec<_>>();
-                if found_records.len() >= specified_amounts.len() {
-                    return Ok(found_records);
+                records.extend(found_records);
+                if records.len() >= specified_amounts.len() {
+                    return Ok(records);
                 }
             }
         }

--- a/rust/src/program/helpers/records.rs
+++ b/rust/src/program/helpers/records.rs
@@ -70,9 +70,8 @@ impl<N: Network> RecordFinder<N> {
         max_microcredits: Option<u64>,
         private_key: &PrivateKey<N>,
     ) -> Result<Vec<Record<N, Plaintext<N>>>> {
-        let view_key = ViewKey::try_from(private_key)?;
         let latest_height = self.api_client.latest_height()?;
         let records = self.api_client.get_unspent_records(private_key, 0..latest_height, max_microcredits, amounts)?;
-        Ok(records.into_iter().filter_map(|(_, record)| record.decrypt(&view_key).ok()).collect())
+        Ok(records.into_iter().map(|(_, record)| record).collect())
     }
 }

--- a/rust/src/program/transfer.rs
+++ b/rust/src/program/transfer.rs
@@ -121,8 +121,7 @@ mod tests {
             let records = api_client.get_unspent_records(&recipient_private_key, 0..height, None, None).unwrap();
             if !records.is_empty() {
                 let (_, record) = &records[0];
-                let record_plaintext = record.decrypt(&recipient_view_key).unwrap();
-                let amount = record_plaintext.microcredits().unwrap();
+                let amount = record.microcredits().unwrap();
                 if amount == 100 {
                     break;
                 }

--- a/rust/src/test_utils/mod.rs
+++ b/rust/src/test_utils/mod.rs
@@ -201,5 +201,5 @@ pub fn transfer_to_test_account(
     let client = program_manager.api_client()?;
     let latest_height = client.latest_height()?;
     let records = client.get_unspent_records(&recipient_private_key, 0..latest_height, None, None)?;
-    Ok(records.iter().map(|(_cm, record)| record.decrypt(&recipient_view_key).unwrap()).collect())
+    Ok(records.into_iter().map(|(_cm, record)| record).collect())
 }


### PR DESCRIPTION
## Motivation

There was a small behavioral bug wherein grouped records would only be found if they were within 50 record blocks of each other. This fix allows the entire range to be considered.