### PR TITLE
[Feature] Add address getter to Program

### DIFF
--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -77,6 +77,12 @@ impl FromStr for Address {
     }
 }
 
+impl From<AddressNative> for Address {
+    fn from(value: AddressNative) -> Self {
+        Self(value)
+    }
+}
+
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)

--- a/wasm/src/programs/program.rs
+++ b/wasm/src/programs/program.rs
@@ -14,8 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the Aleo SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::types::native::{CurrentNetwork, EntryType, IdentifierNative, PlaintextType, ProgramNative, ValueType};
-use crate::account::Address;
+use crate::{
+    account::Address,
+    types::native::{CurrentNetwork, EntryType, IdentifierNative, PlaintextType, ProgramNative, ValueType},
+};
 
 use js_sys::{Array, Object, Reflect};
 use std::{ops::Deref, str::FromStr};

--- a/wasm/src/programs/program.rs
+++ b/wasm/src/programs/program.rs
@@ -15,6 +15,7 @@
 // along with the Aleo SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::types::native::{CurrentNetwork, EntryType, IdentifierNative, PlaintextType, ProgramNative, ValueType};
+use crate::account::Address;
 
 use js_sys::{Array, Object, Reflect};
 use std::{ops::Deref, str::FromStr};
@@ -416,6 +417,14 @@ impl Program {
     #[wasm_bindgen]
     pub fn id(&self) -> String {
         self.0.id().to_string()
+    }
+
+    /// Get a unique address of the program
+    ///
+    /// @returns {Address} The address of the program
+    #[wasm_bindgen]
+    pub fn address(&self) -> Result<Address, String> {
+        Ok(Address::from(self.0.id().to_address().map_err(|e| e.to_string())?))
     }
 
     /// Determine equality with another program


### PR DESCRIPTION
`address()` returns the `Address` object associated with the `Program`

## Motivation

Currently there's no simple way to get the unique address of a program exposed to JS
