### PR TITLE
[Fix] fee record only required if private fee is selected

### DIFF
--- a/website/src/tabs/develop/execute/index.jsx
+++ b/website/src/tabs/develop/execute/index.jsx
@@ -33,7 +33,7 @@ export const Execute = () => {
                     "    input r0 as u32.public;\n" +
                     "    input r1 as u32.private;\n" +
                     "    add r0 r1 into r2;\n" +
-                    "    output r2 as u32.private;\n",
+                    "    output r2 as u32.private;\n"
             );
             form.setFieldValue("manual_input", true);
             form.setFieldValue("functionName", "hello");
@@ -115,7 +115,7 @@ export const Execute = () => {
     function spawnWorker() {
         let worker = new Worker(
             new URL("../../../workers/worker.js", import.meta.url),
-            { type: "module" },
+            { type: "module" }
         );
         worker.addEventListener("message", (ev) => {
             if (ev.data.type == "OFFLINE_EXECUTION_COMPLETED") {
@@ -193,7 +193,7 @@ export const Execute = () => {
     const generateKey = () => {
         form.setFieldValue(
             "private_key",
-            new aleoWASM.PrivateKey().to_string(),
+            new aleoWASM.PrivateKey().to_string()
         );
         form.validateFields(["private_key"]);
     };
@@ -271,7 +271,7 @@ export const Execute = () => {
                         });
                         form.setFieldValue(
                             "inputs",
-                            JSON.stringify(translatedArray),
+                            JSON.stringify(translatedArray)
                         );
                         form.submit();
                     }
@@ -349,7 +349,7 @@ export const Execute = () => {
                                         {
                                             required:
                                                 getFieldValue(
-                                                    "execute_onchain",
+                                                    "execute_onchain"
                                                 ),
                                             message:
                                                 "Fee needed for on-chain execution",
@@ -386,6 +386,9 @@ export const Execute = () => {
                                                 hidden={
                                                     !getFieldValue(
                                                         "private_fee"
+                                                    ) ||
+                                                    !getFieldValue(
+                                                        "execute_onchain"
                                                     )
                                                 }
                                                 rules={[
@@ -393,9 +396,12 @@ export const Execute = () => {
                                                         required:
                                                             getFieldValue(
                                                                 "private_fee"
+                                                            ) &&
+                                                            getFieldValue(
+                                                                "execute_onchain"
                                                             ),
                                                         message:
-                                                            "Fee record needed for for private fee",
+                                                            "Fee record needed for private fee",
                                                     },
                                                 ]}
                                             >
@@ -481,8 +487,8 @@ const renderInput = (input, inputIndex, nameArray = []) => {
                     renderInput(
                         member,
                         memberIndex,
-                        [].concat(nameArray).concat(input.name || inputIndex),
-                    ),
+                        [].concat(nameArray).concat(input.name || inputIndex)
+                    )
                 )}
             </div>
         );
@@ -510,7 +516,7 @@ const functionForm = (func, funcInputs) => {
         >
             {funcInputs.length > 0 ? (
                 funcInputs.map((input, inputIndex) =>
-                    renderInput(input, inputIndex, ["inputs"]),
+                    renderInput(input, inputIndex, ["inputs"])
                 )
             ) : (
                 <Form.Item

--- a/website/src/tabs/develop/execute/index.jsx
+++ b/website/src/tabs/develop/execute/index.jsx
@@ -54,7 +54,6 @@ export const Execute = () => {
     }, []);
 
     const execute = async (values) => {
-        console.log(values)
         setModalModalOpen(true);
         setLoading(true);
         try {
@@ -393,10 +392,10 @@ export const Execute = () => {
                                                     {
                                                         required:
                                                             getFieldValue(
-                                                                "execute_onchain"
+                                                                "private_fee"
                                                             ),
                                                         message:
-                                                            "Fee record needed for on-chain execution",
+                                                            "Fee record needed for for private fee",
                                                     },
                                                 ]}
                                             >


### PR DESCRIPTION
## Motivation

Small fix, fee record was always required for on-chain execution, switching it so it's only required if private fee is toggled.