### PR TITLE
[Fix] adding nonce to getFunctionInputs for records

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -93,7 +93,7 @@ checksum = "7e4f181fc1a372e8ceff89612e5c9b13f72bff5b066da9f8d6827ae65af492c4"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.5.7"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/wasm/src/programs/program.rs
+++ b/wasm/src/programs/program.rs
@@ -683,12 +683,12 @@ function add_and_double:
     fn test_get_inputs() {
         let credits = Program::from(ProgramNative::credits().unwrap());
         let inputs = credits.get_function_inputs("transfer_private".to_string()).unwrap();
-        let expected = r#"Array { obj: Object { obj: JsValue([Object({"type":"record","record":"credits","members":[{"name":"microcredits","type":"u64","visibility":"private"}],"register":"r0"}), Object({"type":"address","visibility":"private","register":"r1"}), Object({"type":"u64","visibility":"private","register":"r2"})]) } }"#.to_string();
+        let expected = r#"Array { obj: Object { obj: JsValue([Object({"type":"record","record":"credits","members":[{"name":"microcredits","type":"u64","visibility":"private"}],"_nonce":{"name":"_nonce","type":"group","visibility":"public"},"register":"r0"}), Object({"type":"address","visibility":"private","register":"r1"}), Object({"type":"u64","visibility":"private","register":"r2"})]) } }"#.to_string();
         assert_eq!(format!("{:?}", inputs), expected);
 
         let token_issue = Program::from_string(TOKEN_ISSUE).unwrap();
         let inputs = token_issue.get_function_inputs("bump_token_version".to_string()).unwrap();
-        let expected = r#"Array { obj: Object { obj: JsValue([Object({"type":"address","visibility":"private","register":"r0"}), Object({"type":"record","record":"Token","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"amount","type":"u64","visibility":"private"},{"name":"token_data","type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private"}],"register":"r1"}), Object({"type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private","register":"r2"})]) } }"#;
+        let expected = r#"Array { obj: Object { obj: JsValue([Object({"type":"address","visibility":"private","register":"r0"}), Object({"type":"record","record":"Token","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"amount","type":"u64","visibility":"private"},{"name":"token_data","type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private"}],"_nonce":{"name":"_nonce","type":"group","visibility":"public"},"register":"r1"}), Object({"type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private","register":"r2"})]) } }"#;
         assert_eq!(format!("{:?}", inputs), expected);
     }
 
@@ -696,12 +696,12 @@ function add_and_double:
     fn test_get_record() {
         let credits = Program::from(ProgramNative::credits().unwrap());
         let members = credits.get_record_members("credits".to_string()).unwrap();
-        let expected = r#"Object { obj: JsValue(Object({"type":"record","record":"credits","members":[{"name":"microcredits","type":"u64","visibility":"private"}]})) }"#.to_string();
+        let expected = r#"Object { obj: JsValue(Object({"type":"record","record":"credits","members":[{"name":"microcredits","type":"u64","visibility":"private"}],"_nonce":{"name":"_nonce","type":"group","visibility":"public"}})) }"#.to_string();
         assert_eq!(format!("{:?}", members), expected);
 
         let token_issue = Program::from_string(TOKEN_ISSUE).unwrap();
         let members = token_issue.get_record_members("Token".to_string()).unwrap();
-        let expected = r#"Object { obj: JsValue(Object({"type":"record","record":"Token","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"amount","type":"u64","visibility":"private"},{"name":"token_data","type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private"}]})) }"#;
+        let expected = r#"Object { obj: JsValue(Object({"type":"record","record":"Token","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"amount","type":"u64","visibility":"private"},{"name":"token_data","type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private"}],"_nonce":{"name":"_nonce","type":"group","visibility":"public"}})) }"#;
         assert_eq!(format!("{:?}", members), expected);
     }
 

--- a/wasm/src/programs/program.rs
+++ b/wasm/src/programs/program.rs
@@ -320,6 +320,8 @@ impl Program {
         Reflect::set(&_nonce, &"type".into(), &"group".into()).map_err(|_| "Failed to set property")?;
         Reflect::set(&_nonce, &"visibility".into(), &"public".into()).map_err(|_| "Failed to set property")?;
 
+        Reflect::set(&input, &"_nonce".into(), &_nonce).map_err(|_| "Failed to set property")?;
+
         Ok(input)
     }
 

--- a/wasm/src/programs/program.rs
+++ b/wasm/src/programs/program.rs
@@ -313,6 +313,13 @@ impl Program {
         }
 
         Reflect::set(&input, &"members".into(), &record_members).map_err(|_| "Failed to set property")?;
