### PR TITLE
[Feature] Add to/from bit and byte methods to algebraic objects

### DIFF
--- a/sdk/tests/arithmetic.test.ts
+++ b/sdk/tests/arithmetic.test.ts
@@ -1,6 +1,7 @@
 import sinon from "sinon";
 import { expect } from "chai";
 import { Field, Scalar, Group} from "../src/node";
+import { FieldGenerator, GroupGenerator, ScalarGenerator } from "./data/algebra";
 
 describe('Field and Group Arithmetic Tests', () => {
     afterEach(() => {
@@ -99,6 +100,41 @@ describe('Field and Group Arithmetic Tests', () => {
             expect(c.equals(d)).equals(true);
             // Ensure adding the inverse element leads to the point at infinity.
             expect((G.add(G_inv)).equals(Ginf)).equals(true);
+        });
+
+        it('Ensure bit and byte serialization is correctly implemented', () => {
+            // Create the chosen generators.
+            const G = Group.generator();
+            const a = Scalar.fromString(ScalarGenerator);
+            const f = Field.fromString(FieldGenerator);
+
+            // Serialize the algebraic objects to bytes.
+            const GBytesLe = G.toBytesLe();
+            const aBytesLe = a.toBytesLe();
+            const fBytesLe = f.toBytesLe();
+
+            // Serialize the algebraic objects to bits.
+            const GBits = G.toBitsLe();
+            const aBits = a.toBitsLe();
+            const fBits = f.toBitsLe();
+
+            // Deserialize the bytes to the original algebraic objects.
+            const GDeserializedBytes = Group.fromBytesLe(GBytesLe).toString();
+            const aDeserializedBytes = Scalar.fromBytesLe(aBytesLe).toString();
+            const fDeserializedBytes = Field.fromBytesLe(fBytesLe).toString();
+
+            // Deserialize the bits to the original algebraic objects.
+            const GDeserializedBits = Group.fromBitsLe(GBits).toString();
+            const aDeserializedBits = Scalar.fromBitsLe(aBits).toString();
+            const fDeserializedBits = Field.fromBitsLe(fBits).toString();
+
+            // Ensure the deserialized objects are the same as the original objects.
+            expect(GDeserializedBytes).equals(GroupGenerator);
+            expect(aDeserializedBytes).equals(ScalarGenerator);
+            expect(fDeserializedBytes).equals(FieldGenerator);
+            expect(GDeserializedBits).equals(GroupGenerator);
+            expect(aDeserializedBits).equals(ScalarGenerator);
+            expect(fDeserializedBits).equals(FieldGenerator);
         });
     });
 });

--- a/sdk/tests/data/algebra.ts
+++ b/sdk/tests/data/algebra.ts
@@ -55,12 +55,12 @@ const expectedPoseidon8HashMany = [
     "491310798299229303453029190751493384624125693265313448104421146921465784609field",
     "476244868544635089532724552855423418881253978175875838088194622836984800804field"
 ];
-
-
-
+/// Write the string representation of the group generator.
+const GroupGenerator = "1540945439182663264862696551825005342995406165131907382295858612069623286213group";
 /// Choose a scalar generator for unit tests.
 const ScalarGenerator = "1774157567936692047646837016039369013254365378639847034769080448564598011047scalar";
