### PR TITLE
[Fix] Small script to ensure snippets folder gets added

### DIFF
--- a/wasm/PUBLISH.md
+++ b/wasm/PUBLISH.md
@@ -4,7 +4,8 @@
 
 ```bash
 npm login
-wasm-pack build --target nodejs --out-name aleo --scope aleohq
-cd pkg
+export RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--max-memory=4294967296' && rustup run nightly-2023-05-24 wasm-pack build --release --target web --scope aleohq --out-dir pkg-parallel -- --features "parallel, browser" --no-default-features -Z build-std=panic_abort,std
+node prepublish
+cd pkg-parallel
 npm publish --access=public
 ```

--- a/wasm/prepublish.js
+++ b/wasm/prepublish.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+try {
+  const pkgPath = path.join(__dirname, "pkg-parallel/package.json");
+
+  // Check if package.json exists
+  if (!fs.existsSync(pkgPath)) {
+    console.error(`Error: File ${pkgPath} not found.`);
+    process.exit(1);
+  }
+
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+
+  // Add snippets to the files array. If no files array exists, create one.
+  pkg.files = pkg.files || [];
+  if (!pkg.files.includes('snippets/')) {
+    pkg.files.push('snippets/');
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+    console.log('Successfully added "snippets/" to package.json.');
+  } else {
+    console.log('"snippets/" already exists in package.json.');
+  }
+} catch (error) {
+  console.error(`An error occurred: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Motivation

wasm pack does not include snippets folder generated required by wasm-bindgen-rayon: https://github.com/rustwasm/wasm-pack/issues/1206

Just adding a small script and updating the read me to have the snippets folder included.
