### PR TITLE
Changing JSON parsing to use bigint for all integers

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -55,6 +55,7 @@
     "@typescript-eslint/parser": "^5.41.0",
     "better-docs": "^2.7.2",
     "clean-jsdoc-theme": "^4.1.8",
+    "core-js": "^3.38.1",
     "cpr": "^3.0.1",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,3 +1,4 @@
+import "./polyfill/shared";
 import {VerifyingKey, Metadata} from "@provablehq/wasm";
 
 const KEY_STORE = Metadata.baseUrl();

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -390,9 +390,9 @@ class AleoNetworkClient {
    * @example
    * const latestHeight = networkClient.getLatestHeight();
    */
-  async getLatestHeight(): Promise<number> {
+  async getLatestHeight(): Promise<bigint> {
     try {
-      return await this.fetchData<number>("/latest/height");
+      return await this.fetchData<bigint>("/latest/height");
     } catch (error) {
       throw new Error("Error fetching latest height.");
     }

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -390,9 +390,9 @@ class AleoNetworkClient {
    * @example
    * const latestHeight = networkClient.getLatestHeight();
    */
-  async getLatestHeight(): Promise<bigint> {
+  async getLatestHeight(): Promise<number> {
     try {
-      return await this.fetchData<bigint>("/latest/height");
+      return Number(await this.fetchData<bigint>("/latest/height"));
     } catch (error) {
       throw new Error("Error fetching latest height.");
     }

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1,4 +1,4 @@
-import { get, post } from "./utils";
+import { get, post, parseJSON } from "./utils";
 import {
   Account,
   Block,
@@ -84,11 +84,13 @@ class AleoNetworkClient {
       url = "/",
   ): Promise<Type> {
     try {
-    const response = await get(this.host + url, {
-      headers: this.headers
-    });
+      const response = await get(this.host + url, {
+        headers: this.headers
+      });
 
-    return await response.json();
+      const text = await response.text();
+      return parseJSON(text);
+
     } catch (error) {
       throw new Error("Error fetching data.");
     }
@@ -648,7 +650,8 @@ class AleoNetworkClient {
       });
 
       try {
-        return await response.json();
+        const text = await response.text();
+        return parseJSON(text);
 
       } catch (error: any) {
         throw new Error(`Error posting transaction. Aleo network response: ${error.message}`);

--- a/sdk/src/node-polyfill.ts
+++ b/sdk/src/node-polyfill.ts
@@ -1,3 +1,4 @@
+import "./polyfill/shared";
 import "./polyfill/crypto";
 import "./polyfill/fetch";
 import "./polyfill/xmlhttprequest";

--- a/sdk/src/polyfill/shared.ts
+++ b/sdk/src/polyfill/shared.ts
@@ -1,2 +1,2 @@
 // These polyfills are shared by everything, both the browser and Node
-import "core-js/proposals/json-parse-with-source";
+import "core-js/proposals/json-parse-with-source.js";

--- a/sdk/src/polyfill/shared.ts
+++ b/sdk/src/polyfill/shared.ts
@@ -1,0 +1,2 @@
+// These polyfills are shared by everything, both the browser and Node
+import "core-js/proposals/json-parse-with-source";

--- a/sdk/src/record-provider.ts
+++ b/sdk/src/record-provider.ts
@@ -203,7 +203,7 @@ class NetworkRecordProvider implements RecordProvider {
         // If the end height is not specified, use the current block height
         if (endHeight == 0) {
             const end = await this.networkClient.getLatestHeight();
-            endHeight = Number(end);
+            endHeight = end;
         }
 
         // If the start height is greater than the end height, throw an error

--- a/sdk/src/record-provider.ts
+++ b/sdk/src/record-provider.ts
@@ -202,12 +202,8 @@ class NetworkRecordProvider implements RecordProvider {
 
         // If the end height is not specified, use the current block height
         if (endHeight == 0) {
-            try {
-                const end = await this.networkClient.getLatestHeight();
-                endHeight = end;
-            } catch (e) {
-                logAndThrow("Unable to get current block height from the network")
-            }
+            const end = await this.networkClient.getLatestHeight();
+            endHeight = Number(end);
         }
 
         // If the start height is greater than the end height, throw an error

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -1,3 +1,17 @@
+export function parseJSON(json: string): any {
+    function revive(key: string, value: any, context: any) {
+        if (Number.isInteger(value)) {
+            return BigInt(context.source);
+
+        } else {
+            return value;
+        }
+    }
+
+    return JSON.parse(json, revive as any);
+}
+
+
 export async function get(url: URL | string, options?: RequestInit) {
     const response = await fetch(url, options);
 

--- a/sdk/src/worker.ts
+++ b/sdk/src/worker.ts
@@ -1,3 +1,4 @@
+import "./polyfill/shared";
 import {initThreadPool, ProgramManager, PrivateKey, verifyFunctionExecution, FunctionKeyPair} from "./index";
 import { AleoKeyProvider, AleoKeyProviderParams} from "./function-key-provider";
 import { expose } from "comlink";

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -100,7 +100,7 @@ describe('NodeConnection', () => {
     describe('getLatestHeight', () => {
         it('should return a number', async () => {
             const latestHeight = await connection.getLatestHeight();
-            expect(typeof latestHeight).toBe('bigint');
+            expect(typeof latestHeight).toBe('number');
         }, 60000);
     });
 

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -100,7 +100,7 @@ describe('NodeConnection', () => {
     describe('getLatestHeight', () => {
         it('should return a number', async () => {
             const latestHeight = await connection.getLatestHeight();
-            expect(typeof latestHeight).toBe('number');
+            expect(typeof latestHeight).toBe('bigint');
         }, 60000);
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,6 +4110,11 @@ core-js@^2.4.0:
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
+core-js@^3.38.1:
+  version "3.38.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.38.1.tgz#aa375b79a286a670388a1a363363d53677c0383e"
+  integrity sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"


### PR DESCRIPTION
Fixes #892.

This is an alternate solution to #901

This parses all integers as a BigInt. We might want to be more selective, such as only parsing certain keys as BigInt.