-export { FieldGenerator, ScalarGenerator, expectedBHP512Commit, expectedBHP512CommitToGroup, expectedBHP512Hash,
+
+export {expectedBHP512Commit, expectedBHP512CommitToGroup, expectedBHP512Hash,
     expectedBHP512HashToGroup, expectedBHP768Commit, expectedBHP768CommitToGroup, expectedBHP768Hash,
     expectedBHP768HashToGroup, expectedBHP1024Commit, expectedBHP1024CommitToGroup, expectedBHP1024Hash,
     expectedBHP1024HashToGroup, expectedBHP256Commit, expectedBHP256CommitToGroup, expectedBHP256Hash,
@@ -68,5 +68,6 @@ export { FieldGenerator, ScalarGenerator, expectedBHP512Commit, expectedBHP512Co
     expectedPedersen128CommitToGroup, expectedPedersen128Commit, expectedPedersen128Hash, expectedPoseidon2Hash,
     expectedPoseidon2HashToGroup, expectedPoseidon2HashToScalar, expectedPoseidon2HashMany, expectedPoseidon4Hash,
     expectedPoseidon4HashToGroup, expectedPoseidon4HashToScalar, expectedPoseidon4HashMany, expectedPoseidon8Hash,
-    expectedPoseidon8HashToGroup, expectedPoseidon8HashToScalar, expectedPoseidon8HashMany
+    expectedPoseidon8HashToGroup, expectedPoseidon8HashToScalar, expectedPoseidon8HashMany, FieldGenerator,
+    GroupGenerator, ScalarGenerator
 };

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "7e4f181fc1a372e8ceff89612e5c9b13f72bff5b066da9f8d6827ae65af492c4"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.8.0"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/wasm/src/types/field.rs
+++ b/wasm/src/types/field.rs
@@ -16,12 +16,13 @@
 
 use crate::{
     Plaintext,
+    from_js_typed_array,
     to_bits_array_le,
     types::native::{FieldNative, LiteralNative, PlaintextNative, Uniform},
 };
-use snarkvm_console::prelude::{Double, One, Pow, ToBits, Zero};
+use snarkvm_console::prelude::{Double, FromBits, FromBytes, One, Pow, ToBits, ToBytes, Zero};
 
-use js_sys::Array;
+use js_sys::{Array, Uint8Array};
 use once_cell::sync::OnceCell;
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
@@ -33,24 +34,53 @@ pub struct Field(FieldNative);
 
 #[wasm_bindgen]
 impl Field {
-    /// Creates a field object from a string representation of a field.
+    /// Creates a field object from a string representation of a field element.
     #[wasm_bindgen(js_name = "fromString")]
     #[allow(clippy::should_implement_trait)]
     pub fn from_string(field: &str) -> Result<Field, String> {
         Ok(Self(FieldNative::from_str(field).map_err(|e| e.to_string())?))
     }
 
-    /// Create a plaintext element from a group element.
-    #[wasm_bindgen(js_name = "toPlaintext")]
-    pub fn to_plaintext(&self) -> Plaintext {
-        Plaintext::from(PlaintextNative::Literal(LiteralNative::Field(self.0), OnceCell::new()))
-    }
-
-    /// Returns the string representation of the field.
+    /// Returns the string representation of the field element.
     #[wasm_bindgen(js_name = "toString")]
     #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
+    }
+
+    /// Create a field element from a Uint8Array of left endian bytes.
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: &Uint8Array) -> Result<Field, String> {
+        let bytes = bytes.to_vec();
+        let transition = FieldNative::from_bytes_le(&bytes).map_err(|e| e.to_string())?;
+        Ok(Field(transition))
+    }
+
+    /// Encode the field element as a Uint8Array of left endian bytes.
+    #[wasm_bindgen(js_name = "toBytesLe")]
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
+        Ok(Uint8Array::from(bytes.as_slice()))
+    }
+
+    /// Reconstruct a field element from a boolean array representation.
+    #[wasm_bindgen(js_name = "fromBitsLe")]
+    pub fn from_bits_le(bits: &Array) -> Result<Field, String> {
+        let bit_vec = from_js_typed_array!(bits, as_bool, "boolean")?;
+        let group = FieldNative::from_bits_le(&bit_vec).map_err(|e| e.to_string())?;
+        Ok(Field(group))
+    }
+
+    /// Get the left endian boolean array representation of the field element.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
+    }
+
+    /// Create a plaintext from the field element.
+    #[wasm_bindgen(js_name = "toPlaintext")]
+    pub fn to_plaintext(&self) -> Plaintext {
+        Plaintext::from(PlaintextNative::Literal(LiteralNative::Field(self.0), OnceCell::new()))
     }
 
     /// Clone the field element.
@@ -94,12 +124,12 @@ impl Field {
         Field(-self.0)
     }
 
-    /// Get the zero element of the field.
+    /// Get the additive identity element of the field.
     pub fn zero() -> Field {
         Field(FieldNative::zero())
     }
 
-    /// Get the one element of the field.
+    /// Get the multiplicative identity of the field.
     pub fn one() -> Field {
         Field(FieldNative::one())
     }
