### PR TITLE
Adding in new X-Aleo-SDK-Version header

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -48,6 +48,7 @@
     "sync-request": "^6.1.0"
   },
   "devDependencies": {
+    "@rollup/plugin-replace": "^5.0.5",
     "@types/jest": "^29.5.5",
     "@types/mime": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^5.41.0",

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -1,4 +1,6 @@
 import typescript from "rollup-plugin-typescript2";
+import replace from "@rollup/plugin-replace";
+import $package from "./package.json" assert { type: "json" };
 
 export default {
     input: {
@@ -23,6 +25,13 @@ export default {
         "@aleohq/wasm",
     ],
     plugins: [
+        replace({
+            preventAssignment: true,
+            delimiters: ['', ''],
+            values: {
+                '%%VERSION%%': $package.version,
+            },
+        }),
         typescript({
             tsconfig: "tsconfig.json",
             clean: true,

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -42,7 +42,8 @@ class AleoNetworkClient {
 
     } else {
       this.headers = {
-        "X-Aleo-SDK-Version": "0.6.9",
+        // This is replaced by the actual version by a Rollup plugin
+        "X-Aleo-SDK-Version": "%%VERSION%%",
       };
     }
   }

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -13,6 +13,10 @@ import {
 
 type ProgramImports = { [key: string]: string | Program };
 
+interface AleoNetworkClientOptions {
+  headers?: { [key: string]: string };
+}
+
 /**
  * Client library that encapsulates REST calls to publicly exposed endpoints of Aleo nodes. The methods provided in this
  * allow users to query public information from the Aleo blockchain and submit transactions to the network.
@@ -27,10 +31,20 @@ type ProgramImports = { [key: string]: string | Program };
  */
 class AleoNetworkClient {
   host: string;
+  headers: { [key: string]: string };
   account: Account | undefined;
 
-  constructor(host: string) {
+  constructor(host: string, options?: AleoNetworkClientOptions) {
     this.host = host + "/testnet3";
+
+    if (options && options.headers) {
+      this.headers = options.headers;
+
+    } else {
+      this.headers = {
+        "X-Aleo-SDK-Version": "0.6.9",
+      };
+    }
   }
 
   /**
@@ -69,8 +83,12 @@ class AleoNetworkClient {
       url = "/",
   ): Promise<Type> {
     try {
-      const response = await get(this.host + url);
+      const response = await get(this.host + url, {
+        headers: this.headers
+      });
+
       return await response.json();
+
     } catch (error) {
       throw new Error("Error fetching data.");
     }
@@ -627,9 +645,9 @@ class AleoNetworkClient {
     try {
       const response = await post(this.host + "/transaction/broadcast", {
         body: transaction_string,
-        headers: {
+        headers: Object.assign({}, this.headers, {
           "Content-Type": "application/json",
-        },
+        }),
       });
 
       try {
@@ -644,4 +662,4 @@ class AleoNetworkClient {
   }
 }
 
-export { AleoNetworkClient, ProgramImports }
+export { AleoNetworkClient, AleoNetworkClientOptions, ProgramImports }

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -1,5 +1,5 @@
-export async function get(url: URL | string) {
-    const response = await fetch(url);
+export async function get(url: URL | string, options?: RequestInit) {
+    const response = await fetch(url, options);
 
     if (!response.ok) {
         throw new Error(response.status + " could not get URL " + url);

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -6,9 +6,16 @@ jest.retryTimes(3);
 
 describe('NodeConnection', () => {
     let connection: AleoNetworkClient;
+    let windowFetchSpy: jest.Spied<typeof fetch>;
 
     beforeEach(() => {
         connection = new AleoNetworkClient("https://api.explorer.aleo.org/v1");
+        windowFetchSpy = jest.spyOn(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        windowFetchSpy = null;
     });
 
     describe('setAccount', () => {
@@ -75,6 +82,25 @@ describe('NodeConnection', () => {
         it('should return a Block object', async () => {
             const latestBlock = await connection.getLatestBlock();
             expect(typeof (latestBlock as Block).block_hash).toBe('string');
+        }, 60000);
+
+        it('should set the X-Aleo-SDK-Version header', async () => {
+            expect(windowFetchSpy.mock.calls).toStrictEqual([]);
+
+            await connection.getLatestBlock();
+
+            expect(windowFetchSpy.mock.calls).toStrictEqual([
+                [
+                    "https://api.explorer.aleo.org/v1/testnet3/latest/block",
+                    {
+                        "headers": {
+                            // @TODO: Run the Jest tests on the compiled Rollup code,
+                            //        so that way the version is properly replaced.
+                            "X-Aleo-SDK-Version": "%%VERSION%%"
+                        }
+                    }
+                ],
+            ]);
         }, 60000);
     });
 

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -15,7 +15,7 @@ describe('NodeConnection', () => {
 
     afterEach(() => {
         jest.restoreAllMocks();
-        windowFetchSpy = null;
+        windowFetchSpy = null as any;
     });
 
     describe('setAccount', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,6 +2088,14 @@
     "@rollup/pluginutils" "^5.0.1"
     magic-string "^0.30.3"
 
+"@rollup/plugin-replace@^5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz#33d5653dce6d03cb24ef98bef7f6d25b57faefdf"
+  integrity sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.30.3"
+
 "@rollup/pluginutils@^4.1.2":
   version "4.2.1"
   resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz"
@@ -8816,7 +8824,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8883,7 +8900,14 @@ string_decoder@^1.1.1, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9782,7 +9806,16 @@ wordwrap@0.0.2:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
   integrity sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
When the SDK makes a request to the server, this automatically adds in an `X-Aleo-SDK-Version` header, so the server can identify whether the request came from the SDK or not.

Fixes https://github.com/AleoHQ/explorer-monorepo/issues/14