### PR TITLE
fix: removed panic from Signature::from_str

### DIFF
--- a/wasm/src/account/signature.rs
+++ b/wasm/src/account/signature.rs
@@ -66,7 +66,7 @@ impl FromStr for Signature {
     type Err = anyhow::Error;
 
     fn from_str(signature: &str) -> Result<Self, Self::Err> {
-        Ok(Self(SignatureNative::from_str(signature).unwrap()))
+        Ok(Self(SignatureNative::from_str(signature)?))
     }
 }
 


### PR DESCRIPTION
## Motivation

The change from `.unwrap()` to `?` in the `from_str` function improves the error handling mechanism of our code. By using `?`, we ensure that any errors that occur during the string parsing are properly propagated up the call stack, allowing for more graceful error handling and better debugging. This avoids potential panics at runtime due to `unwrap()` and adheres to best practices in Rust for error handling.

## Test Plan

To ensure the changes work correctly, the following simple test plan was implemented:

1. Manually tested the `from_str` method by providing both valid and invalid strings to verify that it returns the correct `Result` type.
2. Checked that valid strings are parsed successfully and return `Ok(Self)` as expected.
3. Verified that invalid strings now result in an error being returned instead of causing a panic, confirming that the `?` operator is correctly propagating errors.
4. Ensured that the overall application compiles without any errors after the modification.


## Related PRs

This change does not depend on any other PRs and does not have any related PRs as of now.