### PR TITLE
create-leo-app: explicit template definition, version bump

### DIFF
--- a/create-leo-app/package.json
+++ b/create-leo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-leo-app",
-  "version": "0.7.0",
+  "version": "0.7.3",
   "type": "module",
   "license": "GPL-3.0",
   "collaborators": [
@@ -11,7 +11,15 @@
   },
   "files": [
     "index.js",
-    "template-*",
+    "template-extension",
+    "template-nextjs-ts",
+    "template-node-ts",
+    "template-node",
+    "template-offline-public-transaction-ts",
+    "template-react-leo",
+    "template-react-managed-worker",
+    "template-react-ts",
+    "template-vanilla",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
* Updated the template definitions to be explicit instead of pattern, due to yarn/npm working with these differently.
* Version bump
* New publish of create-leo-app here https://www.npmjs.com/package/create-leo-app/v/0.7.3?activeTab=code