+
+        // Adding _nonce object to record
+        let _nonce = Object::new();
+        Reflect::set(&_nonce, &"name".into(), &"_nonce".into()).map_err(|_| "Failed to set property")?;
+        Reflect::set(&_nonce, &"type".into(), &"group".into()).map_err(|_| "Failed to set property")?;
+        Reflect::set(&_nonce, &"visibility".into(), &"public".into()).map_err(|_| "Failed to set property")?;
+
         Ok(input)
     }
 

--- a/wasm/src/programs/program.rs
+++ b/wasm/src/programs/program.rs
@@ -320,7 +320,7 @@ impl Program {
         Reflect::set(&_nonce, &"type".into(), &"group".into()).map_err(|_| "Failed to set property")?;
         Reflect::set(&_nonce, &"visibility".into(), &"public".into()).map_err(|_| "Failed to set property")?;
 
-        Reflect::set(&input, &"_nonce".into(), &_nonce).map_err(|_| "Failed to set property")?;
+        record_members.push(&JsValue::from(_nonce));
 
         Ok(input)
     }
@@ -683,12 +683,12 @@ function add_and_double:
     fn test_get_inputs() {
         let credits = Program::from(ProgramNative::credits().unwrap());
         let inputs = credits.get_function_inputs("transfer_private".to_string()).unwrap();
-        let expected = r#"Array { obj: Object { obj: JsValue([Object({"type":"record","record":"credits","members":[{"name":"microcredits","type":"u64","visibility":"private"}],"_nonce":{"name":"_nonce","type":"group","visibility":"public"},"register":"r0"}), Object({"type":"address","visibility":"private","register":"r1"}), Object({"type":"u64","visibility":"private","register":"r2"})]) } }"#.to_string();
+        let expected = r#"Array { obj: Object { obj: JsValue([Object({"type":"record","record":"credits","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"_nonce","type":"group","visibility":"public"}],"register":"r0"}), Object({"type":"address","visibility":"private","register":"r1"}), Object({"type":"u64","visibility":"private","register":"r2"})]) } }"#.to_string();
         assert_eq!(format!("{:?}", inputs), expected);
 
         let token_issue = Program::from_string(TOKEN_ISSUE).unwrap();
         let inputs = token_issue.get_function_inputs("bump_token_version".to_string()).unwrap();
-        let expected = r#"Array { obj: Object { obj: JsValue([Object({"type":"address","visibility":"private","register":"r0"}), Object({"type":"record","record":"Token","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"amount","type":"u64","visibility":"private"},{"name":"token_data","type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private"}],"_nonce":{"name":"_nonce","type":"group","visibility":"public"},"register":"r1"}), Object({"type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private","register":"r2"})]) } }"#;
+        let expected = r#"Array { obj: Object { obj: JsValue([Object({"type":"address","visibility":"private","register":"r0"}), Object({"type":"record","record":"Token","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"amount","type":"u64","visibility":"private"},{"name":"token_data","type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private"},{"name":"_nonce","type":"group","visibility":"public"}],"register":"r1"}), Object({"type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private","register":"r2"})]) } }"#;
         assert_eq!(format!("{:?}", inputs), expected);
     }
 
@@ -696,12 +696,12 @@ function add_and_double:
     fn test_get_record() {
         let credits = Program::from(ProgramNative::credits().unwrap());
         let members = credits.get_record_members("credits".to_string()).unwrap();
-        let expected = r#"Object { obj: JsValue(Object({"type":"record","record":"credits","members":[{"name":"microcredits","type":"u64","visibility":"private"}],"_nonce":{"name":"_nonce","type":"group","visibility":"public"}})) }"#.to_string();
+        let expected = r#"Object { obj: JsValue(Object({"type":"record","record":"credits","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"_nonce","type":"group","visibility":"public"}]})) }"#.to_string();
         assert_eq!(format!("{:?}", members), expected);
 
         let token_issue = Program::from_string(TOKEN_ISSUE).unwrap();
         let members = token_issue.get_record_members("Token".to_string()).unwrap();
-        let expected = r#"Object { obj: JsValue(Object({"type":"record","record":"Token","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"amount","type":"u64","visibility":"private"},{"name":"token_data","type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private"}],"_nonce":{"name":"_nonce","type":"group","visibility":"public"}})) }"#;
+        let expected = r#"Object { obj: JsValue(Object({"type":"record","record":"Token","members":[{"name":"microcredits","type":"u64","visibility":"private"},{"name":"amount","type":"u64","visibility":"private"},{"name":"token_data","type":"struct","struct_id":"token_metadata","members":[{"name":"token_id","type":"u32"},{"name":"version","type":"u32"}],"visibility":"private"},{"name":"_nonce","type":"group","visibility":"public"}]})) }"#;
         assert_eq!(format!("{:?}", members), expected);
     }
 


### PR DESCRIPTION
## Motivation

Resolves #742 
## Test Plan

Load credits.aleo in aleo.tools and notice `_nonce` now shows up for functions with records (e.g., `transfer_private`)