### PR TITLE
[Feature] Add offline program execution option

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -204,6 +204,7 @@ pub mod snarkvm_types {
             Literal,
             Locator,
             Network,
+            OutputID,
             Plaintext,
             PlaintextType,
             ProgramID,
@@ -215,7 +216,7 @@ pub mod snarkvm_types {
         },
         types::Field,
     };
-    pub use snarkvm_ledger_block::{Block, Deployment, Transaction};
+    pub use snarkvm_ledger_block::{Block, Deployment, Execution, Transaction};
     pub use snarkvm_ledger_query::Query;
     pub use snarkvm_ledger_store::{
         helpers::memory::{BlockMemory, ConsensusMemory},
@@ -225,9 +226,10 @@ pub mod snarkvm_types {
     pub use snarkvm_synthesizer::{
         deployment_cost,
         execution_cost,
-        snark::{ProvingKey, VerifyingKey},
+        snark::{Proof, ProvingKey, VerifyingKey},
         Process,
         Program,
+        Trace,
         VM,
     };
 }

--- a/rust/src/program/execute.rs
+++ b/rust/src/program/execute.rs
@@ -19,6 +19,15 @@ use snarkvm::prelude::AleoID;
 
 impl<N: Network> ProgramManager<N> {
     /// Create an offline execution of a program to share with a third party.
+    ///
+    /// DISCLAIMER: Offline executions will not interact with the Aleo network and cannot use all
+    /// of the features of the Leo programming language or Aleo instructions. Any code written
+    /// inside finalize blocks will not be executed, mappings cannot be initialized, updated or read,
+    /// and a chain of records cannot be created.
+    ///
+    /// Offline executions however can be used to verify that program outputs follow from program
+    /// inputs and that the program was executed correctly. If this is the aim and no chain
+    /// interaction is desired, this function can be used.
     pub fn execute_program_offline<A: Aleo<Network = N>>(
         &self,
         private_key: &PrivateKey<N>,

--- a/rust/src/program/helpers/mod.rs
+++ b/rust/src/program/helpers/mod.rs
@@ -16,6 +16,9 @@
 
 use super::*;
 
+pub mod offline;
+pub use offline::*;
+
 pub mod state;
 pub use state::*;
 

--- a/rust/src/program/helpers/offline.rs
+++ b/rust/src/program/helpers/offline.rs
@@ -1,0 +1,73 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Aleo SDK library.
+
+// The Aleo SDK library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Aleo SDK library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Aleo SDK library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+/// Offline Execution of a program
+#[derive(Clone)]
+pub struct OfflineExecution<N: Network> {
+    execution: Execution<N>,
+    response: Option<Response<N>>,
+    trace: Trace<N>,
+    public_outputs: Option<Vec<Value<N>>>,
+}
+
+impl<N: Network> OfflineExecution<N> {
+    /// Create a new offline execution
+    pub(crate) fn new(
+        execution: Execution<N>,
+        response: Option<Response<N>>,
+        trace: Trace<N>,
+        public_outputs: Option<Vec<Value<N>>>,
+    ) -> Self {
+        Self { execution, response, trace, public_outputs }
+    }
+
+    /// Get the execution
+    pub fn execution(&self) -> &Execution<N> {
+        &self.execution
+    }
+
+    /// Get the execution id
+    pub fn execution_id(&self) -> Result<Field<N>> {
+        self.execution.to_execution_id()
+    }
+
+    /// Get the execution proof
+    pub fn execution_proof(&self) -> Option<&Proof<N>> {
+        self.execution.proof()
+    }
+
+    /// Get the outputs of the execution
+    pub fn outputs(&self) -> Option<Vec<Value<N>>> {
+        self.response.as_ref().map(|r| r.outputs().to_vec())
+    }
+
+    /// Get the trace of the execution
+    pub fn trace(&self) -> &Trace<N> {
+        &self.trace
+    }
+
+    /// Verify the execution proof against the given verifier inputs and program verifying key
+    pub fn verify_execution_proof(
+        &self,
+        locator: &str,
+        verifier_inputs: Vec<(VerifyingKey<N>, Vec<Vec<N::Field>>)>,
+        execution: &Execution<N>,
+    ) -> Result<(), String> {
+        self.verify_execution_proof(locator, verifier_inputs, execution)
+    }
+}


### PR DESCRIPTION
## Motivation

Currently there is no mechanic for execution programs offline in the Rust SDK. This PR introduces the ability to execute programs online and create an object with facilities to verify the proof which can be shared with 3rd parties. Currently there's no wire serialization format included in this, but this will be added in future work.