### PR TITLE
[Fix] Update SDK integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
             cd ..
             sudo npm install --global typescript
             cargo install snarkos
-            snarkos start --dev 0 --beacon APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH --nodisplay 1> /dev/null &
+            snarkos start --dev 0 --beacon --nodisplay 1> /dev/null &
             cargo install aleo-development-server
             aleo-develop start --server-address 0.0.0.0:4040 --peer http://localhost:3030 -d 1> /dev/null &
             aleo-develop start --server-address 0.0.0.0:5050 --peer http://localhost:3030 -d -k ciphertext1qvqgkey2cxklg4g5qjnkk4dy50zypte5ewp5kwdm9pt833eyext32pu07dgkxqzmn0wnpxx8kvh2phws6j5njsu6zrys20xpvqmqhw9gpngs50mpe9e0nkp6uyzctzdq3fs2n4p9d3kvaps6mg6xu0sef0xpzm028m7 1> /dev/null &


### PR DESCRIPTION
## Motivation

SnarkOS tests recently updated its command for starting a development node. This PR makes a simple update to the ci test to fix this.
