### PR TITLE
[Feature] Enable building valid transactions without submitting them to the network

### DIFF
--- a/create-aleo-app/template-extension/src/worker.js
+++ b/create-aleo-app/template-extension/src/worker.js
@@ -18,7 +18,7 @@ async function localProgramExecution(program, aleoFunction, inputs) {
     const account = new Account();
     programManager.setAccount(account);
 
-    const executionResponse = await programManager.executeOffline(
+    const executionResponse = await programManager.run(
         hello_hello_program,
         "hello",
         ["5u32", "5u32"],

--- a/create-aleo-app/template-nextjs-ts/src/app/worker.ts
+++ b/create-aleo-app/template-nextjs-ts/src/app/worker.ts
@@ -23,7 +23,7 @@ async function localProgramExecution() {
   const account = new Account();
   programManager.setAccount(account);
 
-  const executionResponse = await programManager.executeOffline(
+  const executionResponse = await programManager.run(
       hello_hello_program,
       "hello",
       ["5u32", "5u32"],

--- a/create-aleo-app/template-node-ts/src/index.ts
+++ b/create-aleo-app/template-node-ts/src/index.ts
@@ -40,7 +40,7 @@ async function localProgramExecution() {
 
     // Execute once using the key provider params defined above. This will use the cached proving keys and make
     // execution significantly faster.
-    let executionResponse = await programManager.executeOffline(
+    let executionResponse = await programManager.run(
         hello_hello_program,
         "hello",
         ["5u32", "5u32"],

--- a/create-aleo-app/template-node/index.js
+++ b/create-aleo-app/template-node/index.js
@@ -33,7 +33,7 @@ async function localProgramExecution(program, aleoFunction, inputs) {
 
     // Execute once using the key provider params defined above. This will use the cached proving keys and make
     // execution significantly faster.
-    let executionResponse = await programManager.executeOffline(
+    let executionResponse = await programManager.run(
         hello_hello_program,
         "hello",
         ["5u32", "5u32"],

--- a/create-aleo-app/template-react-leo/src/workers/worker.js
+++ b/create-aleo-app/template-react-leo/src/workers/worker.js
@@ -18,7 +18,7 @@ async function localProgramExecution(program, aleoFunction, inputs) {
   const account = new Account();
   programManager.setAccount(account);
 
-  const executionResponse = await programManager.executeOffline(
+  const executionResponse = await programManager.run(
     program,
     aleoFunction,
     inputs,

--- a/create-aleo-app/template-vanilla/worker.js
+++ b/create-aleo-app/template-vanilla/worker.js
@@ -23,7 +23,7 @@ async function localProgramExecution(program, aleoFunction, inputs) {
     const account = new Account();
     programManager.setAccount(account);
 
-    const executionResponse = await programManager.executeOffline(
+    const executionResponse = await programManager.run(
         hello_hello_program,
         "hello",
         ["5u32", "5u32"],

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -131,7 +131,7 @@ import { Block } from "./models/block";
 import { Execution } from "./models/execution";
 import { Input } from "./models/input";
 import { Output } from "./models/output";
-import { Transaction } from "./models/transaction";
+import { TransactionModel } from "./models/transactionModel";
 import { Transition } from "./models/transition";
 import {
     AleoKeyProvider,
@@ -172,7 +172,7 @@ export {
     RecordCiphertext,
     RecordPlaintext,
     Signature,
-    Transaction as WasmTransaction,
+    Transaction,
     VerifyingKey,
     ViewKey,
     initThreadPool,
@@ -200,7 +200,7 @@ export {
     Output,
     RecordProvider,
     RecordSearchParams,
-    Transaction,
+    TransactionModel,
     Transition,
     CREDITS_PROGRAM_KEYS,
     KEY_STORE,

--- a/sdk/src/models/confirmed_transaction.ts
+++ b/sdk/src/models/confirmed_transaction.ts
@@ -1,7 +1,7 @@
-import { Transaction } from "./transaction";
+import { TransactionModel } from "./transactionModel";
 
 export type ConfirmedTransaction = {
     type: string;
     id: string;
-    transaction: Transaction;
+    transaction: TransactionModel;
 }

--- a/sdk/src/models/transactionModel.ts
+++ b/sdk/src/models/transactionModel.ts
@@ -1,6 +1,6 @@
 import { Execution } from "./execution";
 
-export type Transaction = {
+export type TransactionModel = {
     type: string;
     id: string;
     execution: Execution;

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -6,8 +6,8 @@ import {
   Program,
   RecordPlaintext,
   PrivateKey,
-  WasmTransaction,
   Transaction,
+  TransactionModel,
   logAndThrow
 } from "./index";
 
@@ -310,7 +310,7 @@ class AleoNetworkClient {
    * Returns the deployment transaction id associated with the specified program
    *
    * @param {Program | string} program
-   * @returns {Transaction | Error}
+   * @returns {TransactionModel | Error}
    */
   async getDeploymentTransactionIDForProgram(program: Program | string): Promise<string | Error> {
     if (program instanceof Program) {
@@ -328,12 +328,12 @@ class AleoNetworkClient {
    * Returns the deployment transaction associated with a specified program
    *
    * @param {Program | string} program
-   * @returns {Transaction | Error}
+   * @returns {TransactionModel | Error}
    */
-  async getDeploymentTransactionForProgram(program: Program | string): Promise<Transaction | Error> {
+  async getDeploymentTransactionForProgram(program: Program | string): Promise<TransactionModel | Error> {
     try {
       const transaction_id = <string>await this.getDeploymentTransactionIDForProgram(program);
-      return <Transaction>await this.getTransaction(transaction_id);
+      return <TransactionModel>await this.getTransaction(transaction_id);
     } catch (error) {
       throw new Error("Error fetching deployment transaction for program.");
     }
@@ -563,9 +563,9 @@ class AleoNetworkClient {
    * @example
    * const transaction = networkClient.getTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
    */
-  async getTransaction(id: string): Promise<Transaction | Error> {
+  async getTransaction(id: string): Promise<TransactionModel | Error> {
     try {
-      return await this.fetchData<Transaction>("/transaction/" + id);
+      return await this.fetchData<TransactionModel>("/transaction/" + id);
     } catch (error) {
       throw new Error("Error fetching transaction.");
     }
@@ -579,9 +579,9 @@ class AleoNetworkClient {
    * @example
    * const transactions = networkClient.getTransactions(654);
    */
-  async getTransactions(height: number): Promise<Array<Transaction> | Error> {
+  async getTransactions(height: number): Promise<Array<TransactionModel> | Error> {
     try {
-      return await this.fetchData<Array<Transaction>>("/block/" + height.toString() + "/transactions");
+      return await this.fetchData<Array<TransactionModel>>("/block/" + height.toString() + "/transactions");
     } catch (error) {
       throw new Error("Error fetching transactions.");
     }
@@ -593,9 +593,9 @@ class AleoNetworkClient {
    * @example
    * const transactions = networkClient.getTransactionsInMempool();
    */
-  async getTransactionsInMempool(): Promise<Array<Transaction> | Error> {
+  async getTransactionsInMempool(): Promise<Array<TransactionModel> | Error> {
     try {
-      return await this.fetchData<Array<Transaction>>("/memoryPool/transactions");
+      return await this.fetchData<Array<TransactionModel>>("/memoryPool/transactions");
     } catch (error) {
       throw new Error("Error fetching transactions from mempool.");
     }
@@ -619,11 +619,11 @@ class AleoNetworkClient {
   /**
    * Submit an execute or deployment transaction to the Aleo network
    *
-   * @param {WasmTransaction | string} transaction  - The transaction to submit to the network
+   * @param {Transaction | string} transaction  - The transaction to submit to the network
    * @returns {string | Error} - The transaction id of the submitted transaction or the resulting error
    */
-  async submitTransaction(transaction: WasmTransaction | string): Promise<string | Error> {
-    const transaction_string = transaction instanceof WasmTransaction ? transaction.toString() : transaction;
+  async submitTransaction(transaction: Transaction | string): Promise<string | Error> {
+    const transaction_string = transaction instanceof Transaction ? transaction.toString() : transaction;
     try {
       const response = await post(this.host + "/transaction/broadcast", {
         body: transaction_string,

--- a/sdk/src/worker.ts
+++ b/sdk/src/worker.ts
@@ -74,7 +74,7 @@ async function executeOffline(
         });
 
         // Execute the function locally
-        const response = await programManager.executeOffline(
+        const response = await programManager.run(
             localProgram,
             aleoFunction,
             inputs,

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -1,5 +1,5 @@
 import {jest} from '@jest/globals'
-import {Account, Block, AleoNetworkClient, Transaction} from "../src/node";
+import {Account, Block, AleoNetworkClient, TransactionModel} from "../src/node";
 import {beaconAddressString, beaconPrivateKeyString} from "./data/account-data";
 import {log} from "console";
 jest.retryTimes(3);
@@ -48,7 +48,7 @@ describe('NodeConnection', () => {
     describe('getDeploymentTransactionForProgram', () => {
         it('should return a Transaction object', async () => {
             const transaction = await connection.getDeploymentTransactionForProgram('hello_hello.aleo');
-            expect((transaction as Transaction).type).toBe("deploy");
+            expect((transaction as TransactionModel).type).toBe("deploy");
         }, 60000);
     });
 
@@ -102,7 +102,7 @@ describe('NodeConnection', () => {
     describe('getTransaction', () => {
         it('should return a Transaction object', async () => {
             const transaction = await connection.getTransaction('at1u833jaha7gtqk7vx0yczcg2njds2tj52lyg54c7zyylgfjvc4vpqn8gqqx');
-            expect((transaction as Transaction).type).toBe("deploy");
+            expect((transaction as TransactionModel).type).toBe("deploy");
         }, 60000);
     });
 
@@ -110,7 +110,7 @@ describe('NodeConnection', () => {
         it('should return an array of Transaction objects', async () => {
             const transactions = await connection.getTransactions(1);
             expect(Array.isArray(transactions)).toBe(true);
-            expect((transactions as Transaction[]).length).toBeGreaterThan(0);
+            expect((transactions as TransactionModel[]).length).toBeGreaterThan(0);
         }, 60000);
 
         it('should throw an error if the request fails', async () => {

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -16,7 +16,7 @@ describe('Program Manager', () => {
 
     describe('Execute offline', () => {
         it.skip('Program manager should execute offline and verify the resulting proof correctly', async () => {
-            const execution_result = <ExecutionResponse>await programManager.executeOffline(helloProgram, "hello", ["5u32", "5u32"], true, undefined, undefined, undefined, undefined, undefined, undefined)
+            const execution_result = <ExecutionResponse>await programManager.run(helloProgram, "hello", ["5u32", "5u32"], true, undefined, undefined, undefined, undefined, undefined, undefined)
             expect(execution_result.getOutputs()[0]).toEqual("10u32");
             programManager.verifyExecution(execution_result);
         }, 1020000);
@@ -30,7 +30,7 @@ describe('Program Manager', () => {
             offlineQuery.addStatePath(commitment, recordStatePath);
             const credits = <string>await programManager.networkClient.getProgram("credits.aleo");
 
-            const execution_result = <ExecutionResponse>await programManager.executeOffline(credits, "transfer_private", [statePathRecord, beaconAddressString, "5u64"], true, undefined, undefined, undefined, undefined, undefined, offlineQuery);
+            const execution_result = <ExecutionResponse>await programManager.run(credits, "transfer_private", [statePathRecord, beaconAddressString, "5u64"], true, undefined, undefined, undefined, undefined, undefined, offlineQuery);
             const verified = programManager.verifyExecution(execution_result);
             expect(verified).toEqual(true);
         }, 1020000);

--- a/website/src/workers/worker.js
+++ b/website/src/workers/worker.js
@@ -45,7 +45,7 @@ self.addEventListener("message", (ev) => {
                 const keyParams = new aleo.AleoKeyProviderParams({"cacheKey": cacheKey});
 
                 // Execute the function locally
-                let response = await programManager.executeOffline(
+                let response = await programManager.run(
                     localProgram,
                     aleoFunction,
                     inputs,


### PR DESCRIPTION
## Motivation

This PR adds the ability to build valid execution transactions without immediately submitting them to the network. This allows transactions to be built beforehand and then later submitted to the network.

The following methods have been introduced to build transactions offline. Each will return a `Transaction` object which is a `wasm` object representing an Aleo transaction. Users can use the `toString()` method on this object to get a human readable string representation of the Transaction.

`buildExecutionTransaction` - Build an execution transaction for an arbitrary execution
`buildTransferTransaction` - Build an transfer transaction for any of the 4 transaction types
`buildTransferPublicTransaction` - Build a transfer public transaction
`buildBondPublicTransaction` - Build a bond public transaction to bond as a delegator or validator to the network
`buildUnbondPublicTransaction`  - Build an unbond public transaction
`buildClaimUnbondPublicTransaction` - Build a transaction to claim unbonded stake

If the fee for a transaction is paid publicly (with the `fee_public` method) and the function being executed doesn't take any records as input, the transaction can be built completely offline without connection to the internet.