### PR TITLE
Fixing bug with change-version script

### DIFF
--- a/scripts/change-version.js
+++ b/scripts/change-version.js
@@ -19,8 +19,7 @@ async function updateDependency(path, newVersion) {
 
     const replaced = json
         .replace(/"@provablehq\/sdk": *"[^"]+"/g, `"@provablehq/sdk": "^${newVersion}"`)
-        .replace(/"@provablehq\/wasm": *"[^"]+"/g, `"@provablehq/wasm": "^${newVersion}"`)
-        .replace(/"create-leo-app": *"[^"]+"/g, `"create-leo-app": "^${newVersion}"`);
+        .replace(/"@provablehq\/wasm": *"[^"]+"/g, `"@provablehq/wasm": "^${newVersion}"`);
 
     await writeFile(path, replaced);
 }


### PR DESCRIPTION
There was a small bug with the `change-version` script which caused `build:create-leo-app` to fail. This PR fixes the bug.