### PR TITLE
[Feature] Plaintext toBitsLe method

### DIFF
--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -16,8 +16,10 @@
 
 use crate::account::{PrivateKey, Signature, ViewKey};
 
-use crate::{account::compute_key::ComputeKey, types::native::AddressNative};
+use crate::{account::compute_key::ComputeKey, to_bits_array_le, types::native::AddressNative};
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
+use js_sys::Array;
+use snarkvm_wasm::utilities::ToBits;
 use wasm_bindgen::prelude::*;
 
 /// Public address of an Aleo account
@@ -65,6 +67,12 @@ impl Address {
     #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
+    }
+
+    /// Get the left endian boolean array representation of the address.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
     }
 
     /// Verify a signature for a message signed by the address

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -14,12 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::account::{PrivateKey, Signature, ViewKey};
-
-use crate::{account::compute_key::ComputeKey, to_bits_array_le, types::native::AddressNative};
+use crate::{
+    Plaintext,
+    account::{PrivateKey, Signature, ViewKey, compute_key::ComputeKey},
+    types::native::AddressNative,
+};
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
 use js_sys::Array;
-use snarkvm_wasm::utilities::ToBits;
 use wasm_bindgen::prelude::*;
 
 /// Public address of an Aleo account
@@ -69,10 +70,11 @@ impl Address {
         self.0.to_string()
     }
 
-    /// Get the left endian boolean array representation of the address.
-    #[wasm_bindgen(js_name = "toBitsLe")]
-    pub fn to_bits_le(&self) -> Array {
-        to_bits_array_le!(self)
+    /// Get the left endian boolean array representation of the address plaintext.
+    #[wasm_bindgen(js_name = "plaintextBitsLe")]
+    pub fn plaintext_bits_le(&self) -> Result<Array, String> {
+        let plaintext = Plaintext::from_string(&self.to_string())?;
+        Ok(plaintext.to_bits_le())
     }
 
     /// Verify a signature for a message signed by the address

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -24,10 +24,9 @@ use crate::{
     types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes},
 };
 use snarkvm_console::prelude::ToBits;
-use std::ops::Deref;
 
 use js_sys::{Array, Uint8Array};
-use std::str::FromStr;
+use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
 /// SnarkVM Plaintext object. Plaintext is a fundamental monadic type used to represent Aleo

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -15,7 +15,13 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    plaintext_to_js_value, to_bits_array_le, types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes}, Address, Ciphertext, Field, Scalar
+    Address,
+    Ciphertext,
+    Field,
+    Scalar,
+    plaintext_to_js_value,
+    to_bits_array_le,
+    types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes},
 };
 use snarkvm_console::prelude::ToBits;
 use std::ops::Deref;

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -15,16 +15,12 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    Address,
-    Ciphertext,
-    Field,
-    Scalar,
-    plaintext_to_js_value,
-    types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes},
+    plaintext_to_js_value, to_bits_array_le, types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes}, Address, Ciphertext, Field, Scalar
 };
+use snarkvm_console::prelude::ToBits;
 use std::ops::Deref;
 
-use js_sys::Uint8Array;
+use js_sys::{Array, Uint8Array};
 use std::str::FromStr;
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
@@ -106,6 +102,12 @@ impl Plaintext {
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
         let rust_bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
         Ok(Uint8Array::from(rust_bytes.as_slice()))
+    }
+
+    /// Get the left endian boolean array representation of the plaintext.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
     }
 
     /// Returns the string representation of the plaintext.


### PR DESCRIPTION
## Motivation

In order to hash a plaintext struct, one needs to be able to get the bit serialization of it. This PR exposes the bit serialization method from the WASM so that it may be provided to the hash function.

## Test Plan

N/A

## Related PRs

N/A
