### PR TITLE
[Fix] moving jsdoc to dev dependency only

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@aleohq/wasm": "^0.6.0",
     "comlink": "^4.4.1",
-    "jsdoc": "^3.6.11",
     "mime": "^3.0.0",
     "sync-request": "^6.1.0"
   },


### PR DESCRIPTION
## Motivation

jsdoc is in both dependencies and devDependencies. This causes some issues with auditing production dependencies as the version jsdoc we use has an audit issue but it doesn't actually affect the SDK since it's only used for doc generation.