### PR TITLE
SDK - Update Develop Tab to include Create Account

### DIFF
--- a/website/src/tabs/develop/execute/index.jsx
+++ b/website/src/tabs/develop/execute/index.jsx
@@ -17,6 +17,7 @@ import { LoadProgram } from "./LoadProgram.jsx";
 import { CodeEditor } from "./CodeEditor.jsx";
 import { useAleoWASM } from "../../../aleo-wasm-hook";
 import { useEffect, useState } from "react";
+import { NewAccount } from "../../account/NewAccount.jsx";
 
 const layout = { labelCol: { span: 4 }, wrapperCol: { span: 18 } };
 
@@ -237,6 +238,12 @@ export const Execute = () => {
     };
 
     return (
+        <>
+       
+        <NewAccount />
+
+        <br/>
+
         <Card
             title="Execute Program"
             extra={
@@ -473,6 +480,7 @@ export const Execute = () => {
                 )}
             </Form.Provider>
         </Card>
+        </>
     );
 };
 


### PR DESCRIPTION

## Motivation

Adds "Create Account: to the Develop tab so that user can create a new account before trying to deploy a program in the Develop tab 

References to Monday here: https://provable.monday.com/boards/6731777034/views/146375343/pulses/7220947284

## Test Plan

Screenshot: 
![screencapture-localhost-5173-develop-2024-08-19-14_23_59](https://github.com/user-attachments/assets/52ab20a2-d24f-4625-9dd3-3c264ee51e44)