@@ -112,12 +142,6 @@ impl Field {
     /// Check if one field element equals another.
     pub fn equals(&self, other: &Field) -> bool {
         self.0 == FieldNative::from(other)
-    }
-
-    /// Get the left endian boolean array representation of the field element.
-    #[wasm_bindgen(js_name = "toBitsLe")]
-    pub fn to_bits_le(&self) -> Array {
-        to_bits_array_le!(self)
     }
 }
 

--- a/wasm/src/types/group.rs
+++ b/wasm/src/types/group.rs
@@ -17,15 +17,16 @@
 use crate::{
     Field,
     Plaintext,
+    from_js_typed_array,
     to_bits_array_le,
     types::{
         Scalar,
         native::{GroupNative, LiteralNative, PlaintextNative, Uniform},
     },
 };
-use snarkvm_console::prelude::{Double, ToBits, Zero};
+use snarkvm_console::prelude::{Double, FromBits, FromBytes, ToBits, ToBytes, Zero};
 
-use js_sys::Array;
+use js_sys::{Array, Uint8Array};
 use once_cell::sync::OnceCell;
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
@@ -37,17 +38,46 @@ pub struct Group(GroupNative);
 
 #[wasm_bindgen]
 impl Group {
-    /// Creates a group object from a string representation of a group.
+    /// Creates a group object from a string representation of a group element.
     #[wasm_bindgen(js_name = "fromString")]
     pub fn from_string(group: &str) -> Result<Group, String> {
         Ok(Self(GroupNative::from_str(group).map_err(|e| e.to_string())?))
     }
 
-    /// Returns the string representation of the group.
+    /// Returns the string representation of the group element.
     #[wasm_bindgen(js_name = "toString")]
     #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
+    }
+
+    /// Create a group element from a Uint8Array of left endian bytes.
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: &Uint8Array) -> Result<Group, String> {
+        let bytes = bytes.to_vec();
+        let group = GroupNative::from_bytes_le(&bytes).map_err(|e| e.to_string())?;
+        Ok(Group(group))
+    }
+
+    /// Encode the group element as a Uint8Array of left endian bytes.
+    #[wasm_bindgen(js_name = "toBytesLe")]
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
+        Ok(Uint8Array::from(bytes.as_slice()))
+    }
+
+    /// Reconstruct a group element from a boolean array representation.
+    #[wasm_bindgen(js_name = "fromBitsLe")]
+    pub fn from_bits_le(bits: &Array) -> Result<Group, String> {
+        let bit_vec = from_js_typed_array!(bits, as_bool, "boolean")?;
+        let group = GroupNative::from_bits_le(&bit_vec).map_err(|e| e.to_string())?;
+        Ok(Group(group))
+    }
+
+    /// Get the left endian boolean array representation of the group element.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
     }
 
     /// Get the x-coordinate of the group element.
@@ -113,12 +143,6 @@ impl Group {
     /// Get the generator of the group.
     pub fn generator() -> Group {
         Group::from(GroupNative::generator())
-    }
-
-    /// Get the left endian boolean array representation of the group element.
-    #[wasm_bindgen(js_name = "toBitsLe")]
-    pub fn to_bits_le(&self) -> Array {
-        to_bits_array_le!(self)
     }
 }
 

--- a/wasm/src/types/scalar.rs
+++ b/wasm/src/types/scalar.rs
@@ -16,12 +16,13 @@
 
 use crate::{
     Plaintext,
+    from_js_typed_array,
     to_bits_array_le,
     types::native::{LiteralNative, PlaintextNative, ScalarNative, Uniform},
 };
-use snarkvm_console::prelude::{Double, One, Pow, ToBits, Zero};
+use snarkvm_console::prelude::{Double, FromBits, FromBytes, One, Pow, ToBits, ToBytes, Zero};
 
-use js_sys::Array;
+use js_sys::{Array, Uint8Array};
 use once_cell::sync::OnceCell;
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
@@ -33,23 +34,52 @@ pub struct Scalar(ScalarNative);
 
 #[wasm_bindgen]
 impl Scalar {
-    /// Returns the string representation of the group.
+    /// Creates a scalar object from a string representation of a scalar element.
+    #[wasm_bindgen(js_name = "fromString")]
+    pub fn from_string(group: &str) -> Result<Scalar, String> {
+        Ok(Self(ScalarNative::from_str(group).map_err(|e| e.to_string())?))
+    }
+
+    /// Returns the string representation of the scalar element.
     #[wasm_bindgen(js_name = "toString")]
     #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
     }
 
