### PR TITLE
Add playwright tests

### DIFF
--- a/create-leo-app/template-react-leo/.gitignore
+++ b/create-leo-app/template-react-leo/.gitignore
@@ -1,0 +1,2 @@
+playwright-report/**
+screenshots/**

--- a/create-leo-app/template-react-leo/package.json
+++ b/create-leo-app/template-react-leo/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@provablehq/sdk": "^0.6.0",
+    "@provablehq/wasm": "^0.6.13",
     "comlink": "^4.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -21,6 +22,7 @@
     "@babel/core": "^7.17.2",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
+    "@playwright/test": "^1.46.1",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.0.4",

--- a/create-leo-app/template-react-leo/playwright.config.ts
+++ b/create-leo-app/template-react-leo/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@playwright/test'
 export default defineConfig({
     testDir: './tests',
     reporter: 'html',
-    timeout: 5000,
+    timeout: 15000,
     
     use: {
         baseURL: 'http://localhost:5173'

--- a/create-leo-app/template-react-leo/playwright.config.ts
+++ b/create-leo-app/template-react-leo/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+    testDir: './tests',
+    reporter: 'html',
+    timeout: 5000,
+    
+    use: {
+        baseURL: 'http://localhost:5173'
+    },
+    webServer: {
+        command: 'npm run dev',
+        url: 'http://localhost:5173',
+        reuseExistingServer: !process.env.CI,     
+    }
+});

--- a/create-leo-app/template-react-leo/src/App.jsx
+++ b/create-leo-app/template-react-leo/src/App.jsx
@@ -10,6 +10,7 @@ function App() {
   const [count, setCount] = useState(0);
   const [account, setAccount] = useState(null);
   const [executing, setExecuting] = useState(false);
+  const [result, setResult] = useState(null);
   const [deploying, setDeploying] = useState(false);
 
   const generateAccount = async () => {
@@ -19,14 +20,15 @@ function App() {
 
   async function execute() {
     setExecuting(true);
-    const result = await aleoWorker.localProgramExecution(
+    setResult(null)
+    const localresult = await aleoWorker.localProgramExecution(
       helloworld_program,
       "main",
       ["5u32", "5u32"],
     );
     setExecuting(false);
 
-    alert(JSON.stringify(result));
+    setResult((JSON.stringify(localresult)));
   }
 
   async function deploy() {
@@ -72,6 +74,11 @@ function App() {
               : `Execute helloworld.aleo`}
           </button>
         </p>
+        {result !== null &&
+          <p data-testid="result">
+              value is {result}
+          </p>
+        }
         <p>
           Edit <code>src/App.jsx</code> and save to test HMR
         </p>

--- a/create-leo-app/template-react-leo/tests/template-react-leo.test.ts
+++ b/create-leo-app/template-react-leo/tests/template-react-leo.test.ts
@@ -16,7 +16,7 @@ test('generate account', async ({ page }) => {
   await page.goto('/');
 
   // looks like we need to wait a little for react to setup
-  await page.waitForTimeout(1000);
+  await page.waitForSelector('.read-the-docs', { state: 'visible' });
 
   const accountButton = page.getByRole('button', { name: 'Click to generate account' });
   await accountButton.click(); 
@@ -32,7 +32,7 @@ test('local program execution', async ({ page }) => {
   await page.goto('/');
 
   // looks like we need to wait a little for react to setup
-  await page.waitForTimeout(1000);
+  await page.waitForSelector('.read-the-docs', { state: 'visible' });
 
   const executeButton = page.getByRole('button', { name: 'Execute helloworld.aleo' });
   await executeButton.click();

--- a/create-leo-app/template-react-leo/tests/template-react-leo.test.ts
+++ b/create-leo-app/template-react-leo/tests/template-react-leo.test.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+test('count', async ({ page }) => {
+  await page.goto('/');
+
+  const button = page.getByRole('button', { name: 'count is' });
+  await button.click();
+  
+  expect(await button.textContent()).toBe('count is 1')
+
+  await button.click();
+  expect(await button.textContent()).toBe('count is 2')
+});
+
+test('generate account', async ({ page }) => {
+  await page.goto('/');
+
+  // looks like we need to wait a little for react to setup
+  await page.waitForTimeout(1000);
+
+  const accountButton = page.getByRole('button', { name: 'Click to generate account' });
+  await accountButton.click(); 
+
+  const accountButtonNew = page.getByRole('button', { name: 'Account private key is' });
+  expect(await accountButtonNew.textContent()).toContain('Account private key is');
+  expect(await accountButtonNew.textContent()).toHaveLength(84);
+});
+
+test('local program execution', async ({ page }) => {
+  test.setTimeout(90000);
+
+  await page.goto('/');
+
+  // looks like we need to wait a little for react to setup
+  await page.waitForTimeout(1000);
+
+  const executeButton = page.getByRole('button', { name: 'Execute helloworld.aleo' });
+  await executeButton.click();
+
+  const result = page.getByTestId('result');
+  
+  // wait for program to execute locally
+  for (let i = 1; i <= 60; i++) {
+    await page.waitForTimeout(1000);
+  }
+
+  expect(await result.textContent()).toContain('["10u32"]')
+});
+

--- a/create-leo-app/template-react-leo/tests/template-react-leo.test.ts
+++ b/create-leo-app/template-react-leo/tests/template-react-leo.test.ts
@@ -16,7 +16,8 @@ test('generate account', async ({ page }) => {
   await page.goto('/');
 
   // looks like we need to wait a little for react to setup
-  await page.waitForSelector('.read-the-docs', { state: 'visible' });
+  await page.waitForTimeout(1000);
+  //await page.waitForSelector('.read-the-docs', { state: 'visible' });
 
   const accountButton = page.getByRole('button', { name: 'Click to generate account' });
   await accountButton.click(); 


### PR DESCRIPTION
## Motivation

Add playwright tests to the react template so we can eventually add these in the build and keep the template stable.

## Test Plan

Ran tests locally for now, they passed locally and they can be added to ci at any time
