### PR TITLE
fix: JsValue fetching error

### DIFF
--- a/sdk/src/polyfill/fetch.ts
+++ b/sdk/src/polyfill/fetch.ts
@@ -28,6 +28,10 @@ const oldFetch = globalThis.fetch;
         });
 
     } else {
-        return await oldFetch(request);
+        try {
+            return await oldFetch(request);
+        } catch (e) {
+            return await fetch(request);
+        }
     }
 };


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

I was using @aleohq/sdk 0.6.2, trying to use `progamManager.execute` on a testdeploy program, but it wouldn't succeed. It would always show `JsValue fetching error...` after `executing fee`. Then I found that the error comes from the `globalThis.oldFetch`. Then I tried changing to the normal js fetch function, then it works.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/sdk,
    and link to your PR here.
-->

(Link your related PRs here)
