### PR TITLE
Fixing unit tests to use the proper imports

### DIFF
--- a/sdk/rollup.test.js
+++ b/sdk/rollup.test.js
@@ -39,6 +39,7 @@ export default networks.map((network) => {
 
             // Used by the SDK
             "comlink",
+            `@provablehq/sdk/${network}.js`,
             `@provablehq/wasm/${network}.js`,
             "core-js/proposals/json-parse-with-source.js",
 

--- a/sdk/tests/account.test.ts
+++ b/sdk/tests/account.test.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { Account, Address, PrivateKey, RecordCiphertext, ViewKey } from "@provablehq/sdk";
+import { Account, Address, PrivateKey, RecordCiphertext, ViewKey } from "@provablehq/sdk/%%NETWORK%%.js";
 import { seed, message, beaconPrivateKeyString, beaconViewKeyString, beaconAddressString, recordCiphertextString, foreignCiphertextString, recordPlaintextString } from "./data/account-data";
 
 describe('Account', () => {

--- a/sdk/tests/account.test.ts
+++ b/sdk/tests/account.test.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { Account, Address, PrivateKey, RecordCiphertext, ViewKey } from "../src/node";
+import { Account, Address, PrivateKey, RecordCiphertext, ViewKey } from "@provablehq/sdk";
 import { seed, message, beaconPrivateKeyString, beaconViewKeyString, beaconAddressString, recordCiphertextString, foreignCiphertextString, recordPlaintextString } from "./data/account-data";
 
 describe('Account', () => {

--- a/sdk/tests/arithmetic.test.ts
+++ b/sdk/tests/arithmetic.test.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { Field, Scalar, Group} from "@provablehq/sdk";
+import { Field, Scalar, Group} from "@provablehq/sdk/%%NETWORK%%.js";
 
 describe('Field and Group Arithmetic Tests', () => {
     afterEach(() => {

--- a/sdk/tests/arithmetic.test.ts
+++ b/sdk/tests/arithmetic.test.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { Field, Scalar, Group} from "../src/node";
+import { Field, Scalar, Group} from "@provablehq/sdk";
 
 describe('Field and Group Arithmetic Tests', () => {
     afterEach(() => {

--- a/sdk/tests/key-provider.test.ts
+++ b/sdk/tests/key-provider.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import {AleoKeyProvider, CachedKeyPair, CREDITS_PROGRAM_KEYS, FunctionKeyPair, OfflineKeyProvider, ProvingKey, VerifyingKey} from "@provablehq/sdk";
+import {AleoKeyProvider, CachedKeyPair, CREDITS_PROGRAM_KEYS, FunctionKeyPair, OfflineKeyProvider, ProvingKey, VerifyingKey} from "@provablehq/sdk/%%NETWORK%%.js";
 
 describe('KeyProvider', () => {
     let keyProvider: AleoKeyProvider;

--- a/sdk/tests/key-provider.test.ts
+++ b/sdk/tests/key-provider.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import {AleoKeyProvider, CachedKeyPair, CREDITS_PROGRAM_KEYS, FunctionKeyPair, OfflineKeyProvider, ProvingKey, VerifyingKey} from "../src/node";
+import {AleoKeyProvider, CachedKeyPair, CREDITS_PROGRAM_KEYS, FunctionKeyPair, OfflineKeyProvider, ProvingKey, VerifyingKey} from "@provablehq/sdk";
 
 describe('KeyProvider', () => {
     let keyProvider: AleoKeyProvider;

--- a/sdk/tests/network-client.integration.ts
+++ b/sdk/tests/network-client.integration.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import {beaconAddressString, beaconPrivateKeyString} from "./data/account-data";
-import {Account, AleoNetworkClient} from "@provablehq/sdk";
+import {Account, AleoNetworkClient} from "@provablehq/sdk/%%NETWORK%%.js";
 
 describe('NodeConnection', () => {
     let localApiClient: AleoNetworkClient;

--- a/sdk/tests/network-client.integration.ts
+++ b/sdk/tests/network-client.integration.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import {beaconAddressString, beaconPrivateKeyString} from "./data/account-data";
-import {Account, AleoNetworkClient} from "../src/browser";
+import {Account, AleoNetworkClient} from "@provablehq/sdk";
 
 describe('NodeConnection', () => {
     let localApiClient: AleoNetworkClient;

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -16,7 +16,7 @@ import {
     PlaintextObject,
     Transition,
     TransitionObject,
-} from "@provablehq/sdk";
+} from "@provablehq/sdk/%%NETWORK%%.js";
 import { beaconPrivateKeyString } from "./data/account-data";
 
 async function catchError(f: () => Promise<any>): Promise<Error | null> {

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -7,10 +7,17 @@ import {
     TransactionObject,
     InputObject,
     OutputObject,
-    ExecutionObject
-} from "../src/node";
+    ExecutionObject,
+    DeploymentObject,
+    ExecutionJSON,
+    InputJSON,
+    OutputJSON,
+    Plaintext,
+    PlaintextObject,
+    Transition,
+    TransitionObject,
+} from "@provablehq/sdk";
 import { beaconPrivateKeyString } from "./data/account-data";
-import { DeploymentObject, ExecutionJSON, InputJSON, OutputJSON, Plaintext, PlaintextObject, Transition, TransitionObject } from "../src/node";
 
 async function catchError(f: () => Promise<any>): Promise<Error | null> {
     try {

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -7,7 +7,7 @@ import {
     statePathRecordOwnerPrivateKey,
     stateRoot
 } from "./data/account-data";
-import { Account, ExecutionResponse, OfflineQuery, ProgramManager, RecordPlaintext } from "@provablehq/sdk";
+import { Account, ExecutionResponse, OfflineQuery, ProgramManager, RecordPlaintext } from "@provablehq/sdk/%%NETWORK%%.js";
 
 describe('Program Manager', () => {
     const programManager = new ProgramManager("https://api.explorer.provable.com/v1", undefined, undefined);

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -7,7 +7,7 @@ import {
     statePathRecordOwnerPrivateKey,
     stateRoot
 } from "./data/account-data";
-import { Account, ExecutionResponse, OfflineQuery, ProgramManager, RecordPlaintext } from "../src/node";
+import { Account, ExecutionResponse, OfflineQuery, ProgramManager, RecordPlaintext } from "@provablehq/sdk";
 
 describe('Program Manager', () => {
     const programManager = new ProgramManager("https://api.explorer.provable.com/v1", undefined, undefined);

--- a/sdk/tests/record-provider.integration.ts
+++ b/sdk/tests/record-provider.integration.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { beaconPrivateKeyString } from "./data/account-data";
-import { Account, AleoNetworkClient, NetworkRecordProvider, RecordPlaintext } from "../src/node";
+import { Account, AleoNetworkClient, NetworkRecordProvider, RecordPlaintext } from "@provablehq/sdk";
 
 describe('RecordProvider', () => {
     let account: Account;

--- a/sdk/tests/record-provider.integration.ts
+++ b/sdk/tests/record-provider.integration.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { beaconPrivateKeyString } from "./data/account-data";
-import { Account, AleoNetworkClient, NetworkRecordProvider, RecordPlaintext } from "@provablehq/sdk";
+import { Account, AleoNetworkClient, NetworkRecordProvider, RecordPlaintext } from "@provablehq/sdk/%%NETWORK%%.js";
 
 describe('RecordProvider', () => {
     let account: Account;

--- a/sdk/tests/record-provider.test.ts
+++ b/sdk/tests/record-provider.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import {Account, AleoNetworkClient, BlockHeightSearch, NetworkRecordProvider} from "@provablehq/sdk";
+import {Account, AleoNetworkClient, BlockHeightSearch, NetworkRecordProvider} from "@provablehq/sdk/%%NETWORK%%.js";
 import {beaconPrivateKeyString} from "./data/account-data";
 
 describe.skip('RecordProvider', () => {

--- a/sdk/tests/record-provider.test.ts
+++ b/sdk/tests/record-provider.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import {Account, AleoNetworkClient, BlockHeightSearch, NetworkRecordProvider} from "../src/node";
+import {Account, AleoNetworkClient, BlockHeightSearch, NetworkRecordProvider} from "@provablehq/sdk";
 import {beaconPrivateKeyString} from "./data/account-data";
 
 describe.skip('RecordProvider', () => {

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -191,7 +191,7 @@ describe('WASM Objects', () => {
         });
 
         it('properly assesses equality and inequality', () => {
-            const viewKey1 = new ViewKey();
+            const viewKey1 = new (ViewKey as any)();
             const viewKey2 = ViewKey.from_string(viewKeyString);
             const viewKey3 = ViewKey.from_string(viewKeyString);
 

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Address, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext } from "../src/node";
+import { Address, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext } from "@provablehq/sdk";
 import {
     seed,
     message,

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Address, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext } from "@provablehq/sdk";
+import { Address, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext } from "@provablehq/sdk/%%NETWORK%%.js";
 import {
     seed,
     message,

--- a/sdk/tsconfig.test.json
+++ b/sdk/tsconfig.test.json
@@ -2,5 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "."
-  }
+  },
+  "include": ["tests"],
+  "exclude": ["node_modules", "src"],
 }


### PR DESCRIPTION
Right now, the unit tests import individual files within the SDK.

This PR changes the unit tests so they import the SDK package instead.

This fixes the Node polyfill sometimes not being loaded.