-    /// Create a plaintext element from a group element.
+    /// Create a scalar element from a Uint8Array of left endian bytes.
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: &Uint8Array) -> Result<Scalar, String> {
+        let bytes = bytes.to_vec();
+        let scalar = ScalarNative::from_bytes_le(&bytes).map_err(|e| e.to_string())?;
+        Ok(Scalar(scalar))
+    }
+
+    /// Encode the scalar element as a Uint8Array of left endian bytes.
+    #[wasm_bindgen(js_name = "toBytesLe")]
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
+        Ok(Uint8Array::from(bytes.as_slice()))
+    }
+
+    /// Reconstruct a scalar element from a boolean array representation.
+    #[wasm_bindgen(js_name = "fromBitsLe")]
+    pub fn from_bits_le(bits: &Array) -> Result<Scalar, String> {
+        let bit_vec = from_js_typed_array!(bits, as_bool, "boolean")?;
+        let scalar = ScalarNative::from_bits_le(&bit_vec).map_err(|e| e.to_string())?;
+        Ok(Scalar(scalar))
+    }
+
+    /// Get the left endian boolean array representation of the scalar element.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
+    }
+
+    /// Create a plaintext element from a scalar element.
     #[wasm_bindgen(js_name = "toPlaintext")]
     pub fn to_plaintext(&self) -> Plaintext {
         Plaintext::from(PlaintextNative::Literal(LiteralNative::Scalar(self.0), OnceCell::new()))
-    }
-
-    /// Creates a group object from a string representation of a group.
-    #[wasm_bindgen(js_name = "fromString")]
-    pub fn from_string(group: &str) -> Result<Scalar, String> {
-        Ok(Self(ScalarNative::from_str(group).map_err(|e| e.to_string())?))
     }
 
     /// Clone the scalar element.
@@ -57,7 +87,7 @@ impl Scalar {
         Scalar(self.0.clone())
     }
 
-    /// Generate a random group element.
+    /// Generate a random scalar element.
     pub fn random() -> Scalar {
         let rng = &mut rand::thread_rng();
         Scalar(ScalarNative::rand(rng))
@@ -98,12 +128,12 @@ impl Scalar {
         Scalar(-self.0)
     }
 
-    /// Creates a one valued element of the scalar field.
+    /// Get the multiplicative identity of the scalar field.
     pub fn one() -> Scalar {
         Scalar(ScalarNative::one())
     }
 
-    /// Creates a zero valued element of the scalar field
+    /// Get the additive identity of the scalar field.
     pub fn zero() -> Scalar {
         Scalar(ScalarNative::zero())
     }
@@ -111,12 +141,6 @@ impl Scalar {
     /// Check if one scalar element equals another.
     pub fn equals(&self, other: &Scalar) -> bool {
         self.0 == ScalarNative::from(other)
-    }
-
-    /// Get the left endian boolean array representation of the scalar element.
-    #[wasm_bindgen(js_name = "toBitsLe")]
-    pub fn to_bits_le(&self) -> Array {
-        to_bits_array_le!(self)
     }
 }
 


### PR DESCRIPTION
## Motivation

In order to support custom encoding in the Aleo protocol for important objects in Dapps (such as utf-8 byte encodings of strings, or objects within Dapps that have canonical byte encodings), the Field, Group, and Scalar elements should all support  `from[Bits/Bytes]Le` and `to[Bits/Bytes]Le` methods. This PR adds these methods and a javascript test to ensure they're correct.

These changes:
* Allow encoding strings or objects with canonical byte representation as Field, Scalar, or Group elements
* Allow decoding of Field, Group, or Scalar elements into strings or other objects
* Enable algebraic objects to be turned into representations suitable for hashing
* Enable developers to create hash-based digests of any object with canonical byte serialization.

## Changelog

* Adds `fromBitsLe`, `fromBytesLe`, `toBitsLe`, and `toBytesLe` methods to the `Field`, `Group`, and `Scalar` structs exported to `wasm` allowing these representations to be used in `Javascript`. 
* Fixes subtle errors in doc comments
* Re-organizes all serialization related methods to the top of the exported struct

## Test Plan
* Adds a js test to ensure correctness.

## Related PRs
This PR + following PRs when merged will constitute a release candidate for SDK version `0.8.6`

#996 
#989 