### PR TITLE
Fix Create Leo App's offline public transaction signing template

### DIFF
--- a/create-leo-app/template-offline-public-transaction-ts/README.md
+++ b/create-leo-app/template-offline-public-transaction-ts/README.md
@@ -21,10 +21,13 @@ the internet for it. This provides a way to build Aleo execution transactions wi
 This pathway is suitable for use-cases such as hardware wallets or air-gapped machines used
 for building secure transactions.
 
-### 1.4 Assumptions
+### 1.4 Transaction Types
 
-The key material in this example is assumed to be pre-downloaded onto the machine performing the 
-construction of the offline transaction.
+Several types of transactions can be built and executed using this template:
+
+`bond_public`
+`unbond_public`
+`claim_unbond_public`
 
 ## 2. Usage
 

--- a/create-leo-app/template-offline-public-transaction-ts/README.md
+++ b/create-leo-app/template-offline-public-transaction-ts/README.md
@@ -1,9 +1,9 @@
 # Offline Transaction Builder 
 
 ## 1. Overview
-### 1.1 Proving Keys for Zero Knowledge Function Execution
-To achieve zero knowledge execution, all Aleo functions require a `ProvingKey` and `VerifyingKey` in order to build a
-zero knowledge ZkSnark proof of execution. If a user does not possess these keys for a function, they are normally
+### 1.1 Proving Keys for Zero-Knowledge Function Execution
+To achieve zero-knowledge execution, all Aleo functions require a `ProvingKey` and `VerifyingKey` in order to build a
+zero-knowledge zk-SNARK proof of execution. If a user does not possess these keys for a function, they are normally
 downloaded from the internet when the function is called.
 
 ### 1.2 Key Providers
@@ -31,7 +31,7 @@ construction of the offline transaction.
 ### 2.1 Pre-Download the Keys
 First run this command online to download the key material to disk:
 
-`npm start`
+`npm run build`
 
 Once this command is run, all proving keys for the `transfer_public`, `bond_public`, `unbond_public`, and
 `claim_unbond_public` functions will be downloaded to the `./keys` folder. The machine can then be disconnected from
@@ -43,7 +43,7 @@ adding the key material yourself.
 
 Once the key material is downloaded, turn off your internet connection and run the following command:
 
-`npm start`
+`npm run dev`
 
 You should see the transactions being built and the resulting transaction IDs printed to the console.
 

--- a/create-leo-app/template-offline-public-transaction-ts/README.md
+++ b/create-leo-app/template-offline-public-transaction-ts/README.md
@@ -28,24 +28,17 @@ construction of the offline transaction.
 
 ## 2. Usage
 
-### 2.1 Pre-Download the Keys
-First run this command online to download the key material to disk:
-
 `npm run build`
 
+`npm run dev`
+
 Once this command is run, all proving keys for the `transfer_public`, `bond_public`, `unbond_public`, and
-`claim_unbond_public` functions will be downloaded to the `./keys` folder. The machine can then be disconnected from
+`claim_unbond_public` functions will be downloaded to the `dist/keys` folder. The machine can then be disconnected from
 the internet and the `OfflineKeyProvider` will search this directory for the function proving keys when building the
 transaction instead of connecting to the internet. Alternatively you can skip the online step entirely by adding the proving key creating this directory manually and
 adding the key material yourself.
 
-### 2.2 Build the Transaction Offline
-
-Once the key material is downloaded, turn off your internet connection and run the following command:
-
-`npm run dev`
-
-You should see the transactions being built and the resulting transaction IDs printed to the console.
+Once the keys are downloaded to your local machine, the offline transactions will be built without requiring an internet connection.
 
 ## 3. Notes
 

