### PR TITLE
SDK - Update UX of Record Tab

### DIFF
--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -104,7 +104,7 @@ function Main() {
                         />
                     </Sider>
                     <Layout>
-                        <Content style={{ padding: "50px 50px" }}>
+                        <Content style={{ padding: "50px 50px", margin: "0 auto", minWidth: "850px" }}>
                             <Outlet />
                         </Content>
                         <Footer style={{ textAlign: "center", display:"flex", flexDirection: "column" }}>

--- a/website/src/pages/Homepage.css
+++ b/website/src/pages/Homepage.css
@@ -4,6 +4,14 @@
     font-size: 14px;
 }
 
+.buttonRow { 
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
+
 .button {
     background-color: #12e172;
     padding: 16px 32px 16px 32px;
@@ -91,6 +99,12 @@ a:nth-child(3) {
     .homepage {
         padding: 20px;
         font-size: 18px;
+    }
+
+    .buttonRow { 
+        display: flex;
+        flex-direction: row;
+        gap: 20px;
     }
 
     .actionRow {

--- a/website/src/pages/Homepage.jsx
+++ b/website/src/pages/Homepage.jsx
@@ -18,6 +18,17 @@ const Homepage = () => {
                     The tooling for building zero-knowledge applications at your
                     fingertips
                 </p>{" "}
+                <div className="buttonRow"> 
+                <Link
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    to="/account"
+                >
+                    <button className="button">
+                        {" "}
+                        Try now <span className="arrow">&rarr;</span>{" "}
+                    </button>
+                </Link>{" "}
                 <Link
                     target="_blank"
                     rel="noopener noreferrer"
@@ -25,9 +36,10 @@ const Homepage = () => {
                 >
                     <button className="button">
                         {" "}
-                        View Docs <span className="arrow">&rarr;</span>{" "}
+                        See Docs <span className="arrow">&rarr;</span>{" "}
                     </button>
                 </Link>{" "}
+                </div> 
                 <ul className="actionRow">
                     <Link to="/account" className="actionItem">
                         {" "}
@@ -58,7 +70,7 @@ const Homepage = () => {
                     to="https://docs.leo-lang.org/sdk/create-leo-app/tutorial/"
                 >
                     <button className="button">
-                        Try it now <span className="arrow">&rarr;</span>
+                        Try now <span className="arrow">&rarr;</span>
                     </button>
                 </Link>{" "}
                 <div className="footer">

--- a/website/src/tabs/record/DecryptRecord.css
+++ b/website/src/tabs/record/DecryptRecord.css
@@ -1,0 +1,3 @@
+.container {
+    max-width: 750px;
+}

--- a/website/src/tabs/record/DecryptRecord.jsx
+++ b/website/src/tabs/record/DecryptRecord.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button, Card, Col, Divider, Form, Input, Row, Skeleton } from "antd";
 import { CopyButton } from "../../components/CopyButton";
 import { useAleoWASM } from "../../aleo-wasm-hook";
+import "./DecryptRecord.css";
 
 export const DecryptRecord = () => {
     const [ciphertext, setCiphertext] = useState(null);
@@ -81,81 +82,116 @@ export const DecryptRecord = () => {
             ciphertext !== null ? ciphertext.toString() : "";
 
         return (
-            <Card
-                title="Decrypt Record"
-                style={{ width: "100%" }}
-                extra={
-                    <Button
-                        type="primary"
-                        
-                        size="middle"
-                        onClick={populateForm}
-                    >
-                        Demo
-                    </Button>
-                }
-            >
-                <Form {...layout}>
-                    <Form.Item label="Record (Ciphertext)" colon={false}>
-                        <Input
-                            name="recordCiphertext"
-                            size="large"
-                            placeholder="Record (Ciphertext)"
-                            allowClear
-                            onChange={onCiphertextChange}
-                            value={recordCipherTextString()}
-                        />
-                    </Form.Item>
-                    <Form.Item label="View Key" colon={false}>
-                        <Input
-                            name="viewKey"
-                            size="large"
-                            placeholder="View Key"
-                            allowClear
-                            onChange={onViewKeyChange}
-                            value={viewKeyString()}
-                        />
-                    </Form.Item>
-                </Form>
-                {ciphertext || viewKey ? (
-                    <Row justify="center">
-                        <Col>
+            <div className="container">
+                <h1>Records</h1>
+                <h2>Overview</h2>
+                <ul>
+                    <li>
+                        {" "}
+                        Records are created by Aleo programs and can be used as
+                        inputs for functions within the same program. Once a
+                        record is used, it’s consumed and can’t be reused.
+                    </li>
+                    <li>
+                        Functions that consume records generate new records as
+                        output.
+                    </li>
+                    <li>
+                        Records are <strong>private</strong> by default, tied to
+                        a single Aleo program and a user's private key.
+                    </li>
+                    <li>
+                        The <strong> View Key </strong> is derived from the
+                        private key and allows users to decrypt their encrypted
+                        data and prove ownership of that data.
+                    </li>
+                </ul>
+
+                <br />
+                <p>
+                    Try the demo below! Enter a record and
+                    decrypt it using your View Key to experience how the process
+                    works. You can also click the "Show Demo" button on the
+                    right to generate an example.
+                </p>
+
+                <br />
+
+                <Card
+                    title="Decrypt Record"
+                    style={{ width: "100%" }}
+                    extra={
+                        <>
                             <Button
-                                
+                                type="primary"
                                 size="middle"
-                                onClick={clearForm}
+                                onClick={populateForm}
                             >
-                                Clear
+                                Show Demo
                             </Button>
-                        </Col>
-                    </Row>
-                ) : null}
-                {
+                        </>
+                    }
+                >
                     <Form {...layout}>
-                        <Divider />
-                        <Form.Item label="Record (Plaintext)" colon={false}>
-                            {plaintext ? (
-                                <Row align="middle">
-                                    <Col span={23}>
-                                        <Input.TextArea
-                                            size="large"
-                                            rows={10}
-                                            placeholder="Record (Plaintext)"
-                                            value={recordPlaintext()}
-                                            disabled
-                                        />
-                                    </Col>
-                                    <Col span={1} align="middle">
-                                        <CopyButton data={recordPlaintext()} />
-                                    </Col>
-                                </Row>
-                            ) : (
-                                <Skeleton active />
-                            )}
+                        <Form.Item label="Record (Ciphertext)" colon={false}>
+                            <Input
+                                name="recordCiphertext"
+                                size="large"
+                                placeholder="Record (Ciphertext)"
+                                allowClear
+                                onChange={onCiphertextChange}
+                                value={recordCipherTextString()}
+                            />
+                        </Form.Item>
+                        <Form.Item label="View Key" colon={false}>
+                            <Input
+                                name="viewKey"
+                                size="large"
+                                placeholder="View Key"
+                                allowClear
+                                onChange={onViewKeyChange}
+                                value={viewKeyString()}
+                            />
                         </Form.Item>
                     </Form>
-                }
-            </Card>
+                    {ciphertext || viewKey ? (
+                        <Row justify="center">
+                            <Col>
+                                <Button size="middle" onClick={clearForm}>
+                                    Clear
+                                </Button>
+                            </Col>
+                        </Row>
+                    ) : null}
+                    {
+                        <Form {...layout}>
+                            <Divider />
+                            <Form.Item label="Record (Plaintext)" colon={false}>
+                                {plaintext ? (
+                                    <Row align="middle">
+                                        <Col span={23}>
+                                            <Input.TextArea
+                                                size="large"
+                                                rows={10}
+                                                placeholder="Record (Plaintext)"
+                                                value={recordPlaintext()}
+                                                disabled
+                                            />
+                                        </Col>
+                                        <Col span={1} align="middle">
+                                            <CopyButton
+                                                data={recordPlaintext()}
+                                            />
+                                        </Col>
+                                    </Row>
+                                ) : (
+                                    <Skeleton active />
+                                )}
+                            </Form.Item>
+                        </Form>
+                    }
+                </Card>
+            </div>
         );
     } else {
         return (


### PR DESCRIPTION

## Motivation

- Add more context about records to the record tab 
- Make items in the main pages more centered for better reading / rather than stretching across the entire screen 

## Test Plan

1. Home page adds a "Try it now" button to lead into the SDK, rather than just one button that leads to docs as the main action in the hero
Screenshot: 
<img width="1338" alt="image" src="https://github.com/user-attachments/assets/5f8e4ae0-a221-4967-9584-0bd37a8d5ed3">

2. Record tab updates: 
![screencapture-localhost-5173-record-2024-08-19-14_47_16](https://github.com/user-attachments/assets/4395509c-f32e-4497-80f4-e3bc71d8ee2f)

