### PR TITLE
[Fix] Add string support for verifying keys in the AleoKeyProvider

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aleohq/sdk",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Aleo Team <hello@aleo.org>"

--- a/sdk/src/function-key-provider.ts
+++ b/sdk/src/function-key-provider.ts
@@ -501,7 +501,19 @@ class AleoKeyProvider implements FunctionKeyProvider {
             case CREDITS_PROGRAM_KEYS.unbond_public.verifier:
                 return CREDITS_PROGRAM_KEYS.unbond_public.verifyingKey();
             default:
-                return <VerifyingKey>VerifyingKey.fromBytes(await this.fetchBytes(verifierUri));
+                try {
+                    /// Try to fetch the verifying key from the network as a string
+                    const response = await get(verifierUri);
+                    const text = await response.text();
+                    return <VerifyingKey>VerifyingKey.fromString(text);
+                } catch (e) {
+                    /// If that fails, try to fetch the verifying key from the network as bytes
+                    try {
+                        return <VerifyingKey>VerifyingKey.fromBytes(await this.fetchBytes(verifierUri));
+                    } catch (inner) {
+                        return new Error("Invalid verifying key. Error: " + inner);
+                    }
+                }
         }
     }
 

--- a/sdk/tests/key-provider.test.ts
+++ b/sdk/tests/key-provider.test.ts
@@ -49,7 +49,16 @@ describe('KeyProvider', () => {
             expect(redownloadedVerifyingKey).toBeInstanceOf(VerifyingKey);
         }, 200000);
 
