### PR TITLE
[Feature] Bump SnarkVM to v0.12.5 and add client-side methods for querying program mapping state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,7 @@ jobs:
             ./bin/aleo-develop start --server-address 0.0.0.0:5050 --peer http://localhost:3030 -d -k ciphertext1qvqgkey2cxklg4g5qjnkk4dy50zypte5ewp5kwdm9pt833eyext32pu07dgkxqzmn0wnpxx8kvh2phws6j5njsu6zrys20xpvqmqhw9gpngs50mpe9e0nkp6uyzctzdq3fs2n4p9d3kvaps6mg6xu0sef0xpzm028m7 1> /dev/null &
             sleep 15
             cd rust
+            cargo test test_mappings_query -- --ignored --nocapture --test-threads=1
             cargo test test_transfer_roundtrip -- --ignored --nocapture --test-threads=1
             cargo test test_deploy -- --ignored --nocapture --test-threads=1
             cargo test test_execution -- --ignored --nocapture --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2115,9 +2115,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snarkvm"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c226da8de4d4171b8346a5dc834a1dbabae8c3ffbf4d4b335113743a7e23e72"
+checksum = "c3ec58e0b0292e6987e74a759c6d64c5902e73985dfa31bd3d967bceecbcf3c8"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2144,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f96bc086f932e76b516db79b665861ab87f294bd8a5c4156fc224dd5897f31"
+checksum = "335c8d5b62427a3acfcd6747bd851202c100ac0fe79128f8e446705f1d1103cf"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2175,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c41077b078ca9c8e8429f84fc97863445ba74ca5138801d5d984485ee5f56be"
+checksum = "acedd9708201fef364f3c2d26f98b343d63a5115bc980d39a6d0d29d6fe9b692"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4207440f26559da0c791eeb4b86ad8a5f2a5fe9e1ff0355a17868c6be6d1e0ca"
+checksum = "d38e06c1545b749365f3d80c6a53a04b2a2f0da316390b8a3339e41365f1c22d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b4116a5a9873caeda71b0af8cb201cf2571ad285f17d3c8caa65cadf48b0c"
+checksum = "1b10e29f07b4d6c9a59ae3751ca8904f42ab4c27a39562ab4d56275879df75e8"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2213,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1173c1bf6368f3ddb37e30879dd25027547d6fde2d6c9fb284c137d91c4c25b"
+checksum = "6227fc3243154ab12899bbd930a49cf2a38086140abfff902494184a6a0a8cbe"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2224,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbeaff27abd87bde33bdf6e1ae213121631068e6daf67eac5b78264731a42df"
+checksum = "56276e03677ada2086ad56bfa84f7b00cf7816e1fe1906f9e1606d94b8c91eb1"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2243,15 +2243,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bab331f6aa5e0cdb6dfe3f3eedda540eb13526365148bb786bc0d9b0fd073d6"
+checksum = "ae87eaa781657f16730f90baa746d46b346045c6900a62fb6d977f2bbe4fcdb5"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a80c239200086dc026af70a2884426a7408bcbadf0dcb2236dfcb33803905a"
+checksum = "2f8cb59930d613f1ff4227f104172f9add80a5f2660eca430d962b0e944a1510"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef738ab352e0065d795859c29ce536d7ce8edcb42e16a354986cd4a20170b095"
+checksum = "3cdf435d311e6d983f95e9916ca0eb1c80b5bf86f65636a1f74d00124e5ad188"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2275,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40bc1ad34286c1f2d1b25cece291ce5ebeca92e144973e4dcab60b58e9aaf5f"
+checksum = "462301625a8c2e272ebd6cbf2c97132c25993f0e6ad8116b7f3af744bc076f84"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2291,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0981cee35e34a9472305566d74a94095ff398c441795e62c5ac8e13e0c5653"
+checksum = "7be9cbb979511fa342bf6ab8bc4b659915ab2c9d43303edac02c674a95cda93b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2305,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7718bc963b0cc179fd56429822aa62ccab2a48c936e65e448beae3fd70897237"
+checksum = "38d2221236daa48d03a236c1bd6c2e1b8c8f4a475b554901d6a22211ece40314"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2315,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb13447b15e958baaa2a44b4e70998d4b737888e87ab61139467c3ce60f8b06"
+checksum = "e62fbe7b885af5c29ed5933aec2ec363a1828ab7c6b40001e378140f0808480a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2326,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b3cad07517e020fd2d67b80d3d3f2326fd1790f1174031aa24acd39dcf181"
+checksum = "2125088d1b185270c488ff4e107c59b2a96814056b053e994a27cfc9424f7c17"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2339,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3355e1720d3a7492ed526f715ad1502e8f2c68680e7744856b7776e3ed642f"
+checksum = "2d3d13050c95ffca0e06eef06e5c86c81719efb826440c43ff8479cf024aa733"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2351,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d7ea4a7d3bd078b1a81d36ed3a026d732ac884ec5c979e006420bff56cb61a"
+checksum = "d8d965ea8bd98c90343ac6809db9c47583b72de0802e4bd64aec6cdc8d7fac19"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2363,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c2ba2ef12a05518181a3680fd5e05bb7d3086f7a5c595141d54c19e5105ecb"
+checksum = "15b25418eb9c9a3d023e7d0cb01e39e2b86649e046d07c349db7c79880b310bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2376,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eff0cb7897c79af354d2fad6af0177c151a81052fb4186fc4924ed67fe3cc50"
+checksum = "25d2a4e462e239f20e647eceb8e69dee90fd75dff88473269e881fc557d7c53f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2390,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c2978db5bd0254458ee9bb2838085e7f6c81ea84febb64ebe3c24765d65fae"
+checksum = "41b37e1eac20dbe127b67df30ab20f2e2190909d5b7b57048e22c6e06a355e8c"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2401,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc3a1bc1be988081c20d54d3fb52a5e47ad5f450ef261de702cf39738c51eb3"
+checksum = "86d17199915cfa8723398df0e5d9b7eeeaab9d32a15db6adb2d610916e10bc64"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2414,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e1b0a5bb09257fc53fa4b62fcdf161eac8c76892f35e5ce52a0832ef46c5b4"
+checksum = "8031e5798c6225b3d1d446f9dd6f20b0498bb0945976d1ef04dc591b08cdb9cd"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2426,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fe2ba3e7adb26e003e5d283557890c9c7f2d54897bce4921bca7f6ac4cd145"
+checksum = "58a8da9fd34e9c4248e5431e9e4c91173fcf89e4ea86c5b10dfdd2b29fb03f88"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2450,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdea0c85f9198ce65ce95e4e7c31c1aee311c8fab1fdb176af964a34020031af"
+checksum = "164cca322118ffd941f6e17e546dfb4073c990bad1081a981d8411415ca5cb30"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2468,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433488f61bac6799b0c43733af4e92950a4674890693f67d7790675388ab3dd6"
+checksum = "ecade8e8f1859fc0b32e2f9fda476093c0c747cf1dece1705472460736ef127e"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2488,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4417f6468d6d030456a0e354ad566ef24e859d54ae6d1ddc576bd1aa144526"
+checksum = "2e85bd30a6cfea0f7c5b2b70201d6dd3c252f291384a14fe4f1a1220def77db0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2504,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c929a6574cc92c22b9011f90abdd392e9af8d9262fcb118ccf8b13a6e3f1fc6a"
+checksum = "03f20fb0790ebeda6462dc6766074c5c8ef7b58d20abce83eaa80103c6f1ad0f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2516,18 +2516,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65587cc1fbaa5550db5206de8620c0ba206ab3a117ebd8695b693b4bf9632986"
+checksum = "7a692c5a4472213968bb8bcd03dbe151a301782d96bea7d766fbcb89b132991f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da560561f667ebfb343ddd4b28e00563da8641c6ad05b40e13f51d41ce176b9"
+checksum = "ad4fd2d72d65c142de160979bc5878a965dbc8e78d6b28d0fbc7a39906cebc63"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2535,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66b0ef37640aa0a5e5245c0ae7a47286519879d66d89dd349918adb65ebebd4"
+checksum = "1f54c6c511e461c741729fe7c038318c28c15e95935b57055c0f42449d296f11"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2547,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccbc90319a6464d013e1c86227e0cef6bda5b67fddfa0ead97acb2ec014e8dd"
+checksum = "7b8a67edeb5420d1a1eee4d49ad46632d52fd45996b26fd2ad7d093972bfc00a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2558,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61064fd70f486729e9d5b363dacbd4a139f0ddaca9454c6f64ca875c589cfd5"
+checksum = "6d7037180bbdc14c48abe9824e5a98700c5dcbf90be2a08707a2c2ac3d383829"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2569,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef7a9e309aa3a11c440dbf8ec7d7e96687e8e593720eb037676b25a30f369c0"
+checksum = "a88ba46461891e2c408ca99f80bba907851f5e7f891179b589555fd3695369d6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2581,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b9512e840ba777df944718d27718b9530814723d6a48b9ee2a63e5b35f8980"
+checksum = "b8dd8615019ef05f8fbbf5c44e4aec6ca8eed3efb25c5846363d4d53de247d9e"
 dependencies = [
  "rand",
  "rayon",
@@ -2596,9 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3c9efcfeded661a49ff4820d981d00192cf41ffd4db2da01998bf39ba5f0da"
+checksum = "cf559cff5dff6be05903469ce02920219f53b25435106588303459ec9e8f91c6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2614,14 +2614,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8a58902c62a2ddf991a9940b33dc7ef6db14bc4f136d02e88016f2fe97e208"
+checksum = "ebf06e79b743aa86cee39857c98559b20ab0b18ef762655b18ce1a35b398306e"
 dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap",
- "once_cell",
  "parking_lot",
  "rand",
  "rayon",
@@ -2633,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc0f36f4716eedd88fa5bb0da7c411c91d42cbc8f506294871bb2901f0cca82"
+checksum = "15363ea560f314a3268b979146cb700b106479e03b3a6ff3a4279fb2edfe0c2d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2661,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9467d0d4cd482b9b85b994a52a99d6cad18341cfa856a92fe3f341091adfc68"
+checksum = "b49797c6f786b04001da7a138390548e239090e6817affd2ee772e27c2fa492f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2687,6 +2686,7 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-synthesizer-coinbase",
+ "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
  "tracing",
@@ -2695,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-coinbase"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c68d532cc2f430c8f568b81da87a81c090b6a580d4db7cd2f61aaf776a9c5a3"
+checksum = "c5fe74b33c9c7b9aee4916e6d0924aad300edf6c92811bc02bbe3c877f4b042f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2714,10 +2714,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-synthesizer-snark"
-version = "0.12.3"
+name = "snarkvm-synthesizer-program"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eea7ca8f482a5c98d03167a074326e445f575eb0db4f32e21dfce64efc4cd1b"
+checksum = "ec8166c87af8b0165ecbb1f81aa5179898658c03d7ab6ee5e9785b6e11389bf4"
+dependencies = [
+ "indexmap",
+ "snarkvm-console",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-snark"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f372fe459c1fe23a4f31f96f0d594604c8fdc435917b6d30651db50fefca028"
 dependencies = [
  "bincode",
  "once_cell",
@@ -2729,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58899b49fecb502348e02e6627cbb8384e99b2a79047488c271ccebc2c474082"
+checksum = "bb2bae5d086357c3d1ab1a1a0b1e6f3888d277fb7ef28f7e26bf47b3aac5cd50"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2749,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3154b00fa475bbe1a579148656722bdb8e4dbec74aa281acb7f0382bff744cb2"
+checksum = "86974a928d9799b7304d6c13df3f4ed73732c3fdeefcd4d0fff32cac5dca08a5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.28",
@@ -2760,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5af03e853b02442f3a9507059987f00c3e965bf20e8c8fdc7cc0283eec6f680"
+checksum = "25425cc7e0ecefb7c4bfaa44f83de93cfff9de8fcd06b171c56f497ee2a47f4d"
 dependencies = [
  "getrandom",
  "rand",
@@ -3198,9 +3208,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b45063f47caea744e48f5baa99169bd8bd9b882d80a99941141327bbb00f99"
+checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
 dependencies = [
  "base64 0.21.2",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,22 +26,22 @@ path = "rust"
 default-features = false
 
 [workspace.dependencies.snarkvm]
-version = "=0.12.3"
+version = "=0.12.5"
 
 [workspace.dependencies.snarkvm-circuit-network]
-version = "=0.12.3"
+version = "=0.12.5"
 
 [workspace.dependencies.snarkvm-console]
-version = "=0.12.3"
+version = "=0.12.5"
 
 [workspace.dependencies.snarkvm-console-network]
-version = "=0.12.3"
+version = "=0.12.5"
 
 [workspace.dependencies.snarkvm-synthesizer]
-version = "=0.12.3"
+version = "=0.12.5"
 
 [workspace.dependencies.snarkvm-wasm]
-version = "=0.12.3"
+version = "=0.12.5"
 
 [lib]
 path = "cli/lib.rs"

--- a/cli/commands/execute.rs
+++ b/cli/commands/execute.rs
@@ -21,6 +21,7 @@ use snarkvm::prelude::{Ciphertext, Identifier, Plaintext, PrivateKey, ProgramID,
 use anyhow::{anyhow, ensure, Result};
 use clap::Parser;
 use colored::Colorize;
+use snarkvm::circuit::AleoV0;
 
 /// Executes an Aleo program function
 #[derive(Debug, Parser)]
@@ -116,7 +117,7 @@ impl Execute {
 
         // Execute the program function
         println!("Executing function {} from program: {}", function_string.bright_blue(), program_string.bright_blue());
-        let result = program_manager.execute_program(
+        let result = program_manager.execute_program::<AleoV0>(
             self.program_id,
             self.function,
             self.inputs.iter(),

--- a/rust/develop/src/cli.rs
+++ b/rust/develop/src/cli.rs
@@ -68,7 +68,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub fn parse(self) -> Result<Rest<Testnet3>> {
+    pub fn parse(self) -> Result<Rest<Testnet3, AleoV0>> {
         match self {
             Command::Start { server_address, key_ciphertext: key, peer, debug } => {
                 Rest::initialize(server_address, key, peer, debug)

--- a/rust/develop/src/lib.rs
+++ b/rust/develop/src/lib.rs
@@ -149,7 +149,14 @@ use requests::*;
 mod routes;
 pub use routes::*;
 
-use aleo_rust::{snarkvm_types::{Aleo, AleoV0}, AleoAPIClient, Encryptor, ProgramManager, RecordFinder, TransferType};
+use aleo_rust::{
+    snarkvm_types::{Aleo, AleoV0},
+    AleoAPIClient,
+    Encryptor,
+    ProgramManager,
+    RecordFinder,
+    TransferType,
+};
 use snarkvm::{
     console::{
         account::{Address, PrivateKey},
@@ -206,7 +213,14 @@ impl<N: Network, A: Aleo<Network = N>> Rest<N, A> {
         };
 
         // Initialize the server.
-        let server = Self { api_client, private_key_ciphertext, record_finder, socket_address, debug, phantom: std::marker::PhantomData };
+        let server = Self {
+            api_client,
+            private_key_ciphertext,
+            record_finder,
+            socket_address,
+            debug,
+            phantom: std::marker::PhantomData,
+        };
 
         // Print an initialization message and return the server
         println!("{}", "\nStarting Aleo development server...".bright_blue());

--- a/rust/develop/src/lib.rs
+++ b/rust/develop/src/lib.rs
@@ -156,7 +156,7 @@ use snarkvm::{
         program::{Ciphertext, Identifier, Plaintext, ProgramID, Record},
     },
     prelude::{Network, Testnet3},
-    synthesizer::program::Program,
+    synthesizer::Program,
 };
 use tracing_subscriber::fmt;
 

--- a/rust/develop/src/lib.rs
+++ b/rust/develop/src/lib.rs
@@ -149,7 +149,7 @@ use requests::*;
 mod routes;
 pub use routes::*;
 
-use aleo_rust::{AleoAPIClient, Encryptor, ProgramManager, RecordFinder, TransferType};
+use aleo_rust::{snarkvm_types::{Aleo, AleoV0}, AleoAPIClient, Encryptor, ProgramManager, RecordFinder, TransferType};
 use snarkvm::{
     console::{
         account::{Address, PrivateKey},
@@ -168,7 +168,7 @@ use warp::{reject, reply, Filter, Rejection, Reply};
 
 /// Server object for the Aleo Development Server
 #[derive(Clone)]
-pub struct Rest<N: Network> {
+pub struct Rest<N: Network, A: Aleo<Network = N>> {
     api_client: AleoAPIClient<N>,
     /// Private key ciphertext for the account being used with the server
     private_key_ciphertext: Option<Ciphertext<N>>,
@@ -178,9 +178,10 @@ pub struct Rest<N: Network> {
     socket_address: SocketAddr,
     /// Debug mode flag
     debug: bool,
+    phantom: std::marker::PhantomData<A>,
 }
 
-impl<N: Network> Rest<N> {
+impl<N: Network, A: Aleo<Network = N>> Rest<N, A> {
     /// Initializes a new instance of the server.
     pub fn initialize(
         socket_address: Option<SocketAddr>,
@@ -205,7 +206,7 @@ impl<N: Network> Rest<N> {
         };
 
         // Initialize the server.
-        let server = Self { api_client, private_key_ciphertext, record_finder, socket_address, debug };
+        let server = Self { api_client, private_key_ciphertext, record_finder, socket_address, debug, phantom: std::marker::PhantomData };
 
         // Print an initialization message and return the server
         println!("{}", "\nStarting Aleo development server...".bright_blue());
@@ -221,7 +222,7 @@ impl<N: Network> Rest<N> {
     }
 }
 
-impl<N: Network> Rest<N> {
+impl<N: Network, A: Aleo<Network = N>> Rest<N, A> {
     /// Initializes the development server
     pub async fn start(&mut self) {
         let cors = warp::cors().allow_any_origin().allow_methods(vec!["GET", "POST", "OPTIONS"]).allow_headers(vec![

--- a/rust/develop/src/routes.rs
+++ b/rust/develop/src/routes.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-impl<N: Network> Rest<N> {
+impl<N: Network, A: Aleo<Network = N>> Rest<N, A> {
     /// Initializes the routes for the development server REST API
     pub fn routes(&self) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
         // POST /deploy
@@ -56,7 +56,7 @@ impl<N: Network> Rest<N> {
     }
 }
 
-impl<N: Network> Rest<N> {
+impl<N: Network, A: Aleo<Network = N>> Rest<N, A> {
     // Get the private key if one is specified in the request or decrypt the local request
     fn get_private_key(
         private_key_ciphertext: Option<Ciphertext<N>>,
@@ -146,7 +146,7 @@ impl<N: Network> Rest<N> {
         };
 
         // Execute the program and return the resulting transaction id
-        let transaction_id = spawn_blocking!(program_manager.execute_program(
+        let transaction_id = spawn_blocking!(program_manager.execute_program::<A>(
             request.program_id,
             request.program_function,
             request.inputs.iter(),

--- a/rust/src/api/blocking.rs
+++ b/rust/src/api/blocking.rs
@@ -346,4 +346,18 @@ mod tests {
         assert_eq!(blocks[1].previous_hash(), blocks[0].hash());
         assert_eq!(blocks[2].previous_hash(), blocks[1].hash());
     }
+
+    #[test]
+    #[ignore]
+    fn test_mappings_query() {
+        let client = AleoAPIClient::<Testnet3>::local_testnet3("3030");
+        let mappings = client.get_program_mappings("credits.aleo").unwrap();
+        // Assert there's only one mapping in credits.aleo
+        assert_eq!(mappings.len(), 1);
+
+        let mappings = mappings.into_iter().map(|mapping| mapping).collect::<Vec<_>>();
+        let identifier = mappings[0];
+        // Assert the identifier is "account"
+        assert_eq!(identifier.to_string(), "account");
+    }
 }

--- a/rust/src/api/blocking.rs
+++ b/rust/src/api/blocking.rs
@@ -355,7 +355,7 @@ mod tests {
         // Assert there's only one mapping in credits.aleo
         assert_eq!(mappings.len(), 1);
 
-        let mappings = mappings.into_iter().map(|mapping| mapping).collect::<Vec<_>>();
+        let mappings = mappings.into_iter().collect::<Vec<_>>();
         let identifier = mappings[0];
         // Assert the identifier is "account"
         assert_eq!(identifier.to_string(), "account");

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -214,7 +214,7 @@ use snarkvm::{file::Manifest, package::Package};
 pub use snarkvm_types::*;
 
 use anyhow::{anyhow, bail, ensure, Error, Result};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use once_cell::sync::OnceCell;
 use snarkvm_console::program::Entry;
 #[cfg(feature = "full")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -81,7 +81,7 @@
 //! ```no_run
 //!   use aleo_rust::{
 //!     AleoAPIClient, Encryptor, ProgramManager, RecordFinder,
-//!     snarkvm_types::{Address, PrivateKey, Testnet3, Program},
+//!     snarkvm_types::{Address, AleoV0, PrivateKey, Testnet3, Program},
 //!     TransferType
 //!   };
 //!   use rand::thread_rng;
@@ -112,7 +112,7 @@
 //!
 //!   // Execute the function `hello` of the hello.aleo program with the arguments 5u32 and 3u32.
 //!   // Specify 0 for the fee and provide a password to decrypt the private key stored in the program manager
-//!   program_manager.execute_program("hello.aleo", "hello", ["5u32", "3u32"].into_iter(), 0, fee_record, Some("password")).unwrap();
+//!   program_manager.execute_program::<AleoV0>("hello.aleo", "hello", ["5u32", "3u32"].into_iter(), 0, fee_record, Some("password")).unwrap();
 //!
 //!   // ------------------
 //!   // DEPLOY PROGRAM STEPS
@@ -191,6 +191,8 @@ pub use test_utils::*;
 pub mod snarkvm_types {
     //! Re-export of crucial types from the snarkVM crate
     #[cfg(feature = "full")]
+    pub use snarkvm::circuit::{Aleo, AleoV0};
+    #[cfg(feature = "full")]
     pub use snarkvm::synthesizer::{
         store::helpers::memory::ConsensusMemory,
         Block,
@@ -209,7 +211,12 @@ pub mod snarkvm_types {
     };
 }
 #[cfg(feature = "full")]
-use snarkvm::{file::Manifest, package::Package};
+use snarkvm::{
+    circuit::Aleo,
+    file::Manifest,
+    package::Package,
+    synthesizer::{helpers::memory::BlockMemory, Process},
+};
 
 pub use snarkvm_types::*;
 
@@ -218,7 +225,13 @@ use indexmap::{IndexMap, IndexSet};
 use once_cell::sync::OnceCell;
 use snarkvm_console::program::Entry;
 #[cfg(feature = "full")]
-use std::{convert::TryInto, fs::File, io::Read, ops::Range, path::PathBuf};
+use std::{
+    convert::TryInto,
+    fs::File,
+    io::Read,
+    ops::{Add, Range},
+    path::PathBuf,
+};
 use std::{iter::FromIterator, marker::PhantomData, str::FromStr};
 
 /// A trait providing convenient methods for accessing the amount of Aleo present in a record

--- a/rust/src/program/transfer.rs
+++ b/rust/src/program/transfer.rs
@@ -250,13 +250,13 @@ mod tests {
         let expected_value = Value::from(Plaintext::<Testnet3>::from_str(amount_str).unwrap());
         let zero_value = Value::from(Plaintext::<Testnet3>::from_str("0u64").unwrap());
 
-        println!("Private recipient private_key: {}", private_recipient_private_key.to_string());
+        println!("Private recipient private_key: {}", private_recipient_private_key);
         println!("Private recipient address: {}", private_recipient_address);
-        println!("Private to public recipient private_key: {}", private_to_public_recipient_private_key.to_string());
+        println!("Private to public recipient private_key: {}", private_to_public_recipient_private_key);
         println!("Private to public recipient address: {}", private_to_public_recipient_address);
-        println!("Public recipient private_key: {}", public_recipient_private_key.to_string());
+        println!("Public recipient private_key: {}", public_recipient_private_key);
         println!("Public recipient address: {}", public_recipient_address);
-        println!("Public to private recipient private_key: {}", public_to_private_recipient_private_key.to_string());
+        println!("Public to private recipient private_key: {}", public_to_private_recipient_private_key);
         println!("Public to private recipient address: {}", public_to_private_recipient_address);
 
         // Transfer funds to the private recipient and confirm that the transaction is on chain
@@ -286,7 +286,7 @@ mod tests {
 
         try_transfer(&private_to_public_recipient_private_key, &public_recipient_address, amount, TransferType::Public);
         thread::sleep(std::time::Duration::from_secs(25));
-        let value = api_client.get_mapping_value("credits.aleo", "account", &public_address_literal).unwrap();
+        let value = api_client.get_mapping_value("credits.aleo", "account", public_address_literal).unwrap();
         assert!(value.eq(&expected_value));
         let value =
             api_client.get_mapping_value("credits.aleo", "account", &private_to_public_address_literal).unwrap();

--- a/rust/src/program/transfer.rs
+++ b/rust/src/program/transfer.rs
@@ -223,29 +223,42 @@ mod tests {
         // Initialize necessary key material
         // Use the beacon private key to make the initial transfer
         let beacon_private_key = PrivateKey::<Testnet3>::from_str(BEACON_PRIVATE_KEY).unwrap();
-        let rng = &mut rand::thread_rng();
+        let amount = 16_666_666;
+        let amount_str = "16666666u64";
+        let fee = 26_666_666;
         // Create a unique recipient for each transfer type so we can unique identify each transfer
-        let private_recipient_private_key = PrivateKey::<Testnet3>::new(rng).unwrap();
+        let private_recipient_private_key =
+            PrivateKey::<Testnet3>::from_str("APrivateKey1zkpCF24vGLohfHWNZam1z7qDhDq5Bp1u8WPFhh9q2wWoNh8").unwrap();
         let private_recipient_view_key = ViewKey::try_from(&private_recipient_private_key).unwrap();
         let private_recipient_address = Address::try_from(&private_recipient_view_key).unwrap();
-        let private_to_public_recipient_private_key = PrivateKey::<Testnet3>::new(rng).unwrap();
+        let private_to_public_recipient_private_key =
+            PrivateKey::<Testnet3>::from_str("APrivateKey1zkpFkojCEFsw3LaozkqaVkMuxdTq2DEsUV88WGexXoWGuNA").unwrap();
         let private_to_public_recipient_view_key = ViewKey::try_from(&private_to_public_recipient_private_key).unwrap();
         let private_to_public_recipient_address = Address::try_from(&private_to_public_recipient_view_key).unwrap();
-        let public_recipient_private_key = PrivateKey::<Testnet3>::new(rng).unwrap();
+        let public_recipient_private_key =
+            PrivateKey::<Testnet3>::from_str("APrivateKey1zkp6rwhE5Jxz16cv32kM8Z8VMsLe78BCK8LU3FM7htmSsis").unwrap();
         let public_recipient_view_key = ViewKey::try_from(&public_recipient_private_key).unwrap();
         let public_recipient_address = Address::try_from(&public_recipient_view_key).unwrap();
-        let public_to_private_recipient_private_key = PrivateKey::<Testnet3>::new(rng).unwrap();
+        let public_to_private_recipient_private_key =
+            PrivateKey::<Testnet3>::from_str("APrivateKey1zkp3NchSbrypyf2UoJSGyag58biAFPvtd1WtpM5M9pqoifK").unwrap();
         let public_to_private_recipient_view_key = ViewKey::try_from(&public_to_private_recipient_private_key).unwrap();
         let public_to_private_recipient_address = Address::try_from(&public_to_private_recipient_view_key).unwrap();
         let api_client = AleoAPIClient::<Testnet3>::local_testnet3("3030");
+        let public_address_literal = Literal::<Testnet3>::from_str(&public_recipient_address.to_string()).unwrap();
+        let private_to_public_address_literal =
+            Literal::<Testnet3>::from_str(&private_to_public_recipient_address.to_string()).unwrap();
+        let expected_value = Value::from(Plaintext::<Testnet3>::from_str(amount_str).unwrap());
+        let zero_value = Value::from(Plaintext::<Testnet3>::from_str("0u64").unwrap());
 
+        println!("Private recipient private_key: {}", private_recipient_private_key.to_string());
         println!("Private recipient address: {}", private_recipient_address);
+        println!("Private to public recipient private_key: {}", private_to_public_recipient_private_key.to_string());
         println!("Private to public recipient address: {}", private_to_public_recipient_address);
+        println!("Public recipient private_key: {}", public_recipient_private_key.to_string());
         println!("Public recipient address: {}", public_recipient_address);
+        println!("Public to private recipient private_key: {}", public_to_private_recipient_private_key.to_string());
         println!("Public to private recipient address: {}", public_to_private_recipient_address);
 
-        let amount = 16_666_666;
-        let fee = 6_666_666;
         // Transfer funds to the private recipient and confirm that the transaction is on chain
         try_transfer(&beacon_private_key, &private_recipient_address, amount, TransferType::Private);
 
@@ -266,12 +279,18 @@ mod tests {
             amount,
             TransferType::PrivateToPublic,
         );
-        thread::sleep(std::time::Duration::from_secs(20));
-        // TODO: when a snarkOS api is available for finalize, verify the transfer is on chain
+        thread::sleep(std::time::Duration::from_secs(25));
+        let value =
+            api_client.get_mapping_value("credits.aleo", "account", &private_to_public_address_literal).unwrap();
+        assert!(value.eq(&expected_value));
 
         try_transfer(&private_to_public_recipient_private_key, &public_recipient_address, amount, TransferType::Public);
-        thread::sleep(std::time::Duration::from_secs(20));
-        // TODO: when a snarkOS api is available for finalize, verify the transfer is on chain
+        thread::sleep(std::time::Duration::from_secs(25));
+        let value = api_client.get_mapping_value("credits.aleo", "account", &public_address_literal).unwrap();
+        assert!(value.eq(&expected_value));
+        let value =
+            api_client.get_mapping_value("credits.aleo", "account", &private_to_public_address_literal).unwrap();
+        assert!(value.eq(&zero_value));
 
         // Transfer funds to the public_to_private recipient and ensure the funds made the entire journey
         try_transfer(
@@ -280,8 +299,7 @@ mod tests {
             amount,
             TransferType::PublicToPrivate,
         );
-        thread::sleep(std::time::Duration::from_secs(20));
-
+        thread::sleep(std::time::Duration::from_secs(25));
         verify_transfer(amount, &api_client, &public_to_private_recipient_private_key, TransferType::PublicToPrivate);
     }
 }

--- a/sdk/src/aleo_network_client.ts
+++ b/sdk/src/aleo_network_client.ts
@@ -104,6 +104,39 @@ export class AleoNetworkClient {
   }
 
   /**
+   * Returns the names of the mappings of a program
+   *
+   * @param {string} programId
+   * @example
+   * let mappings = connection.getProgramMappingNames("credits.aleo");
+   */
+  async getProgramMappingNames(programId: string): Promise<Array<string> | Error> {
+    try {
+      return await this.fetchData<Array<string>>("/program/" + programId + "/mappings")
+    } catch (error) {
+      throw new Error("Error fetching program mappings - ensure the program exists on chain before trying again");
+    }
+  }
+
+  /**
+   * Returns the value of a program's mapping for a specific key
+   *
+   * @param {string} programId
+   * @param {string} mappingName
+   * @param {string} key
+   * @example
+   * ## Get public balance of an account
+   * let mappingValue = connection.getMappingValue("credits.aleo", "account", "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px");
+   */
+  async getMappingValue(programId: string, mappingName: string, key: string): Promise<string | Error> {
+    try {
+      return await this.fetchData<string>("/program/" + programId + "/mapping/" + mappingName + "/" + key)
+    } catch (error) {
+      throw new Error("Error fetching mapping value - ensure the mapping exists and the key is correct");
+    }
+  }
+
+  /**
    * Returns the block contents of the latest block
    *
    * @example

--- a/sdk/tests/node.integration.ts
+++ b/sdk/tests/node.integration.ts
@@ -52,5 +52,16 @@ describe('NodeConnection', () => {
                 expect(records.length).toBeGreaterThan(0);
             }
         }, 60000);
+
+        it('should find finalize scope values', async () => {
+            const mappings = await localApiClient.getProgramMappingNames("credits.aleo");
+            if (!(mappings instanceof Error)) {
+                expect(mappings[0]).toBe("account");
+            }
+            const mappingValue = await localApiClient.getMappingValue("credits.aleo", "account", "aleo1zrtqrkrr9l09lgnj2qvzyr9sjgs6r5rfqneaj4a9kh7l7tsn2c9qeevqcm");
+            if (!(mappingValue instanceof Error)) {
+                expect(mappingValue).toBe("0u64");
+            }
+        }, 60000);
     });
 });


### PR DESCRIPTION
## Motivation

This PR bumps the SDK to the latest version of SnarkVM. 

Also, the Aleo Network has released REST endpoints for querying mappings associated with functions on the Aleo network.

## Test Plan
* Add an integration test to query the finalize scope

## Related PRs
[Add REST endpoints for finalize scope](https://github.com/AleoHQ/snarkOS/pull/2461)