### PR TITLE
Fixing build errors and change-version script

### DIFF
--- a/scripts/change-version.js
+++ b/scripts/change-version.js
@@ -37,6 +37,17 @@ async function updateVersions(newVersion) {
 }
 
 
+// Updates the version in `Cargo.toml`
+async function updateCargo(newVersion) {
+    const json = await readFile("wasm/Cargo.toml", { encoding: "utf8" });
+
+    const replaced = json
+        .replace(/(name *= *"aleo-wasm"\s+version *= *)"[^"]+"/, `$1"${newVersion}"`);
+
+    await writeFile("wasm/Cargo.toml", replaced);
+}
+
+
 // Updates all of the `package.json` files so they use the correct
 // version of `@provablehq/wasm` and `@provablehq/sdk`
 async function updateDependencies(newVersion) {
@@ -51,4 +62,5 @@ async function updateDependencies(newVersion) {
 const newVersion = process.argv[2];
 
 await updateVersions(newVersion);
+await updateCargo(newVersion);
 await updateDependencies(newVersion);

--- a/scripts/change-version.js
+++ b/scripts/change-version.js
@@ -39,9 +39,9 @@ async function updateVersions(newVersion) {
 
 // Updates the version in `Cargo.toml`
 async function updateCargo(newVersion) {
-    const json = await readFile("wasm/Cargo.toml", { encoding: "utf8" });
+    const toml = await readFile("wasm/Cargo.toml", { encoding: "utf8" });
 
-    const replaced = json
+    const replaced = toml
         .replace(/(name *= *"aleo-wasm"\s+version *= *)"[^"]+"/, `$1"${newVersion}"`);
 
     await writeFile("wasm/Cargo.toml", replaced);

--- a/scripts/change-version.js
+++ b/scripts/change-version.js
@@ -42,7 +42,7 @@ async function updateCargo(newVersion) {
     const toml = await readFile("wasm/Cargo.toml", { encoding: "utf8" });
 
     const replaced = toml
-        .replace(/(name *= *"aleo-wasm"\s+version *= *)"[^"]+"/, `$1"${newVersion}"`);
+        .replace(/(\[package\]\s+name *= *"aleo-wasm"\s+version *= *)"[^"]+"/, `$1"${newVersion}"`);
 
     await writeFile("wasm/Cargo.toml", replaced);
 }

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -1,6 +1,6 @@
 import typescript from "rollup-plugin-typescript2";
 import replace from "@rollup/plugin-replace";
-import $package from "./package.json" assert { type: "json" };
+import $package from "./package.json" with { type: "json" };
 
 const networks = [
     "testnet",

--- a/sdk/rollup.test.js
+++ b/sdk/rollup.test.js
@@ -1,7 +1,7 @@
 import typescript from "rollup-plugin-typescript2";
 import replace from "@rollup/plugin-replace";
 import { globSync } from "glob";
-import $package from "./package.json" assert { type: "json" };
+import $package from "./package.json" with { type: "json" };
 
 const networks = [
     "testnet",


### PR DESCRIPTION
This fixes a build error with Node 22, and also fixes the `change-version` script so that it correctly updates the `Cargo.toml` file.