### PR TITLE
[Documentation] Amend transfer examples to use buildTransferTransaction

### DIFF
--- a/docs/examples/01_transfer_public.md
+++ b/docs/examples/01_transfer_public.md
@@ -21,17 +21,17 @@ programManager.setAccount(account);
 // Create recipient account.
 const recipient = new Account();
 
-// Execute `transfer_public` function in `credits.aleo`
+// Build a public transfer transaction.
 // Publicly send 5 microcredits to the recipient
-const transaction2 = await programManager.buildExecutionTransaction({
-  programName: "credits.aleo",
-  functionName: "transfer_public",
-  fee: 0.020,
-  privateFee: false,
-  inputs: [recipient.address(), "5u32"],
-  keySearchParams: { "cacheKey": "credits:transfer_public" }
-});
+const transaction = await programManager
+  .buildTransferPublicTransaction(
+    5,
+    recipient
+      .address()
+      .to_string(),
+    0.1
+  );
 
 // Broadcast the transaction to the Aleo network.
-const result2 = await programManager.networkClient.submitTransaction(transaction2);
+const result = await programManager.networkClient.submitTransaction(transaction);
 ```

--- a/docs/examples/01_transfer_public.md
+++ b/docs/examples/01_transfer_public.md
@@ -21,7 +21,7 @@ programManager.setAccount(account);
 // Create recipient account.
 const recipient = new Account();
 
-// Build a public transfer transaction.
+// Build a transfer_public transaction.
 // Publicly send 5 microcredits to the recipient
 const transaction = await programManager
   .buildTransferPublicTransaction(

--- a/docs/examples/01_transfer_public.md
+++ b/docs/examples/01_transfer_public.md
@@ -25,11 +25,11 @@ const recipient = new Account();
 // Publicly send 5 microcredits to the recipient
 const transaction = await programManager
   .buildTransferPublicTransaction(
-    5,
-    recipient
+    5,              // The amount to be transferred in credits (not microcredits)
+    recipient       // The address of the recipient.
       .address()
       .to_string(),
-    0.1
+    0.1             // The fee amount.
   );
 
 // Broadcast the transaction to the Aleo network.

--- a/docs/examples/02_transfer_private.md
+++ b/docs/examples/02_transfer_private.md
@@ -19,14 +19,16 @@ const programManager = new ProgramManager("https://api.explorer.provable.com/v1"
 programManager.setAccount(account);
 
 // Create a record for the sender using the transfer_public_to_private function.
-const transaction = await programManager.buildExecutionTransaction({
-    programName: "credits.aleo",
-    functionName: "transfer_public_to_private",
-    fee: 0.020,
-    privateFee: false,
-    inputs: [account.address().to_string(), "5u64"],
-    keySearchParams: { "cacheKey": "credits:transfer_private" },
-});
+const transaction = await programManager
+    .buildTransferTransaction(
+        5,
+        account
+            .address()
+            .to_string(),
+        "publicToPrivate",
+        0.1,
+        false,
+    );
 // Broadcast the transaction to the Aleo network.
 let result = await programManager.networkClient.submitTransaction(transaction);
 
@@ -52,14 +54,16 @@ const recipient = new Account();
 
 // Execute `transfer_private` function in `credits.aleo`
 // Privately send 5 microcredits to the recipient from the sender's record
-const transaction2 = await programManager.buildExecutionTransaction({
-    programName: "credits.aleo",
-    functionName: "transfer_private",
-    fee: 0.020,
-    privateFee: false,
-    inputs: [record, recipient.address().to_string(), "5u64"],
-    keySearchParams: { "cacheKey": "credits:transfer_private" },
-})
+const transaction2 = await programManager
+    .buildTransferTransaction(
+        5,
+        recipient
+            .address()
+            .to_string(),
+        "private",
+        0.1,
+        false
+    );
 // Broadcast the transaction to the Aleo network.
 const result2 = await programManager.networkClient.submitTransaction(transaction2);
 //

--- a/docs/examples/02_transfer_private.md
+++ b/docs/examples/02_transfer_private.md
@@ -21,13 +21,13 @@ programManager.setAccount(account);
 // Create a record for the sender using the transfer_public_to_private function.
 const transaction = await programManager
     .buildTransferTransaction(
-        5,
-        account
+        5,                 // The amount to be transferred in credits (not microcredits)
+        account            // The address of the recipient (In this case, your own address).
             .address()
             .to_string(),
-        "publicToPrivate",
-        0.1,
-        false,
+        "publicToPrivate", // The transfer type.
+        0.1,               // The fee amount.
+        false,             // Indicates whether or not the fee will be private. 
     );
 // Broadcast the transaction to the Aleo network.
 let result = await programManager.networkClient.submitTransaction(transaction);
@@ -56,13 +56,13 @@ const recipient = new Account();
 // Privately send 5 microcredits to the recipient from the sender's record
 const transaction2 = await programManager
     .buildTransferTransaction(
-        5,
-        recipient
+        5,                 // The amount to be transferred in credits (not microcredits)
+        recipient          // The address of the recipient.
             .address()
             .to_string(),
-        "private",
-        0.1,
-        false
+        "private",         // The transfer type.
+        0.1,               // The fee amount.
+        false,             // Indicates whether or not the fee will be private.
     );
 // Broadcast the transaction to the Aleo network.
 const result2 = await programManager.networkClient.submitTransaction(transaction2);

--- a/docs/examples/02_transfer_private.md
+++ b/docs/examples/02_transfer_private.md
@@ -18,7 +18,8 @@ const programManager = new ProgramManager("https://api.explorer.provable.com/v1"
 // Set the account as the program caller.
 programManager.setAccount(account);
 
-// Create a record for the sender using the transfer_public_to_private function.
+// Build a transfer_public_to_private transaction.
+// Create a credits record for the sender.
 const transaction = await programManager
     .buildTransferTransaction(
         5,                 // The amount to be transferred in credits (not microcredits)
@@ -52,7 +53,7 @@ let record = transactionRecords[0];
 // This new account will stand in as the recipient in this transfer.
 const recipient = new Account();
 
-// Execute `transfer_private` function in `credits.aleo`
+// Build a transfer_private transaction.
 // Privately send 5 microcredits to the recipient from the sender's record
 const transaction2 = await programManager
     .buildTransferTransaction(


### PR DESCRIPTION
This PR amends the transfer examples to use buildTransferTransaction instead of buildExecutionTransaction