### PR TITLE
[Feature] Add multiple transfer type options to Aleo.tools

### DIFF
--- a/wasm/src/programs/manager/transfer.rs
+++ b/wasm/src/programs/manager/transfer.rs
@@ -89,20 +89,20 @@ impl ProgramManager {
 
         let (transfer_type, inputs) = match transfer_type {
             "private" => {
-                let inputs = Array::new_with_length(3);
                 if amount_record.is_none() {
                     return Err("Amount record must be provided for private transfers".to_string());
                 }
+                let inputs = Array::new_with_length(3);
                 inputs.set(0u32, wasm_bindgen::JsValue::from_str(&amount_record.unwrap().to_string()));
                 inputs.set(1u32, wasm_bindgen::JsValue::from_str(&recipient));
                 inputs.set(2u32, wasm_bindgen::JsValue::from_str(&amount_microcredits.to_string().add("u64")));
                 ("transfer_private", inputs)
             }
             "private_to_public" | "privateToPublic" | "transfer_private_to_public" | "transferPrivateToPublic" => {
-                let inputs = Array::new_with_length(3);
                 if amount_record.is_none() {
                     return Err("Amount record must be provided for private transfers".to_string());
                 }
+                let inputs = Array::new_with_length(3);
                 inputs.set(0u32, wasm_bindgen::JsValue::from_str(&amount_record.unwrap().to_string()));
                 inputs.set(1u32, wasm_bindgen::JsValue::from_str(&recipient));
                 inputs.set(2u32, wasm_bindgen::JsValue::from_str(&amount_microcredits.to_string().add("u64")));

--- a/website/src/tabs/develop/Transfer.jsx
+++ b/website/src/tabs/develop/Transfer.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
-import { Button, Card, Col, Form, Input, Row, Result, Spin } from "antd";
+import { Button, Card, Col, Dropdown, Form, Input, Row, Result, Space, Spin } from "antd";
+import { DownOutlined } from "@ant-design/icons";
 import axios from "axios";
 
 export const Transfer = () => {
@@ -14,6 +15,7 @@ export const Transfer = () => {
     const [transferError, setTransferError] = useState(null);
     const [status, setStatus] = useState("");
     const [transactionID, setTransactionID] = useState(null);
+    const [visibility, setVisibility] = useState("private");
     const [worker, setWorker] = useState(null);
 
     function spawnWorker() {
@@ -89,7 +91,7 @@ export const Transfer = () => {
             type: "ALEO_TRANSFER",
             privateKey: privateKeyString(),
             amountCredits: amount,
-            transfer_type: "private",
+            transfer_type: visibilityString(),
             recipient: recipientString(),
             amountRecord: amountRecordString(),
             fee: feeAmount,
@@ -174,6 +176,33 @@ export const Transfer = () => {
         return privateKey;
     };
 
+    const onClick = ({ key }) => {
+        setTransactionID(null);
+        setTransferError(null);
+        console.log("Visibility changed to: ", key);
+        setVisibility(key);
+        setAmountRecord(null);
+    };
+
+    const items = [
+        {
+            label: 'private',
+            key: 'private',
+        },
+        {
+            label: 'privateToPublic',
+            key: 'privateToPublic',
+        },
+        {
+            label: 'public',
+            key: 'public',
+        },
+        {
+            label: 'publicToPrivate',
+            key: 'publicToPrivate',
+        },
+    ];
+
     const layout = { labelCol: { span: 3 }, wrapperCol: { span: 21 } };
     const feeString = () => (transferFee !== null ? transferFee : "");
     const amountString = () => (transferAmount !== null ? transferAmount : "");
@@ -188,12 +217,19 @@ export const Transfer = () => {
     const transferErrorString = () =>
         transferError !== null ? transferError : "";
     const peerUrl = () => (transferUrl !== null ? transferUrl : "");
+    const visibilityString = () => (visibility !== null ? visibility : "private");
 
     return (
         <Card
             title="Transfer"
             style={{ width: "100%", borderRadius: "20px" }}
             bordered={false}
+            extra={
+            <Dropdown menu={{ items, onClick }}>
+                <a onClick={(e) => e.preventDefault()}>
+                    <Button>{visibilityString()}</Button>
+                </a>
+            </Dropdown>}
         >
             <Form {...layout}>
                 <Form.Item
@@ -220,20 +256,23 @@ export const Transfer = () => {
                         value={amountString()}
                     />
                 </Form.Item>
-                <Form.Item
-                    label="Amount Record"
-                    colon={false}
-                    validateStatus={status}
-                >
-                    <Input.TextArea
-                        name="Amount Record"
-                        size="small"
-                        placeholder="Record used to pay transfer amount"
-                        allowClear
-                        onChange={onAmountRecordChange}
-                        value={amountRecordString()}
-                    />
-                </Form.Item>
+                {
+                    (visibilityString() === "privateToPublic" || visibilityString() === "private") &&
+                    <Form.Item
+                        label="Amount Record"
+                        colon={false}
+                        validateStatus={status}
+                    >
+                        <Input.TextArea
+                            name="Amount Record"
+                            size="small"
+                            placeholder="Record used to pay transfer amount"
+                            allowClear
+                            onChange={onAmountRecordChange}
+                            value={amountRecordString()}
+                        />
+                    </Form.Item>
+                }
                 <Form.Item label="Fee" colon={false} validateStatus={status}>
                     <Input.TextArea
                         name="Fee"

--- a/website/src/tabs/develop/Transfer.jsx
+++ b/website/src/tabs/develop/Transfer.jsx
@@ -87,13 +87,18 @@ export const Transfer = () => {
             return;
         }
 
+        let amountRecord = amountRecordString();
+        if (visibilityString() === "public" || visibilityString() === "publicToPrivate") {
+            amountRecord = undefined;
+        }
+
         await postMessagePromise(worker, {
             type: "ALEO_TRANSFER",
             privateKey: privateKeyString(),
             amountCredits: amount,
             transfer_type: visibilityString(),
             recipient: recipientString(),
-            amountRecord: amountRecordString(),
+            amountRecord: amountRecord,
             fee: feeAmount,
             feeRecord: feeRecordString(),
             url: peerUrl(),
@@ -181,7 +186,9 @@ export const Transfer = () => {
         setTransferError(null);
         console.log("Visibility changed to: ", key);
         setVisibility(key);
-        setAmountRecord(null);
+        if (key === "public" || key === "publicToPrivate") {
+            setAmountRecord(null);
+        }
     };
 
     const items = [

--- a/website/src/workers/worker.js
+++ b/website/src/workers/worker.js
@@ -352,12 +352,12 @@ self.addEventListener("message", (ev) => {
                         if (
                             !aleoProgramManager.keyExists(
                                 "credits.aleo",
-                                "public_to_private",
+                                "transfer_public_to_private",
                             )
                         ) {
                             aleoProgramManager.cacheKeypairInWasmMemory(
                                 aleo.Program.getCreditsProgram().toString(),
-                                "public_to_private",
+                                "transfer_public_to_private",
                                 transferPublicToPrivateProvingKey,
                                 transferPublicToPrivateVerifyingKey,
                             );
@@ -379,12 +379,12 @@ self.addEventListener("message", (ev) => {
                         if (
                             !aleoProgramManager.keyExists(
                                 "credits.aleo",
-                                "private_to_public",
+                                "transfer_private_to_public",
                             )
                         ) {
                             aleoProgramManager.cacheKeypairInWasmMemory(
                                 aleo.Program.getCreditsProgram().toString(),
-                                "private_to_public",
+                                "transfer_private_to_public",
                                 transferPrivateToPublicProvingKey,
                                 transferPrivateToPublicVerifyingKey,
                             );
@@ -434,12 +434,14 @@ self.addEventListener("message", (ev) => {
                     );
                 }
 
+                let transferAmountRecord = amountRecord !== undefined ? aleo.RecordPlaintext.fromString(amountRecord) : undefined;
+
                 let transferTransaction = await aleoProgramManager.transfer(
                     aleo.PrivateKey.from_string(privateKey),
                     amountCredits,
                     recipient,
                     transfer_type,
-                    aleo.RecordPlaintext.fromString(amountRecord),
+                    transferAmountRecord,
                     fee,
                     aleo.RecordPlaintext.fromString(feeRecord),
                     url,

--- a/website/src/workers/worker.js
+++ b/website/src/workers/worker.js
@@ -307,7 +307,7 @@ self.addEventListener("message", (ev) => {
             url,
         } = ev.data;
 
-        console.log("Web worker: Creating transfer...");
+        console.log(`Web worker: Creating transfer of type ${transfer_type}...`);
         let startTime = performance.now();
 
         (async function () {
@@ -352,18 +352,19 @@ self.addEventListener("message", (ev) => {
                         if (
                             !aleoProgramManager.keyExists(
                                 "credits.aleo",
-                                "transfer_public_to_private",
+                                "public_to_private",
                             )
                         ) {
                             aleoProgramManager.cacheKeypairInWasmMemory(
                                 aleo.Program.getCreditsProgram().toString(),
-                                "transfer_public_to_private",
+                                "public_to_private",
                                 transferPublicToPrivateProvingKey,
                                 transferPublicToPrivateVerifyingKey,
                             );
                         }
                     }
                 } else if (transfer_type === "privateToPublic") {
+                    console.log("private to public");
                     if (
                         transferPrivateToPublicProvingKey === null ||
                         transferPrivateToPublicVerifyingKey === null
@@ -378,12 +379,12 @@ self.addEventListener("message", (ev) => {
                         if (
                             !aleoProgramManager.keyExists(
                                 "credits.aleo",
-                                "transfer_private_to_public",
+                                "private_to_public",
                             )
                         ) {
                             aleoProgramManager.cacheKeypairInWasmMemory(
                                 aleo.Program.getCreditsProgram().toString(),
-                                "transfer_private_to_public",
+                                "private_to_public",
                                 transferPrivateToPublicProvingKey,
                                 transferPrivateToPublicVerifyingKey,
                             );


### PR DESCRIPTION
## Motivation

There are 4 different types of transfers currently possible
`transfer_private` - Transfer microcredits privately and create another record in the target address with a microcredits balance
`transfer_private_to_public` - Transfer a microcredits privately to a public microcredits mapping in credits.aleo for the target address
`transfer_public` - Transfer microcredits publicly from one microcredits mapping to another
`transfer_public_to_private` - Transfer microcredits from a public mapping to a private record

Aleo.tools currently only supports the ability to execute `transfer_private` - this PR the ability execute all 4 types of transfers on aleo.tools
