### PR TITLE
[Fix] Fix minor UI issues with scalar multiplication and multiplicative inverse of fields.

### DIFF
--- a/website/src/tabs/algebra/FieldArithmetic.jsx
+++ b/website/src/tabs/algebra/FieldArithmetic.jsx
@@ -47,8 +47,8 @@ export const FieldArithmetic = () => {
     };
 
     const calculateResult = (num1, num2, op) => {
-        if ((op === "inv" && num1 === "") || 
-            (op !== "inv" && (num1 === "" || num2 === ""))) {
+        if (((op === "inv" || op === "mulinv") && num1 === "") ||
+            ((op !== "inv" && op !== "mulinv") && (num1 === "" || num2 === ""))) {
             setResult("");
             return;
         }

--- a/website/src/tabs/algebra/GroupArithmetic.jsx
+++ b/website/src/tabs/algebra/GroupArithmetic.jsx
@@ -152,6 +152,12 @@ export const GroupArithmetic = () => {
         calculateResult(groupValueOne, newValue, operation);
     };
 
+    const onScalarRandom = () => {
+        const newValue = generateRandomScalar();
+        setScalarValue(newValue);
+        calculateResult(groupValueOne, groupValueTwo, operation, newValue);
+    }
+
     const layout = { 
         labelCol: { span: 6 }, 
         wrapperCol: { span: 18 },
@@ -264,7 +270,7 @@ export const GroupArithmetic = () => {
                             />
                             <Button 
                                 size="large"
-                                onClick={() => setScalarValue(generateRandomScalar())}
+                                onClick={onScalarRandom}
                                 style={{ width: '110px' }}
                             >
                                 Random


### PR DESCRIPTION
## Motivation

Two small UI errors on the provable.tools existed on the new algebra page.
* The multiplicative inverse calculation wasn't triggered without two field elements being in the react state. (The second field element wasn't used, the logic simply set the Result field to empty).
* The scalar multiplication calculation didn't update with the "Random" button.

## Changes
* Logic is updated to ensure when the multiplicative inverse operation is selected, only the first field element field needs to be populated to proceed the inverse calculation.
* The `random` button in the scalar input field triggers a result update.
