### PR TITLE
change App.jsx text to App.tsx

### DIFF
--- a/create-aleo-app/template-react-ts/src/App.tsx
+++ b/create-aleo-app/template-react-ts/src/App.tsx
@@ -73,7 +73,7 @@ function App() {
           </button>
         </p>
         <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
+          Edit <code>src/App.tsx</code> and save to test HMR
         </p>
       </div>
 


### PR DESCRIPTION
## Motivation

Currently when running 'npm create aleo-app@latest', the developer is given the option to choose a certain template. When choosing the typescript and react template the text shown on the template when running the app locally is incorrect.

## Test Plan

1. Locally run npm create aleo-app@latest
2. Choose 'React + Typescript' when prompted 
3. Change directories into project name
4. Run 'npm i'
5. Run 'npm run dev'
6. Observe updated text

## Related PRs

N/A