### PR TITLE
change executeOffline call to run

### DIFF
--- a/create-aleo-app/template-react-ts/src/workers/worker.ts
+++ b/create-aleo-app/template-react-ts/src/workers/worker.ts
@@ -19,7 +19,7 @@ async function localProgramExecution(program, aleoFunction, inputs) {
   const account = new Account();
   programManager.setAccount(account);
 
-  const executionResponse = await programManager.executeOffline(
+  const executionResponse = await programManager.run(
     program,
     aleoFunction,
     inputs,


### PR DESCRIPTION
## Motivation

When running react-typescript template the button "helloworld.aleo" is erroring out. Observe browser console below:

<img width="661" alt="Screenshot 2023-12-30 at 5 06 55 PM" src="https://github.com/AleoHQ/sdk/assets/76723523/5a6f06f5-6910-4abb-bb0d-830092256e30">

If you observe a different template (for example: react-leo https://github.com/AleoHQ/sdk/blob/testnet3/create-aleo-app/template-react-leo/src/workers/worker.js) it utilizes run() instead of executeOffline(). It seems that this function either hasn't been imported correctly or its implementation is still in progress. Either way since it's user facing I marked it as a patch.

## Test Plan (Reproduction)

1. Locally run npm create aleo-app@latest
2. Choose 'React + Typescript' when prompted
3. Change directories into project name
4. Run 'npm i'
5. Run 'npm run dev'
6. Click button with text "helloworld.aleo"
7. Notice expected alert with output doesn't occur/dev console has error.


## Related PRs

None