--- a/create-leo-app/template-offline-public-transaction-ts/src/helpers.ts
+++ b/create-leo-app/template-offline-public-transaction-ts/src/helpers.ts
@@ -28,7 +28,7 @@ async function preDownloadTransferKeys() {
     const keysDirPath = path.join(__dirname, "keys");
     await fsPromises.mkdir(keysDirPath, { recursive: true });
 
-    for (const keyData of [CREDITS_PROGRAM_KEYS.transfer_public, CREDITS_PROGRAM_KEYS.fee_public]) {
+    for (const keyData of [CREDITS_PROGRAM_KEYS.transfer_public, CREDITS_PROGRAM_KEYS.fee_public, CREDITS_PROGRAM_KEYS.transfer_public_as_signer]) {
         try {
             keyPaths[keyData.locator] = await downloadAndSaveKey(keyData, keysDirPath);
         } catch (error) {

--- a/create-leo-app/template-offline-public-transaction-ts/src/index.ts
+++ b/create-leo-app/template-offline-public-transaction-ts/src/index.ts
@@ -15,7 +15,6 @@ async function buildTransferPublicTxOffline(recipientAddress: Address, amount: n
     // Create the proving keys from the key bytes on the offline machine
     console.log("Creating proving keys from local key files");
     const feePublicKeyBytes = await getLocalKey(<string>keyPaths[CREDITS_PROGRAM_KEYS.fee_public.locator]);
-    const transferPublicAsSignerKeyBytes = await getLocalKey(<string>keyPaths[CREDITS_PROGRAM_KEYS.transfer_public_as_signer.locator]);
     const feePublicProvingKey = ProvingKey.fromBytes(feePublicKeyBytes);
     const transferPublicProvingKey = ProvingKey.fromBytes(
         await getLocalKey(<string>keyPaths[CREDITS_PROGRAM_KEYS.transfer_public.locator])
@@ -180,7 +179,7 @@ console.log(`\n-----------------bond_public transaction-----------------\n${bond
 console.log(`---------------------------------------------------------`);
 console.log(`\n----------------unbond_public transaction:---------------\n${bondTransactions[1]}`);
 console.log(`---------------------------------------------------------`);
-console.log(`\n-----------------claim_unbond transaction:---------------\n${bondTransactions[2]}`);
+console.log(`\n-----------------claim_unbond_public transaction:---------------\n${bondTransactions[2]}`);
 console.log(`---------------------------------------------------------`);
 //---------------------------------------------------------
 

--- a/create-leo-app/template-offline-public-transaction-ts/src/index.ts
+++ b/create-leo-app/template-offline-public-transaction-ts/src/index.ts
@@ -64,7 +64,13 @@ try {
 }
 
 /// Build bonding and unbonding transactions without connection to the internet
-async function buildBondingTxOffline(stakerAddress: Address,  validatorAddress: Address, withdrawalAddress: Address, amount: number, latestStateRoot: string, keyPaths: {}): Promise<Transaction[]> {
+async function buildBondingTxOffline(
+    validatorAddress: Address, 
+    withdrawalAddress: Address, 
+    amount: number, 
+    latestStateRoot: string, 
+    keyPaths: {}
+): Promise<Transaction[]> {
     // Create an offline program manager
     const programManager = new ProgramManager();
 
@@ -87,8 +93,7 @@ async function buildBondingTxOffline(stakerAddress: Address,  validatorAddress: 
     console.log("Creating offline key provider");
     const offlineKeyProvider = new OfflineKeyProvider();
 
-    // Insert the proving keys into the offline key provider. The key provider will automatically insert the verifying
-    // keys into the key manager.
+    // Insert the proving keys into the offline key provider
     console.log("Inserting proving keys into key provider");
     offlineKeyProvider.insertFeePublicKeys(feePublicProvingKey);
     offlineKeyProvider.insertBondPublicKeys(bondPublicProvingKey);
@@ -100,38 +105,48 @@ async function buildBondingTxOffline(stakerAddress: Address,  validatorAddress: 
 
     // Build the bonding transactions offline
     console.log("Building a bond_public execution transaction offline");
+
+    if (!latestStateRoot) {
+        throw new Error("latestStateRoot is undefined");
+    }
+
     const bondPublicOptions = {
         keySearchParams: OfflineSearchParams.bondPublicKeyParams(),
-        offlineQuery: new OfflineQuery(latestStateRoot)
+        offlineQuery: new OfflineQuery(0, latestStateRoot)
     };
-    
+
 
     const bondTx = <Transaction>await programManager.buildBondPublicTransaction(
-        stakerAddress.to_string(),
         validatorAddress.to_string(),
         withdrawalAddress.to_string(),
         amount,
-        bondPublicOptions,
-    )
+        bondPublicOptions
+    );
+
     console.log("\nbond_public transaction built!\n");
 
-    console.log("Building an unbond_public execution transaction offline")
     const unbondPublicOptions = {
         keySearchParams: OfflineSearchParams.unbondPublicKeyParams(),
-        offlineQuery: new OfflineQuery(latestStateRoot)
+        offlineQuery: new OfflineQuery(0, latestStateRoot)
     };
 
-    const unBondTx = <Transaction>await programManager.buildUnbondPublicTransaction(stakerAddress.to_string(), amount, unbondPublicOptions);
+    const unBondTx = <Transaction>await programManager.buildUnbondPublicTransaction(
+        stakerAddress.to_string(),
+        amount,
+        unbondPublicOptions
+    );
     console.log("\nunbond_public transaction built!\n");
 
-    console.log("Building a claim_unbond_public transaction offline")
-    // Build the claim unbonding transaction offline
+    console.log("Building a claim_unbond_public transaction offline");
     const claimUnbondPublicOptions = {
         keySearchParams: OfflineSearchParams.claimUnbondPublicKeyParams(),
-        offlineQuery: new OfflineQuery(latestStateRoot)
+        offlineQuery: new OfflineQuery(0, latestStateRoot)
     };
 
-    const claimUnbondTx = <Transaction>await programManager.buildClaimUnbondPublicTransaction(stakerAddress.to_string(), claimUnbondPublicOptions);
+    const claimUnbondTx = <Transaction>await programManager.buildClaimUnbondPublicTransaction(
+        stakerAddress.to_string(),
+        claimUnbondPublicOptions
+    );
     console.log("\nclaim_unbond_public transaction built!\n");
     return [bondTx, unBondTx, claimUnbondTx];
 }
@@ -159,7 +174,7 @@ console.log(`\n---------------transfer_public transaction---------------\n${tran
 console.log(`---------------------------------------------------------`);
 
 // Build bonding & unbonding transactions
-const bondTransactions = await buildBondingTxOffline(stakerAddress, validatorAddress, withdrawalAddress, 100, latestStateRoot, bondingKeyPaths);
+const bondTransactions = await buildBondingTxOffline(validatorAddress, withdrawalAddress, 100, latestStateRoot, bondingKeyPaths);
 console.log("Bonding transactions built offline!");
 console.log(`\n-----------------bond_public transaction-----------------\n${bondTransactions[0]}`);
 console.log(`---------------------------------------------------------`);

--- a/create-leo-app/template-offline-public-transaction-ts/src/index.ts
+++ b/create-leo-app/template-offline-public-transaction-ts/src/index.ts
@@ -17,8 +17,10 @@ async function buildTransferPublicTxOffline(recipientAddress: Address, amount: n
     const feePublicKeyBytes = await getLocalKey(<string>keyPaths[CREDITS_PROGRAM_KEYS.fee_public.locator]);
     const transferPublicAsSignerKeyBytes = await getLocalKey(<string>keyPaths[CREDITS_PROGRAM_KEYS.transfer_public_as_signer.locator]);
     const feePublicProvingKey = ProvingKey.fromBytes(feePublicKeyBytes);
-    const transferPublicProvingKey = ProvingKey.fromBytes(transferPublicAsSignerKeyBytes);
-
+    const transferPublicProvingKey = ProvingKey.fromBytes(
+        await getLocalKey(<string>keyPaths[CREDITS_PROGRAM_KEYS.transfer_public.locator])
+    );
+    
     // Create an offline key provider
     console.log("Creating offline key provider");
     const offlineKeyProvider = new OfflineKeyProvider();
@@ -27,10 +29,25 @@ async function buildTransferPublicTxOffline(recipientAddress: Address, amount: n
     // keys into the key manager.
     console.log("Inserting proving keys into key provider");
     offlineKeyProvider.insertFeePublicKeys(feePublicProvingKey);
+
+try {
     offlineKeyProvider.insertTransferPublicKeys(transferPublicProvingKey);
+    console.log("Successfully inserted proving key");
+} catch (err) {
+    console.error("Failed to insert proving key:", err);
+}
+
 
     // Create an offline query to complete the inclusion proof
-    const offlineQuery = new OfflineQuery(latestStateRoot);
+    let offlineQuery: OfflineQuery;
+    const blockHeight = 0;
+    // TODO this is a placeholder block height for now, which offlineQuery now requires
+try {
+    const offlineQuery = new OfflineQuery(blockHeight, latestStateRoot);
+    console.log("Successfully created OfflineQuery", offlineQuery);
+} catch (err) {
+    console.error("Failed to create OfflineQuery:", err);
+}
 
     // Insert the key provider into the program manager
     programManager.setKeyProvider(offlineKeyProvider);
@@ -84,13 +101,10 @@ async function buildBondingTxOffline(stakerAddress: Address,  validatorAddress: 
     // Build the bonding transactions offline
     console.log("Building a bond_public execution transaction offline");
     const bondPublicOptions = {
-        executionParams: {
-            keySearchParams: OfflineSearchParams.bondPublicKeyParams()
-        },
-        offlineParams: {
-            offlineQuery: new OfflineQuery(latestStateRoot)
-        }
-    }
+        keySearchParams: OfflineSearchParams.bondPublicKeyParams(),
+        offlineQuery: new OfflineQuery(latestStateRoot)
+    };
+    
 
     const bondTx = <Transaction>await programManager.buildBondPublicTransaction(
         stakerAddress.to_string(),
@@ -103,13 +117,9 @@ async function buildBondingTxOffline(stakerAddress: Address,  validatorAddress: 
 
     console.log("Building an unbond_public execution transaction offline")
     const unbondPublicOptions = {
-        executionParams: {
-            keySearchParams: OfflineSearchParams.unbondPublicKeyParams()
-        },
-        offlineParams: {
-            offlineQuery: new OfflineQuery(latestStateRoot)
-        }
-    }
+        keySearchParams: OfflineSearchParams.unbondPublicKeyParams(),
+        offlineQuery: new OfflineQuery(latestStateRoot)
+    };
 
     const unBondTx = <Transaction>await programManager.buildUnbondPublicTransaction(stakerAddress.to_string(), amount, unbondPublicOptions);
     console.log("\nunbond_public transaction built!\n");
@@ -117,13 +127,9 @@ async function buildBondingTxOffline(stakerAddress: Address,  validatorAddress: 
     console.log("Building a claim_unbond_public transaction offline")
     // Build the claim unbonding transaction offline
     const claimUnbondPublicOptions = {
-        executionParams: {
-            keySearchParams: OfflineSearchParams.claimUnbondPublicKeyParams()
-        },
-        offlineParams: {
-            offlineQuery: new OfflineQuery(latestStateRoot)
-        }
-    }
+        keySearchParams: OfflineSearchParams.claimUnbondPublicKeyParams(),
+        offlineQuery: new OfflineQuery(latestStateRoot)
+    };
 
     const claimUnbondTx = <Transaction>await programManager.buildClaimUnbondPublicTransaction(stakerAddress.to_string(), claimUnbondPublicOptions);
     console.log("\nclaim_unbond_public transaction built!\n");

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -843,7 +843,6 @@ class ProgramManager {
      * const result = await programManager.networkClient.submitTransaction(tx);
      *
      * @returns string
-     * @param {string} staker_address Address of the staker who is bonding the credits
      * @param {string} validator_address Address of the validator to bond to, if this address is the same as the staker (i.e. the
      * executor of this function), it will attempt to bond the credits as a validator. Bonding as a validator currently
      * requires a minimum of 10,000,000 credits to bond (subject to change). If the address is specified is an existing
@@ -853,7 +852,7 @@ class ProgramManager {
      * @param {number} amount The amount of credits to bond
      * @param {Partial<ExecuteOptions>} options - Override default execution options.
      */
-    async buildBondPublicTransaction(staker_address: string, validator_address: string, withdrawal_address: string, amount: number, options: Partial<ExecuteOptions> = {}) {
+    async buildBondPublicTransaction(validator_address: string, withdrawal_address: string, amount: number, options: Partial<ExecuteOptions> = {}) {
         const scaledAmount = Math.trunc(amount * 1000000);
 
         const {
@@ -861,7 +860,7 @@ class ProgramManager {
             functionName = "bond_public",
             fee = options.fee || 0.86,
             privateFee = false,
-            inputs = [staker_address, validator_address, withdrawal_address, `${scaledAmount.toString()}u64`],
+            inputs = [validator_address, withdrawal_address, `${scaledAmount.toString()}u64`],
             keySearchParams = new AleoKeyProviderParams({
                 proverUri: CREDITS_PROGRAM_KEYS.bond_public.prover,
                 verifierUri: CREDITS_PROGRAM_KEYS.bond_public.verifier,
@@ -900,7 +899,6 @@ class ProgramManager {
      * const tx_id = await programManager.bondPublic("aleo1jx8s4dvjepculny4wfrzwyhs3tlyv65r58ns3g6q2gm2esh7ps8sqy9s5j", "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px", "aleo1feya8sjy9k2zflvl2dx39pdsq5tju28elnp2ektnn588uu9ghv8s84msv9", 2000000);
      *
      * @returns string
-     * @param {string} staker_address Address of the staker who is bonding the credits
      * @param {string} validator_address Address of the validator to bond to, if this address is the same as the signer (i.e. the
      * executor of this function), it will attempt to bond the credits as a validator. Bonding as a validator currently
      * requires a minimum of 1,000,000 credits to bond (subject to change). If the address is specified is an existing
@@ -910,8 +908,8 @@ class ProgramManager {
      * @param {number} amount The amount of credits to bond
      * @param {Options} options Options for the execution
      */
-    async bondPublic(staker_address: string, validator_address: string, withdrawal_address:string, amount: number, options: Partial<ExecuteOptions> = {}) {
-        const tx = <Transaction>await this.buildBondPublicTransaction(staker_address, validator_address, withdrawal_address, amount, options);
+    async bondPublic(validator_address: string, withdrawal_address:string, amount: number, options: Partial<ExecuteOptions> = {}) {
+        const tx = <Transaction>await this.buildBondPublicTransaction(validator_address, withdrawal_address, amount, options);
         return await this.networkClient.submitTransaction(tx);
     }
 


### PR DESCRIPTION
Makes updates to the `create-leo-app` offline public transaction signing template. The SDK also had to be modified to remove the `stakerAddress` from `bond_public` 