-        it("Should not fetch offline keys that haven't already been stored", async () => {
+        it('Should fetch verifying keys stored as text', async () => {
+            const provider = new AleoKeyProvider();
+            provider.useCache(true);
+            const [provingKey, verifyingKey] = <FunctionKeyPair> await provider.fetchKeys("https://pub-65a47b199b944d48a057ca6603a415a2.r2.dev/tree_mnist_2.prover.30e265c",
+                "https://pub-65a47b199b944d48a057ca6603a415a2.r2.dev/tree_mnist_2.verifier.17db860", "tree_mnist_2/main");
+            expect(provingKey).toBeInstanceOf(ProvingKey);
+            expect(verifyingKey).toBeInstanceOf(VerifyingKey);
+        }, 120000);
+
+        it.skip("Should not fetch offline keys that haven't already been stored", async () => {
             // Download the credits.aleo function keys
             const [bondPublicProver, bondPublicVerifier] = <FunctionKeyPair>await keyProvider.fetchKeys(CREDITS_PROGRAM_KEYS.bond_public.prover, CREDITS_PROGRAM_KEYS.bond_public.verifier, CREDITS_PROGRAM_KEYS.bond_public.locator);
             const [claimUnbondPublicProver, claimUnbondVerifier] = <FunctionKeyPair>await keyProvider.fetchKeys(CREDITS_PROGRAM_KEYS.claim_unbond_public.prover, CREDITS_PROGRAM_KEYS.claim_unbond_public.verifier, CREDITS_PROGRAM_KEYS.claim_unbond_public.locator);

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -93,7 +93,7 @@ checksum = "7e4f181fc1a372e8ceff89612e5c9b13f72bff5b066da9f8d6827ae65af492c4"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1615,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa338b6668006fa66df09df371c6cfd03f9eadb7042c34ed5b95ad39b94beb0d"
+checksum = "08da1e033ccc98ae6b3a36d58d480ff50337d7966cc1790f4cab49e41e94663f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b924113a282952f720a92f8630e1d816c4cf6009d17dc7b90a6bf18dd1a2308"
+checksum = "efd220c3d8c0bec7653f4e3bbb99f0794364b049dfc582ccc6c812d95e61eb3b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -1662,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329d3207ee86d5e499e0eda46d3c2f9e6a21e1548dd2faa166b03072064b64"
+checksum = "e95a3a044e0ff6ccab0af918d0a1abd56cabc883c8c25186521eb66690f8292b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -1674,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a8453fb6bb012f41c1f72c275ca26c1b6b0f6124b136ba36dbf759e97b1dc8"
+checksum = "27d89a4a5aa9b3c5f615c8d497bd2567746a40e9276eaf9c686af65d083b3f4c"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -1685,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30caca60bb663d3849d4401544c523b594a2b41d5e86e6b4794b03fbe1809e3b"
+checksum = "3c5801379acc9012ceb333d34acea819fd2064f106182ff6dd894d1a42ae23a5"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -1696,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881155b6f6949d9bcea09bd590cde79f8ce367a3af1072095679fda27cd68ebb"
+checksum = "81eb5bfd6f50ec6370f64087af759dd56a56a52bceb9419098ec6eea3e36ec6f"
 dependencies = [
  "indexmap 2.0.2",
  "itertools",
@@ -1715,15 +1715,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f7e7d38fa0f87fa9041782824ce857558a462d792dd391ca2e84f978f26af1"
+checksum = "a2345f76b90c2befccebbd16b41fa240d2364b4c362087c2719bc3d37eb271e1"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253a980ff632059de7550a3ec11f9168c65cecbc90d8f6e43715321a4440004b"
+checksum = "38a0f7b1cbb1ee0b3d47e3096e8bafe8045844f1f0b8f034e39d76a93ef772e8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -1733,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9afea5f206a4382395800d84e7a91ed66c59793044f5a4be0734cb9cea7e7ef"
+checksum = "1fcb96db67935aaf492e87d85c78b58d78c40871760e03bbf63bcf5893be904b"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -1749,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5da112e41b6021f4a7569541b6530224fee7724d47c5511470990acf9560251"
+checksum = "69e12119948f0e8ac2e1452e9f3f53ef1ee84638f5b61ba3ab9c0402f91cfddf"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -1765,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a32b51ff963543083a56cdfe58e76e34a3cb93cff5920da8dfe416950853587"
+checksum = "06993421e661bd92f5726096a52bb5a8c73fd637ef5d2c7cb160e9c80db5f43c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c449b5a53431f521a5455b0724ebabc966b253f839198df4df531dff24a9760a"
+checksum = "d47a776246d84d448a533f944c64811326f766f8fa6ec1960faee702e5ab9985"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -1789,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083b2fc69547c55a2c10f8ffef466d2381e5b16f6fbc5366f29e337337d8f37a"
+checksum = "d51d328748ed6d9808528a7ad5dc83c481d8b32a34883e1b1d0e7e2a2694c3e3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1800,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7653945c0862ea5810321999319e369a05a4eca13f7e9f397a7c692f2dbab4"
+checksum = "1bd190b09af0318ce1c130332b163729a2228fb1bed52a63b25a68127cdfa7d8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7db06434f25d6f8c0d0f2c0d37bbc0a1a211f3a0c297c4c44dce9c9c7caedb9"
+checksum = "68b00c8695658f89b4a304773969078b93b357b8b71768c62bc1078729f8e008"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93d3463aa60ae068e47a261ac660ae810e29fdc6c97c7b97e0fd38b878bbb49"
+checksum = "b56fdec9bd5575123959d7543a04d032a91121efff4b3cd7c482ce3c4e065202"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1838,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615ece430fe9685de9e1b93a43dd4387c10276aea37ab265687cd7e837eef49d"
+checksum = "2080f787779a1f6930ad596f7d4f2af5dfe111fe9f0109614c1098d769b6ebb1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1851,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12bb7e873ecce77eaab1ff65f28c720d872010cd6436cf16e6f383783ad6301"
+checksum = "8281defbca21fd8a5dc652d7cad21a34ad1b4522d818d530693d6051b9d6eeef"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -1865,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde745da7adb5e370a3202fe25695f7fd8a8359fa10b7e4bbc03125f7b7d5e82"
+checksum = "c360c5389bfc658a5e0765bd9dbf4a1633ac549bf169574fd7d7f8708081c641"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -1877,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d7675fe694184d1aa717a4e74324a9f509185d5f0d717a09fe92ab97818792"
+checksum = "fcd97c40f77f0860e51fb776fd81759b288be94b28d46169613e9be5f25f4c92"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -1891,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480022fd77dcf4e0afd6f83c7d27ace76e94ce6cb1052d5a04ddbbb703236c05"
+checksum = "62fe802bdcdd7b1f75fc6937a5645afb92532b7fc4498040747c82125dab5b58"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -1903,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34519a39ef71c09bc12907acc4da85cb10d53d7f543a66b43080dab710d280f4"
+checksum = "ee27ab3d078f3b5b766cd2cfe20b18b2447e3bb6a16c7a862462373c5db703ce"
 dependencies = [
  "anyhow",
  "indexmap 2.0.2",
@@ -1927,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bdfe56b88bc1fbe81cd26dc15a4c016568c806076ac354e91dd0bd6ce304b5"
+checksum = "debdf438642b0ee5a20f1951fc5efdf2681ec328b6c77ff4f29b95aff767da38"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a782513945b9b0a08110bfce163cca2d42a94b6f4bb569fb38ed54c7b809260"
+checksum = "0ced83a7d55de400a9ed8f304cb62522e548610781ec28119858e94f38503623"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -1968,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44145b528b5baaff2e061a51b8c115b79b909e76f69f4478bbd992737eb729d"
+checksum = "ef5e3d4940b1acfe25d0cc7003268715ba4f575b78bad2365347c385c3b3834c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -1984,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22457bd32e0d7dc4143362b3c1100a6fdcd2c3a14a25abe03adf93df2e3ed8b"
+checksum = "d8d0fb70f75c87a6cb866f1e00a6dd031fbd0adcd5172934efa1c8dfd06c1fef"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1996,18 +1996,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94e8235f7b37507296b113c3143d96f516b0d3f2180babd7f2eacb7b48a453e"
+checksum = "2957ce2dbb9632669e0310fcaabe9a9dd680d5979f4c3f965c3745826d2c333f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f2804cb7c7795eb35f50911091d3354ef007d92c81e15aa40989068eef260f"
+checksum = "925bed973c50b7d04848bde04d29e57b1ebb1c590ef959f31c0a3a70f9843cdb"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2016,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0901df8e0e264e2a31f3fa9f6a5659239b83ace4d3d51163c3728059aba6ff51"
+checksum = "4d734bd39060eaa3aeec0997b8f9755040aee4cdf3e2e225666d8888164b58f0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2028,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b012c127b228bafa0dd7238e30876c12b719b356de2720bf891d1b48cf289a"
+checksum = "932fb17064983820362c6b757ffeb4029a0c2b80a918b01af6b0306d3dcd6a6b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2040,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d87127df6edaae7216611be3fde91c3df2c29dc404078ae38efd4dd6e189572"
+checksum = "035afa7b185a05f68e0fc0d339f6ce2b84e323c431944aeb241d031a34a435ec"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2052,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081efd385c3466a98344743c1722bd9f691cc9628ee949e13b1fa6e9544cff61"
+checksum = "2ed979bc56a3938bcaf6444fe36d52ce1fcb3b526173a9d5c8fa99c75c91c438"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2064,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5b00c74a167e3d4c79620396ef9f8f8e75f169f9afd1bcf17bdae3d083580e"
+checksum = "012f2e0576f44ec165b5f46accfe9960619bb88acf115a247ebbb4d5ab37131a"
 dependencies = [
  "rand",
  "rayon",
@@ -2079,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705671554528f85456cd7c4c620594614b6b9ac3d5f966537b4f6307e5390448"
+checksum = "e38c91b1f2797726f3125c32e6837d15cbb473472ae4a6746a90388850fb361c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ff371686f2af532a362448fe0058f763f529ff70595edd2e36ad569480c6cd"
+checksum = "ebbd1fd021ff44bcd2921676cf2e5e1d09649f3c135f49c5556c5f2d57dc85c1"
 dependencies = [
  "anyhow",
  "rand",
@@ -2111,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913a0e9301a86313b294876bf05da58480e09e8cd5334beb1db22bea018755d2"
+checksum = "4c0b34daa6e379ff532ec59ebe7526334ae27b5be44486c88eb986db75e6212d"
 dependencies = [
  "indexmap 2.0.2",
  "rayon",
@@ -2130,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-coinbase"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822c1750f5dbc7d7106d5f44be9025e32d52b215210344f51cf6d0daec11a144"
+checksum = "fdacdf3079c775cd6c9b4f8ce77a374e6bf96884ff0d060432a15755d37521f7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2151,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a53cf397a4855cbe125ec860c9ef277e453c661af668c202b8c6a58e865967"
+checksum = "388c085d059898e363ff3bbfa4541c3ce4bb803d9e019a1b153dbedc250909db"
 dependencies = [
  "indexmap 2.0.2",
  "serde_json",
@@ -2162,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c383e23f56223d6f09c00d3caaf497e6fc0fc54baf1fd4bef3de60e6ae9fbf"
+checksum = "c273f32c68ad76ca284d9e7094bd2ea0a09ee7925088be05080fa849925b436d"
 dependencies = [
  "indexmap 2.0.2",
  "serde_json",
@@ -2175,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366812dfd631c595f101f4c1f17fac990643c9bfbfa5ff74b59681fe4b74a0dc"
+checksum = "68f7ad72bc7f32cec469af51eb82a7cb5d23d00cfd5c1bf39d3eca0f0197e5e8"
 dependencies = [
  "indexmap 2.0.2",
  "serde_json",
@@ -2187,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb7dc0dfaa486a5e28f84a5f838449af27783c09da9e140ed41a7d51e736a92"
+checksum = "ece4480b32a23505cd1ed5d133c0dcf1473e7bbafce1ebf93cf0acab324a1f75"
 dependencies = [
  "indexmap 2.0.2",
  "rayon",
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdaf050cb2a58252cd5554dcda8fb7b0e72df2528a3ce13f2e348297651109d"
+checksum = "be13d324fc359c1528d541cf50349d3dcc40f1caf461672c2e8a4927a0eff6dc"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -2212,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b777f57a4e0409487c745c2814dcbd4194b2e5f41c5b1607efaeaf5bc2f9884c"
+checksum = "8b91cc603f6656ff0b5a5456c6ba4daf3e6d5aa4d177dfdf1528c68161109c72"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2226,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b785a36927eae0196554144db06a8a74be4ad223a312636e3bd1b1092708f91b"
+checksum = "01541d583578d0ac73d9e30d4299796e8c770dd0686853ed48b7044ae71392bf"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2248,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b406e574c36fe51d9975cd98d4f3b13794af7f09eb8d869c7de926a88c903dcc"
+checksum = "c2baaea9dea656ae00ad6411cc7640b192e3193061e7132d7c41dbb3460c62c4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2276,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7748e22c493da5664071df9c5197d0eba642c0277e4288bc96bf86c549ea7107"
+checksum = "048cea58b5917b36f7cb1c2c5bce6447248eeeee148105af8c8b812df8e3153c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2302,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1632d2b0399686c44e0d72957c153e50c05c033d7b4e7e2a6328c6edd6b96c5f"
+checksum = "8a916d416fade91351bd296b9e6015c2eb4481302d045ba29b6ef927aa2278d6"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2326,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491a2b6c3a6566a7683cf406e49398e29c3ea8d8b5160356f24e2f81389d9a7d"
+checksum = "9b32f15bb9d2526bbae866d458bd527bf0394e450d9ccf0ad3d4ba55c3bc2a78"
 dependencies = [
  "indexmap 2.0.2",
  "paste",
@@ -2341,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4185f61b41581e6da4b8fda492a3865fd42ff2b90c03727da94a7aa079828b8f"
+checksum = "3b8879dfdd0472dc3b369accf4e4589b29556f2917fd35e9cb6f98d5160023e0"
 dependencies = [
  "bincode",
  "once_cell",
@@ -2355,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741c27cc58f6499dac952c1c48b54c944a5331ec3a6627514227cd981e8dd97a"
+checksum = "c90fb901c04e68974e1006f4c77126b2f7a65a1e645589aec1b5d4aab0bdde49"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2377,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2033b34d2bef273af018388099119b542c645b76d399c0a979a07190c06bc91c"
+checksum = "97b3ef65861467314b189dcb824587d13fde96e1b39b88d9b72440e15fb7d25d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "0.16.10"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b33574bac160512783cb24a28aae038f17dffb6ffb350d1234798a6e8bc243"
+checksum = "40358c508589ba06c5b34050a00d02295fdd696114f57a13e2a88d24c0d71dba"
 dependencies = [
  "getrandom",
  "rand",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-wasm"
-version = "0.6.8"
+version = "0.6.9"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "WebAssembly based toolkit for developing zero knowledge applications with Aleo"
 homepage = "https://aleo.org"
@@ -22,33 +22,33 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-circuit-network]
-version = "0.16.10"
+version = "=0.16.12"
 
 [dependencies.snarkvm-console]
-version = "0.16.10"
+version = "=0.16.12"
 features = [ "wasm" ]
 
 [dependencies.snarkvm-ledger-block]
-version = "0.16.10"
+version = "=0.16.12"
 features = [ "wasm" ]
 
 [dependencies.snarkvm-ledger-query]
-version = "0.16.10"
+version = "=0.16.12"
 features = [ "async", "wasm" ]
 
 [dependencies.snarkvm-ledger-store]
-version = "0.16.10"
+version = "=0.16.12"
 
 [dependencies.snarkvm-parameters]
-version = "0.16.10"
+version = "=0.16.12"
 features = [ "wasm" ]
 
 [dependencies.snarkvm-synthesizer]
-version = "0.16.10"
+version = "=0.16.12"
 features = [ "async", "wasm" ]
 
 [dependencies.snarkvm-wasm]
-version = "0.16.10"
+version = "0.16.12"
 features = [ "console", "fields", "utilities" ]
 
 [dependencies.anyhow]

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aleohq/wasm",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Wasm build for the SDK",
   "collaborators": [
     "The Aleo Team <hello@aleo.org>"

--- a/website/src/workers/worker.js
+++ b/website/src/workers/worker.js
@@ -133,7 +133,8 @@ self.addEventListener("message", (ev) => {
                     undefined,
                     undefined,
                     privateKeyObject,
-                    undefined
+                    undefined,
+                    undefined,
                 );
 
                 // Return the transaction id to the main thread
@@ -329,7 +330,6 @@ self.addEventListener("message", (ev) => {
                     undefined,
                     feeRecord,
                     aleo.PrivateKey.from_string(privateKey),
-                    undefined
                 )
 
                 // Return the transaction id to the main thread


### PR DESCRIPTION
## Motivation

Currently the AleoKeyProvider only supports byte downloads for verifying key. Verifying keys are now small and can be represented as short strings. This PR allows trying strings when fetching keys and then fetching bytes as a fallback.
