### PR TITLE
[Upgrade] Update snarkVM rev for Testnet reset

### DIFF
--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -29,7 +29,7 @@ describe('NodeConnection', () => {
     describe('getBlock', () => {
         it('should return a Block object', async () => {
             const block = await connection.getBlock(1);
-            expect((block as Block).block_hash).toEqual("ab17jdwevmgu20kcqazp2wjyy2u2k75rac2mtvuf6w6kjn8egv0uvrqe7mra6");
+            expect((block as Block).block_hash).toEqual("ab1eddc3np4h6duwf5a7ht6u0x5maa08780l885j6xq0s7l88df0qrq3d72me");
         }, 60000);
 
         it('should throw an error if the request fails', async () => {
@@ -42,8 +42,8 @@ describe('NodeConnection', () => {
             const blockRange = await connection.getBlockRange(1, 3);
             expect(Array.isArray(blockRange)).toBe(true);
             expect((blockRange as Block[]).length).toBe(3);
-            expect(((blockRange as Block[])[0] as Block).block_hash).toBe("ab17jdwevmgu20kcqazp2wjyy2u2k75rac2mtvuf6w6kjn8egv0uvrqe7mra6");
-            expect(((blockRange as Block[])[1] as Block).block_hash).toBe("ab1q60nvh5ha8ld43x0jph9futqwkdm4j3cvw5a2unj5d23ml090c9qkcvr3g");
+            expect(((blockRange as Block[])[0] as Block).block_hash).toBe("ab1eddc3np4h6duwf5a7ht6u0x5maa08780l885j6xq0s7l88df0qrq3d72me");
+            expect(((blockRange as Block[])[1] as Block).block_hash).toBe("ab1uqmm97qk5gzhgwh6308h48aszazhfnn0xdq84lrj7e7myyrf9yyqmqdf42");
 
         }, 60000);
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -1595,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -1605,7 +1605,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "indexmap",
  "itertools",
@@ -1633,12 +1633,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1692,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1723,7 +1723,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1746,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1758,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -1782,7 +1782,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -1795,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -1869,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -1903,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1913,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "rand",
  "rayon",
@@ -1971,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1988,7 +1988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "anyhow",
  "rand",
@@ -2000,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2032,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2057,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2082,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "indexmap",
  "paste",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "bincode",
  "once_cell",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-wasm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=3d8b912ed396cc13e63ef2673ec238b8cff4ea43#3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce0720544c2bc51e27e1674a62fff585adc#be171ce0720544c2bc51e27e1674a62fff585adc"
 dependencies = [
  "getrandom",
  "snarkvm-circuit-network",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -24,47 +24,47 @@ doctest = false
 [dependencies.snarkvm-circuit-network]
 version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+rev = "be171ce0720544c2bc51e27e1674a62fff585adc"
 
 [dependencies.snarkvm-console]
 version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+rev = "be171ce0720544c2bc51e27e1674a62fff585adc"
 features = [ "wasm" ]
 
 [dependencies.snarkvm-ledger-block]
 version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+rev = "be171ce0720544c2bc51e27e1674a62fff585adc"
 features = [ "wasm" ]
 
 [dependencies.snarkvm-ledger-query]
 version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+rev = "be171ce0720544c2bc51e27e1674a62fff585adc"
 features = [ "async", "wasm" ]
 
 [dependencies.snarkvm-ledger-store]
 version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+rev = "be171ce0720544c2bc51e27e1674a62fff585adc"
 
 [dependencies.snarkvm-parameters]
 version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+rev = "be171ce0720544c2bc51e27e1674a62fff585adc"
 features = [ "wasm" ]
 
 [dependencies.snarkvm-synthesizer]
 version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+rev = "be171ce0720544c2bc51e27e1674a62fff585adc"
 features = [ "async", "wasm" ]
 
 [dependencies.snarkvm-wasm]
 version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "3d8b912ed396cc13e63ef2673ec238b8cff4ea43"
+rev = "be171ce0720544c2bc51e27e1674a62fff585adc"
 features = [ "console", "fields", "utilities" ]
 
 [dependencies.anyhow]


### PR DESCRIPTION
## Motivation

Updating revs for `wasm` to maintain consistency with Testnet reset

## Test Plan

## Related PRs
