### PR TITLE
[Feature] Expose bit, byte, and fields serialization methods for plaintext, ciphertext, records, and addresses

### DIFF
--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -16,8 +16,10 @@
 
 use crate::account::{PrivateKey, Signature, ViewKey};
 
-use crate::{account::compute_key::ComputeKey, types::native::AddressNative};
+use crate::{account::compute_key::ComputeKey, to_bits_array_le, types::native::AddressNative};
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
+use js_sys::Array;
+use snarkvm_wasm::utilities::ToBits;
 use wasm_bindgen::prelude::*;
 
 /// Public address of an Aleo account
@@ -65,6 +67,12 @@ impl Address {
     #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
+    }
+
+    /// Get the left endian boolean array representation of the address.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
     }
 
     /// Verify a signature for a message signed by the address

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -17,10 +17,11 @@
 use crate::{
     Plaintext,
     account::{PrivateKey, Signature, ViewKey, compute_key::ComputeKey},
+    native::LiteralNative,
     types::native::AddressNative,
 };
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
-use js_sys::Array;
+use js_sys::{Array, Uint8Array};
 use wasm_bindgen::prelude::*;
 
 /// Public address of an Aleo account
@@ -70,11 +71,18 @@ impl Address {
         self.0.to_string()
     }
 
-    /// Get the left endian boolean array representation of the address plaintext.
-    #[wasm_bindgen(js_name = "plaintextBitsLe")]
-    pub fn plaintext_bits_le(&self) -> Result<Array, String> {
-        let plaintext = Plaintext::from_string(&self.to_string())?;
-        Ok(plaintext.to_bits_le())
+    /// Get the left endian byte array representation of the address plaintext.
+    #[wasm_bindgen(js_name = "toPlaintextBytesLe")]
+    pub fn to_plaintext_bytes_le(&self) -> Result<Uint8Array, String> {
+        let plaintext = Plaintext::from(LiteralNative::Address(self.0));
+        plaintext.to_bytes_le()
+    }
+
+    /// Get the left endian boolean array representation of the address plaintext bits.
+    #[wasm_bindgen(js_name = "toPlaintextBitsLe")]
+    pub fn to_plaintext_bits_le(&self) -> Array {
+        let plaintext = Plaintext::from(LiteralNative::Address(self.0));
+        plaintext.to_bits_le()
     }
 
     /// Verify a signature for a message signed by the address

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -14,12 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::account::{PrivateKey, Signature, ViewKey};
-
-use crate::{account::compute_key::ComputeKey, to_bits_array_le, types::native::AddressNative};
+use crate::{
+    Plaintext,
+    account::{PrivateKey, Signature, ViewKey, compute_key::ComputeKey},
+    types::native::AddressNative,
+};
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
 use js_sys::Array;
-use snarkvm_wasm::utilities::ToBits;
 use wasm_bindgen::prelude::*;
 
 /// Public address of an Aleo account
@@ -69,10 +70,11 @@ impl Address {
         self.0.to_string()
     }
 
-    /// Get the left endian boolean array representation of the address.
-    #[wasm_bindgen(js_name = "toBitsLe")]
-    pub fn to_bits_le(&self) -> Array {
-        to_bits_array_le!(self)
+    /// Get the left endian boolean array representation of the address plaintext.
+    #[wasm_bindgen(js_name = "plaintextBitsLe")]
+    pub fn plaintext_bits_le(&self) -> Result<Array, String> {
+        let plaintext = Plaintext::from_string(&self.to_string())?;
+        Ok(plaintext.to_bits_le())
     }
 
     /// Verify a signature for a message signed by the address

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -16,6 +16,7 @@
 
 use crate::{
     Field,
+    Group,
     Plaintext,
     account::{PrivateKey, Signature, ViewKey, compute_key::ComputeKey},
     from_js_typed_array,
@@ -25,7 +26,6 @@ use crate::{
     to_bits_array_le,
     types::native::AddressNative,
 };
-
 use snarkvm_console::prelude::{FromBits, FromBytes, FromFields, ToBits, ToBytes, ToFields};
 
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
@@ -119,6 +119,22 @@ impl Address {
         Ok(js_array_from_fields!(&native_fields))
     }
 
+    /// Get an address object from a group.
+    ///
+    /// @param {Group} group The group object.
+    ///
+    /// @returns {Address} The address object.
+    #[wasm_bindgen(js_name = "fromGroup")]
+    pub fn from_group(group: Group) -> Self {
+        Self::from(group)
+    }
+
+    /// Get the group representation of the address object.
+    #[wasm_bindgen(js_name = "toGroup")]
+    pub fn to_group(&self) -> Group {
+        Group::from(self)
+    }
+
     /// Create an aleo address object from a string representation of an address
     ///
     /// @param {string} address String representation of an addressm
@@ -186,6 +202,31 @@ impl From<&AddressNative> for Address {
 impl From<&Address> for AddressNative {
     fn from(value: &Address) -> Self {
         value.0
+    }
+}
+
+impl From<AddressNative> for Group {
+    fn from(value: AddressNative) -> Self {
+        let vm_group = value.to_group();
+        Self::from(vm_group)
+    }
+}
+
+impl From<Address> for Group {
+    fn from(value: Address) -> Self {
+        Self::from(value.0)
+    }
+}
+
+impl From<&AddressNative> for Group {
+    fn from(value: &AddressNative) -> Self {
+        Self::from(value.clone())
+    }
+}
+
+impl From<&Address> for Group {
+    fn from(value: &Address) -> Self {
+        Self::from(value.0)
     }
 }
 

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -142,24 +142,6 @@ impl Address {
         Plaintext::from(LiteralNative::Address(self.0))
     }
 
-    /// Get the left endian byte array representation of the address plaintext.
-    #[wasm_bindgen(js_name = "toPlaintextBytesLe")]
-    pub fn to_plaintext_bytes_le(&self) -> Result<Uint8Array, String> {
-        self.to_plaintext().to_bytes_le()
-    }
-
-    /// Get the left endian boolean array representation of the address plaintext bits.
-    #[wasm_bindgen(js_name = "toPlaintextBitsLe")]
-    pub fn to_plaintext_bits_le(&self) -> Array {
-        self.to_plaintext().to_bits_le()
-    }
-
-    /// Get the field array representation of the address plaintext.
-    #[wasm_bindgen(js_name = "toPlaintextFields")]
-    pub fn to_plaintext_fields(&self) -> Result<Array, String> {
-        self.to_plaintext().to_fields()
-    }
-
     /// Verify a signature for a message signed by the address
     ///
     /// @param {Uint8Array} Byte array representing a message signed by the address

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -15,14 +15,22 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    Field,
     Plaintext,
     account::{PrivateKey, Signature, ViewKey, compute_key::ComputeKey},
-    native::LiteralNative,
+    from_js_typed_array,
+    from_wasm_object_array,
+    js_array_from_fields,
+    native::{FieldNative, LiteralNative},
+    to_bits_array_le,
     types::native::AddressNative,
 };
+
+use snarkvm_console::prelude::{FromBits, FromBytes, FromFields, ToBits, ToBytes, ToFields};
+
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
 use js_sys::{Array, Uint8Array};
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{convert::TryFromJsValue, prelude::*};
 
 /// Public address of an Aleo account
 #[wasm_bindgen]
@@ -54,6 +62,63 @@ impl Address {
         compute_key.address()
     }
 
+    /// Get an address from a series of bytes.
+    ///
+    /// @param {Uint8Array} bytes A left endian byte array representing the address.
+    ///
+    /// @returns {Address} The address object.
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: Uint8Array) -> Result<Self, String> {
+        let rust_bytes = bytes.to_vec();
+        let native = AddressNative::from_bytes_le(rust_bytes.as_slice()).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
+    /// Get the left endian byte array representation of the address.
+    #[wasm_bindgen(js_name = "toBytesLe")]
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let rust_bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
+        Ok(Uint8Array::from(rust_bytes.as_slice()))
+    }
+
+    /// Get an address from a series of bits represented as a boolean array.
+    ///
+    /// @param {Array} bits A left endian boolean array representing the bits of the address.
+    ///
+    /// @returns {Address} The address object.
+    #[wasm_bindgen(js_name = "fromBitsLe")]
+    pub fn from_bits_le(bits: Array) -> Result<Self, String> {
+        let rust_bits = from_js_typed_array!(bits, as_bool, "boolean")?;
+        let native = AddressNative::from_bits_le(&rust_bits).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
+    /// Get the left endian boolean array representation of the bits of the address.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
+    }
+
+    /// Get an address object from an array of fields.
+    ///
+    /// @param {Array} fields An array of fields.
+    ///
+    /// @returns {Plaintext} The address object.
+    #[wasm_bindgen(js_name = "fromFields")]
+    pub fn from_fields(fields: Array) -> Result<Self, String> {
+        let native_fields = from_wasm_object_array!(fields, Field)?;
+        let native = AddressNative::from_fields(&native_fields).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
+    /// Get the field array representation of the address.
+    #[wasm_bindgen(js_name = "toFields")]
+    pub fn to_fields(&self) -> Result<Array, String> {
+        let native = self.0.clone();
+        let native_fields = native.to_fields().map_err(|e| e.to_string())?;
+        Ok(js_array_from_fields!(&native_fields))
+    }
+
     /// Create an aleo address object from a string representation of an address
     ///
     /// @param {string} address String representation of an addressm
@@ -71,18 +136,28 @@ impl Address {
         self.0.to_string()
     }
 
+    /// Get the plaintext representation of the address.
+    #[wasm_bindgen(js_name = "toPlaintext")]
+    pub fn to_plaintext(&self) -> Plaintext {
+        Plaintext::from(LiteralNative::Address(self.0))
+    }
+
     /// Get the left endian byte array representation of the address plaintext.
     #[wasm_bindgen(js_name = "toPlaintextBytesLe")]
     pub fn to_plaintext_bytes_le(&self) -> Result<Uint8Array, String> {
-        let plaintext = Plaintext::from(LiteralNative::Address(self.0));
-        plaintext.to_bytes_le()
+        self.to_plaintext().to_bytes_le()
     }
 
     /// Get the left endian boolean array representation of the address plaintext bits.
     #[wasm_bindgen(js_name = "toPlaintextBitsLe")]
     pub fn to_plaintext_bits_le(&self) -> Array {
-        let plaintext = Plaintext::from(LiteralNative::Address(self.0));
-        plaintext.to_bits_le()
+        self.to_plaintext().to_bits_le()
+    }
+
+    /// Get the field array representation of the address plaintext.
+    #[wasm_bindgen(js_name = "toPlaintextFields")]
+    pub fn to_plaintext_fields(&self) -> Result<Array, String> {
+        self.to_plaintext().to_fields()
     }
 
     /// Verify a signature for a message signed by the address

--- a/wasm/src/account/signature.rs
+++ b/wasm/src/account/signature.rs
@@ -26,7 +26,6 @@ use crate::{
     to_bits_array_le,
     types::native::SignatureNative,
 };
-
 use snarkvm_console::prelude::{FromBits, FromBytes, ToBits, ToBytes, ToFields};
 
 use core::{fmt, ops::Deref, str::FromStr};

--- a/wasm/src/account/signature.rs
+++ b/wasm/src/account/signature.rs
@@ -14,7 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Address, Plaintext, PrivateKey, Scalar, native::LiteralNative, types::native::SignatureNative};
+use crate::{
+    Address,
+    Field,
+    Plaintext,
+    PrivateKey,
+    Scalar,
+    from_js_typed_array,
+    js_array_from_fields,
+    native::LiteralNative,
+    to_bits_array_le,
+    types::native::SignatureNative,
+};
+
+use snarkvm_console::prelude::{FromBits, FromBytes, ToBits, ToBytes, ToFields};
 
 use core::{fmt, ops::Deref, str::FromStr};
 use js_sys::{Array, Uint8Array};
@@ -62,6 +75,51 @@ impl Signature {
         self.0.verify_bytes(address, message)
     }
 
+    /// Get a signature from a series of bytes.
+    ///
+    /// @param {Uint8Array} bytes A left endian byte array representing the signature.
+    ///
+    /// @returns {Signature} The signature object.
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: Uint8Array) -> Result<Self, String> {
+        let rust_bytes = bytes.to_vec();
+        let native = SignatureNative::from_bytes_le(rust_bytes.as_slice()).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
+    /// Get the left endian byte array representation of the signature.
+    #[wasm_bindgen(js_name = "toBytesLe")]
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let rust_bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
+        Ok(Uint8Array::from(rust_bytes.as_slice()))
+    }
+
+    /// Get a signature from a series of bits represented as a boolean array.
+    ///
+    /// @param {Array} bits A left endian boolean array representing the bits of the signature.
+    ///
+    /// @returns {Signature} The signature object.
+    #[wasm_bindgen(js_name = "fromBitsLe")]
+    pub fn from_bits_le(bits: Array) -> Result<Self, String> {
+        let rust_bits = from_js_typed_array!(bits, as_bool, "boolean")?;
+        let native = SignatureNative::from_bits_le(&rust_bits).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
+    /// Get the left endian boolean array representation of the bits of the signature.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
+    }
+
+    /// Get the field array representation of the signature.
+    #[wasm_bindgen(js_name = "toFields")]
+    pub fn to_fields(&self) -> Result<Array, String> {
+        let native = self.0.clone();
+        let native_fields = native.to_fields().map_err(|e| e.to_string())?;
+        Ok(js_array_from_fields!(&native_fields))
+    }
+
     /// Get a signature from a string representation of a signature
     ///
     /// @param {string} signature String representation of a signature
@@ -78,18 +136,28 @@ impl Signature {
         self.0.to_string()
     }
 
+    /// Get the plaintext representation of the signature.
+    #[wasm_bindgen(js_name = "toPlaintext")]
+    pub fn to_plaintext(&self) -> Plaintext {
+        Plaintext::from(LiteralNative::Signature(Box::new(self.0)))
+    }
+
     /// Get the left endian byte array representation of the signature plaintext.
     #[wasm_bindgen(js_name = "toPlaintextBytesLe")]
     pub fn to_plaintext_bytes_le(&self) -> Result<Uint8Array, String> {
-        let plaintext = Plaintext::from(LiteralNative::Signature(Box::new(self.0)));
-        plaintext.to_bytes_le()
+        self.to_plaintext().to_bytes_le()
     }
 
     /// Get the left endian boolean array representation of the signature plaintext bits.
     #[wasm_bindgen(js_name = "toPlaintextBitsLe")]
     pub fn to_plaintext_bits_le(&self) -> Array {
-        let plaintext = Plaintext::from(LiteralNative::Signature(Box::new(self.0)));
-        plaintext.to_bits_le()
+        self.to_plaintext().to_bits_le()
+    }
+
+    /// Get the field array representation of the signature plaintext.
+    #[wasm_bindgen(js_name = "toPlaintextFields")]
+    pub fn to_plaintext_fields(&self) -> Result<Array, String> {
+        self.to_plaintext().to_fields()
     }
 }
 

--- a/wasm/src/account/signature.rs
+++ b/wasm/src/account/signature.rs
@@ -14,9 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Address, PrivateKey, Scalar, types::native::SignatureNative};
+use crate::{Address, Plaintext, PrivateKey, Scalar, native::LiteralNative, types::native::SignatureNative};
 
 use core::{fmt, ops::Deref, str::FromStr};
+use js_sys::{Array, Uint8Array};
 use rand::{SeedableRng, rngs::StdRng};
 use wasm_bindgen::prelude::*;
 
@@ -75,6 +76,20 @@ impl Signature {
     #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
+    }
+
+    /// Get the left endian byte array representation of the signature plaintext.
+    #[wasm_bindgen(js_name = "toPlaintextBytesLe")]
+    pub fn to_plaintext_bytes_le(&self) -> Result<Uint8Array, String> {
+        let plaintext = Plaintext::from(LiteralNative::Signature(Box::new(self.0)));
+        plaintext.to_bytes_le()
+    }
+
+    /// Get the left endian boolean array representation of the signature plaintext bits.
+    #[wasm_bindgen(js_name = "toPlaintextBitsLe")]
+    pub fn to_plaintext_bits_le(&self) -> Array {
+        let plaintext = Plaintext::from(LiteralNative::Signature(Box::new(self.0)));
+        plaintext.to_bits_le()
     }
 }
 

--- a/wasm/src/account/signature.rs
+++ b/wasm/src/account/signature.rs
@@ -141,24 +141,6 @@ impl Signature {
     pub fn to_plaintext(&self) -> Plaintext {
         Plaintext::from(LiteralNative::Signature(Box::new(self.0)))
     }
-
-    /// Get the left endian byte array representation of the signature plaintext.
-    #[wasm_bindgen(js_name = "toPlaintextBytesLe")]
-    pub fn to_plaintext_bytes_le(&self) -> Result<Uint8Array, String> {
-        self.to_plaintext().to_bytes_le()
-    }
-
-    /// Get the left endian boolean array representation of the signature plaintext bits.
-    #[wasm_bindgen(js_name = "toPlaintextBitsLe")]
-    pub fn to_plaintext_bits_le(&self) -> Array {
-        self.to_plaintext().to_bits_le()
-    }
-
-    /// Get the field array representation of the signature plaintext.
-    #[wasm_bindgen(js_name = "toPlaintextFields")]
-    pub fn to_plaintext_fields(&self) -> Result<Array, String> {
-        self.to_plaintext().to_fields()
-    }
 }
 
 impl Deref for Signature {

--- a/wasm/src/algorithms/bhp/mod.rs
+++ b/wasm/src/algorithms/bhp/mod.rs
@@ -30,15 +30,13 @@ pub use bhp1024::BHP1024;
 mod tests {
     use super::*;
     use crate::{
-        Field,
-        Group,
-        Scalar,
-        test::create_native_field_vector,
-        types::native::{BHP256Native, BHP512Native, BHP768Native, BHP1024Native},
+        native::{FieldNative, GroupNative, LiteralNative, PlaintextNative, ScalarNative}, test::{create_native_field_vector, TEST_STRUCT}, types::native::{BHP1024Native, BHP256Native, BHP512Native, BHP768Native, CurrentNetwork}, Field, Group, Scalar
     };
-    use snarkvm_console::algorithms::{Commit, CommitUncompressed, Hash, HashUncompressed, ToBits};
-
+    use snarkvm_console::{algorithms::{Commit, CommitUncompressed, Hash, HashUncompressed, ToBits}, program::{Literal, Plaintext}, types::{Address, Boolean}};
+    
     use js_sys::Array;
+    use once_cell::sync::OnceCell;
+    use std::str::FromStr;
     use wasm_bindgen::JsValue;
     use wasm_bindgen_test::*;
 
@@ -124,5 +122,169 @@ mod tests {
             assert_eq!(commit_to_group_768, Group::from(native_commit_to_group_768));
             assert_eq!(commit_to_group_1024, Group::from(native_commit_to_group_1024));
         }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_literal_bhp_hashes_equal_native_hashes() {
+        // Create a field element and a scalar element.
+        let scalar = Scalar::from_string(SCALAR_FIELD_ELEMENT).unwrap();
+
+        // Create all exported BHP hasher instances.
+        let bhp256 = BHP256::new();
+        let bhp512 = BHP512::new();
+        let bhp768 = BHP768::new();
+        let bhp1024 = BHP1024::new();
+
+        // Create all native BHP hasher instances.
+        let native_bhp256 = BHP256Native::setup("AleoBHP256").unwrap();
+        let native_bhp512 = BHP512Native::setup("AleoBHP512").unwrap();
+        let native_bhp768 = BHP768Native::setup("AleoBHP768").unwrap();
+        let native_bhp1024 = BHP1024Native::setup("AleoBHP1024").unwrap();
+
+        let address = Address::zero();
+
+        let literals = vec![
+            Literal::Address(address),
+            Literal::Boolean(Boolean::new(false)),
+            Literal::Field(snarkvm_console::types::Field::from_u8(2)),
+            Literal::Group(
+                snarkvm_console::types::Group::from_str(
+                    "7243206743250892049702172909169115544952822465955921992746259936160368017976group",
+                )
+                .unwrap(),
+            ),
+            Literal::Scalar(snarkvm_console::types::Scalar::from_field_lossy(&snarkvm_console::types::Field::from_u8(
+                2,
+            ))),
+        ];
+
+        let native_literals = vec![
+            LiteralNative::Address(address),
+            LiteralNative::Boolean(Boolean::new(false)),
+            LiteralNative::Field(FieldNative::from_u8(2)),
+            LiteralNative::Group(
+                GroupNative::from_str(
+                    "7243206743250892049702172909169115544952822465955921992746259936160368017976group",
+                )
+                .unwrap(),
+            ),
+            LiteralNative::Scalar(ScalarNative::from_field_lossy(&snarkvm_console::types::Field::from_u8(2))),
+        ];
+
+        for i in 0..literals.len() {
+            let literal_bits = Plaintext::Literal(literals[i].clone(), OnceCell::new()).to_bits_le();
+            let bit_array = literal_bits.iter().map(|item| JsValue::from(*item)).collect::<Array>();
+
+            let hash_256 = bhp256.hash(bit_array.clone()).unwrap();
+            let hash_512 = bhp512.hash(bit_array.clone()).unwrap();
+            let hash_768 = bhp768.hash(bit_array.clone()).unwrap();
+            let hash_1024 = bhp1024.hash(bit_array.clone()).unwrap();
+            let hash_to_group_256 = bhp256.hash_to_group(bit_array.clone()).unwrap();
+            let hash_to_group_512 = bhp512.hash_to_group(bit_array.clone()).unwrap();
+            let hash_to_group_768 = bhp768.hash_to_group(bit_array.clone()).unwrap();
+            let hash_to_group_1024 = bhp1024.hash_to_group(bit_array.clone()).unwrap();
+            let commit_256 = bhp256.commit(bit_array.clone(), scalar.clone()).unwrap();
+            let commit_512 = bhp512.commit(bit_array.clone(), scalar.clone()).unwrap();
+            let commit_768 = bhp768.commit(bit_array.clone(), scalar.clone()).unwrap();
+            let commit_1024 = bhp1024.commit(bit_array.clone(), scalar.clone()).unwrap();
+            let commit_to_group_256 = bhp256.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+            let commit_to_group_512 = bhp512.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+            let commit_to_group_768 = bhp768.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+            let commit_to_group_1024 = bhp1024.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+
+            let native_bits = PlaintextNative::Literal(native_literals[i].clone(), OnceCell::new()).to_bits_le();
+
+            let native_hash_256 = native_bhp256.hash(&native_bits).unwrap();
+            let native_hash_512 = native_bhp512.hash(&native_bits).unwrap();
+            let native_hash_768 = native_bhp768.hash(&native_bits).unwrap();
+            let native_hash_1024 = native_bhp1024.hash(&native_bits).unwrap();
+            let native_hash_to_group_256 = native_bhp256.hash_uncompressed(&native_bits).unwrap();
+            let native_hash_to_group_512 = native_bhp512.hash_uncompressed(&native_bits).unwrap();
+            let native_hash_to_group_768 = native_bhp768.hash_uncompressed(&native_bits).unwrap();
+            let native_hash_to_group_1024 = native_bhp1024.hash_uncompressed(&native_bits).unwrap();
+            let native_commit_256 = native_bhp256.commit(&native_bits, &scalar).unwrap();
+            let native_commit_512 = native_bhp512.commit(&native_bits, &scalar).unwrap();
+            let native_commit_768 = native_bhp768.commit(&native_bits, &scalar).unwrap();
+            let native_commit_1024 = native_bhp1024.commit(&native_bits, &scalar).unwrap();
+            let native_commit_to_group_256 = native_bhp256.commit_uncompressed(&native_bits, &scalar).unwrap();
+            let native_commit_to_group_512 = native_bhp512.commit_uncompressed(&native_bits, &scalar).unwrap();
+            let native_commit_to_group_768 = native_bhp768.commit_uncompressed(&native_bits, &scalar).unwrap();
+            let native_commit_to_group_1024 = native_bhp1024.commit_uncompressed(&native_bits, &scalar).unwrap();
+
+            assert_eq!(hash_256, Field::from(native_hash_256));
+            assert_eq!(hash_512, Field::from(native_hash_512));
+            assert_eq!(hash_768, Field::from(native_hash_768));
+            assert_eq!(hash_1024, Field::from(native_hash_1024));
+            assert_eq!(hash_to_group_256, Group::from(native_hash_to_group_256));
+            assert_eq!(hash_to_group_512, Group::from(native_hash_to_group_512));
+            assert_eq!(hash_to_group_768, Group::from(native_hash_to_group_768));
+            assert_eq!(hash_to_group_1024, Group::from(native_hash_to_group_1024));
+            assert_eq!(commit_256, Field::from(native_commit_256));
+            assert_eq!(commit_512, Field::from(native_commit_512));
+            assert_eq!(commit_768, Field::from(native_commit_768));
+            assert_eq!(commit_1024, Field::from(native_commit_1024));
+            assert_eq!(commit_to_group_256, Group::from(native_commit_to_group_256));
+            assert_eq!(commit_to_group_512, Group::from(native_commit_to_group_512));
+            assert_eq!(commit_to_group_768, Group::from(native_commit_to_group_768));
+            assert_eq!(commit_to_group_1024, Group::from(native_commit_to_group_1024));
+        }
+
+        let struct_pt: Plaintext<CurrentNetwork> = Plaintext::from_str(TEST_STRUCT).unwrap();
+        let struct_bits = struct_pt.to_bits_le();
+        let bit_array = struct_bits.iter().map(|item| JsValue::from(*item)).collect::<Array>();
+
+        let hash_256 = bhp256.hash(bit_array.clone()).unwrap();
+        let hash_512 = bhp512.hash(bit_array.clone()).unwrap();
+        let hash_768 = bhp768.hash(bit_array.clone()).unwrap();
+        let hash_1024 = bhp1024.hash(bit_array.clone()).unwrap();
+        let hash_to_group_256 = bhp256.hash_to_group(bit_array.clone()).unwrap();
+        let hash_to_group_512 = bhp512.hash_to_group(bit_array.clone()).unwrap();
+        let hash_to_group_768 = bhp768.hash_to_group(bit_array.clone()).unwrap();
+        let hash_to_group_1024 = bhp1024.hash_to_group(bit_array.clone()).unwrap();
+        let commit_256 = bhp256.commit(bit_array.clone(), scalar.clone()).unwrap();
+        let commit_512 = bhp512.commit(bit_array.clone(), scalar.clone()).unwrap();
+        let commit_768 = bhp768.commit(bit_array.clone(), scalar.clone()).unwrap();
+        let commit_1024 = bhp1024.commit(bit_array.clone(), scalar.clone()).unwrap();
+        let commit_to_group_256 = bhp256.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+        let commit_to_group_512 = bhp512.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+        let commit_to_group_768 = bhp768.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+        let commit_to_group_1024 = bhp1024.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+
+        let native_struct_pt = PlaintextNative::from_str(TEST_STRUCT).unwrap();
+        let native_struct_bits = native_struct_pt.to_bits_le();
+
+        let native_hash_256 = native_bhp256.hash(&native_struct_bits).unwrap();
+        let native_hash_512 = native_bhp512.hash(&native_struct_bits).unwrap();
+        let native_hash_768 = native_bhp768.hash(&native_struct_bits).unwrap();
+        let native_hash_1024 = native_bhp1024.hash(&native_struct_bits).unwrap();
+        let native_hash_to_group_256 = native_bhp256.hash_uncompressed(&native_struct_bits).unwrap();
+        let native_hash_to_group_512 = native_bhp512.hash_uncompressed(&native_struct_bits).unwrap();
+        let native_hash_to_group_768 = native_bhp768.hash_uncompressed(&native_struct_bits).unwrap();
+        let native_hash_to_group_1024 = native_bhp1024.hash_uncompressed(&native_struct_bits).unwrap();
+        let native_commit_256 = native_bhp256.commit(&native_struct_bits, &scalar).unwrap();
+        let native_commit_512 = native_bhp512.commit(&native_struct_bits, &scalar).unwrap();
+        let native_commit_768 = native_bhp768.commit(&native_struct_bits, &scalar).unwrap();
+        let native_commit_1024 = native_bhp1024.commit(&native_struct_bits, &scalar).unwrap();
+        let native_commit_to_group_256 = native_bhp256.commit_uncompressed(&native_struct_bits, &scalar).unwrap();
+        let native_commit_to_group_512 = native_bhp512.commit_uncompressed(&native_struct_bits, &scalar).unwrap();
+        let native_commit_to_group_768 = native_bhp768.commit_uncompressed(&native_struct_bits, &scalar).unwrap();
+        let native_commit_to_group_1024 = native_bhp1024.commit_uncompressed(&native_struct_bits, &scalar).unwrap();
+
+        assert_eq!(hash_256, Field::from(native_hash_256));
+        assert_eq!(hash_512, Field::from(native_hash_512));
+        assert_eq!(hash_768, Field::from(native_hash_768));
+        assert_eq!(hash_1024, Field::from(native_hash_1024));
+        assert_eq!(hash_to_group_256, Group::from(native_hash_to_group_256));
+        assert_eq!(hash_to_group_512, Group::from(native_hash_to_group_512));
+        assert_eq!(hash_to_group_768, Group::from(native_hash_to_group_768));
+        assert_eq!(hash_to_group_1024, Group::from(native_hash_to_group_1024));
+        assert_eq!(commit_256, Field::from(native_commit_256));
+        assert_eq!(commit_512, Field::from(native_commit_512));
+        assert_eq!(commit_768, Field::from(native_commit_768));
+        assert_eq!(commit_1024, Field::from(native_commit_1024));
+        assert_eq!(commit_to_group_256, Group::from(native_commit_to_group_256));
+        assert_eq!(commit_to_group_512, Group::from(native_commit_to_group_512));
+        assert_eq!(commit_to_group_768, Group::from(native_commit_to_group_768));
+        assert_eq!(commit_to_group_1024, Group::from(native_commit_to_group_1024));
     }
 }

--- a/wasm/src/algorithms/bhp/mod.rs
+++ b/wasm/src/algorithms/bhp/mod.rs
@@ -30,10 +30,17 @@ pub use bhp1024::BHP1024;
 mod tests {
     use super::*;
     use crate::{
-        native::{FieldNative, GroupNative, LiteralNative, PlaintextNative, ScalarNative}, test::{create_native_field_vector, TEST_STRUCT}, types::native::{BHP1024Native, BHP256Native, BHP512Native, BHP768Native, CurrentNetwork}, Field, Group, Scalar
+        Address,
+        Field,
+        Group,
+        Plaintext,
+        Scalar,
+        native::{FieldNative, GroupNative, LiteralNative, PlaintextNative, ScalarNative},
+        test::{TEST_STRUCT, create_native_field_vector},
+        types::native::{BHP256Native, BHP512Native, BHP768Native, BHP1024Native},
     };
-    use snarkvm_console::{algorithms::{Commit, CommitUncompressed, Hash, HashUncompressed, ToBits}, program::{Literal, Plaintext}, types::{Address, Boolean}};
-    
+    use snarkvm_console::algorithms::{Commit, CommitUncompressed, Hash, HashUncompressed, ToBits};
+
     use js_sys::Array;
     use once_cell::sync::OnceCell;
     use std::str::FromStr;
@@ -141,26 +148,21 @@ mod tests {
         let native_bhp768 = BHP768Native::setup("AleoBHP768").unwrap();
         let native_bhp1024 = BHP1024Native::setup("AleoBHP1024").unwrap();
 
-        let address = Address::zero();
+        let address = Address::from_string("aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc");
 
         let literals = vec![
-            Literal::Address(address),
-            Literal::Boolean(Boolean::new(false)),
-            Literal::Field(snarkvm_console::types::Field::from_u8(2)),
-            Literal::Group(
-                snarkvm_console::types::Group::from_str(
-                    "7243206743250892049702172909169115544952822465955921992746259936160368017976group",
-                )
-                .unwrap(),
-            ),
-            Literal::Scalar(snarkvm_console::types::Scalar::from_field_lossy(&snarkvm_console::types::Field::from_u8(
-                2,
-            ))),
+            address.to_plaintext(),
+            Field::from_string("2field").unwrap().to_plaintext(),
+            Group::from_string("7243206743250892049702172909169115544952822465955921992746259936160368017976group")
+                .unwrap()
+                .to_plaintext(),
+            Scalar::from_string("836504693989570607341914239820012911582004515616146791081874852343183183566scalar")
+                .unwrap()
+                .to_plaintext(),
         ];
 
         let native_literals = vec![
-            LiteralNative::Address(address),
-            LiteralNative::Boolean(Boolean::new(false)),
+            LiteralNative::Address(address.into()),
             LiteralNative::Field(FieldNative::from_u8(2)),
             LiteralNative::Group(
                 GroupNative::from_str(
@@ -168,29 +170,33 @@ mod tests {
                 )
                 .unwrap(),
             ),
-            LiteralNative::Scalar(ScalarNative::from_field_lossy(&snarkvm_console::types::Field::from_u8(2))),
+            LiteralNative::Scalar(
+                ScalarNative::from_str(
+                    "836504693989570607341914239820012911582004515616146791081874852343183183566scalar",
+                )
+                .unwrap(),
+            ),
         ];
 
         for i in 0..literals.len() {
-            let literal_bits = Plaintext::Literal(literals[i].clone(), OnceCell::new()).to_bits_le();
-            let bit_array = literal_bits.iter().map(|item| JsValue::from(*item)).collect::<Array>();
+            let literal_bits = literals[i].to_bits_le();
 
-            let hash_256 = bhp256.hash(bit_array.clone()).unwrap();
-            let hash_512 = bhp512.hash(bit_array.clone()).unwrap();
-            let hash_768 = bhp768.hash(bit_array.clone()).unwrap();
-            let hash_1024 = bhp1024.hash(bit_array.clone()).unwrap();
-            let hash_to_group_256 = bhp256.hash_to_group(bit_array.clone()).unwrap();
-            let hash_to_group_512 = bhp512.hash_to_group(bit_array.clone()).unwrap();
-            let hash_to_group_768 = bhp768.hash_to_group(bit_array.clone()).unwrap();
-            let hash_to_group_1024 = bhp1024.hash_to_group(bit_array.clone()).unwrap();
-            let commit_256 = bhp256.commit(bit_array.clone(), scalar.clone()).unwrap();
-            let commit_512 = bhp512.commit(bit_array.clone(), scalar.clone()).unwrap();
-            let commit_768 = bhp768.commit(bit_array.clone(), scalar.clone()).unwrap();
-            let commit_1024 = bhp1024.commit(bit_array.clone(), scalar.clone()).unwrap();
-            let commit_to_group_256 = bhp256.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
-            let commit_to_group_512 = bhp512.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
-            let commit_to_group_768 = bhp768.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
-            let commit_to_group_1024 = bhp1024.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+            let hash_256 = bhp256.hash(literal_bits.clone()).unwrap();
+            let hash_512 = bhp512.hash(literal_bits.clone()).unwrap();
+            let hash_768 = bhp768.hash(literal_bits.clone()).unwrap();
+            let hash_1024 = bhp1024.hash(literal_bits.clone()).unwrap();
+            let hash_to_group_256 = bhp256.hash_to_group(literal_bits.clone()).unwrap();
+            let hash_to_group_512 = bhp512.hash_to_group(literal_bits.clone()).unwrap();
+            let hash_to_group_768 = bhp768.hash_to_group(literal_bits.clone()).unwrap();
+            let hash_to_group_1024 = bhp1024.hash_to_group(literal_bits.clone()).unwrap();
+            let commit_256 = bhp256.commit(literal_bits.clone(), scalar.clone()).unwrap();
+            let commit_512 = bhp512.commit(literal_bits.clone(), scalar.clone()).unwrap();
+            let commit_768 = bhp768.commit(literal_bits.clone(), scalar.clone()).unwrap();
+            let commit_1024 = bhp1024.commit(literal_bits.clone(), scalar.clone()).unwrap();
+            let commit_to_group_256 = bhp256.commit_to_group(literal_bits.clone(), scalar.clone()).unwrap();
+            let commit_to_group_512 = bhp512.commit_to_group(literal_bits.clone(), scalar.clone()).unwrap();
+            let commit_to_group_768 = bhp768.commit_to_group(literal_bits.clone(), scalar.clone()).unwrap();
+            let commit_to_group_1024 = bhp1024.commit_to_group(literal_bits.clone(), scalar.clone()).unwrap();
 
             let native_bits = PlaintextNative::Literal(native_literals[i].clone(), OnceCell::new()).to_bits_le();
 
@@ -229,26 +235,25 @@ mod tests {
             assert_eq!(commit_to_group_1024, Group::from(native_commit_to_group_1024));
         }
 
-        let struct_pt: Plaintext<CurrentNetwork> = Plaintext::from_str(TEST_STRUCT).unwrap();
+        let struct_pt: Plaintext = Plaintext::from_string(TEST_STRUCT).unwrap();
         let struct_bits = struct_pt.to_bits_le();
-        let bit_array = struct_bits.iter().map(|item| JsValue::from(*item)).collect::<Array>();
 
-        let hash_256 = bhp256.hash(bit_array.clone()).unwrap();
-        let hash_512 = bhp512.hash(bit_array.clone()).unwrap();
-        let hash_768 = bhp768.hash(bit_array.clone()).unwrap();
-        let hash_1024 = bhp1024.hash(bit_array.clone()).unwrap();
-        let hash_to_group_256 = bhp256.hash_to_group(bit_array.clone()).unwrap();
-        let hash_to_group_512 = bhp512.hash_to_group(bit_array.clone()).unwrap();
-        let hash_to_group_768 = bhp768.hash_to_group(bit_array.clone()).unwrap();
-        let hash_to_group_1024 = bhp1024.hash_to_group(bit_array.clone()).unwrap();
-        let commit_256 = bhp256.commit(bit_array.clone(), scalar.clone()).unwrap();
-        let commit_512 = bhp512.commit(bit_array.clone(), scalar.clone()).unwrap();
-        let commit_768 = bhp768.commit(bit_array.clone(), scalar.clone()).unwrap();
-        let commit_1024 = bhp1024.commit(bit_array.clone(), scalar.clone()).unwrap();
-        let commit_to_group_256 = bhp256.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
-        let commit_to_group_512 = bhp512.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
-        let commit_to_group_768 = bhp768.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
-        let commit_to_group_1024 = bhp1024.commit_to_group(bit_array.clone(), scalar.clone()).unwrap();
+        let hash_256 = bhp256.hash(struct_bits.clone()).unwrap();
+        let hash_512 = bhp512.hash(struct_bits.clone()).unwrap();
+        let hash_768 = bhp768.hash(struct_bits.clone()).unwrap();
+        let hash_1024 = bhp1024.hash(struct_bits.clone()).unwrap();
+        let hash_to_group_256 = bhp256.hash_to_group(struct_bits.clone()).unwrap();
+        let hash_to_group_512 = bhp512.hash_to_group(struct_bits.clone()).unwrap();
+        let hash_to_group_768 = bhp768.hash_to_group(struct_bits.clone()).unwrap();
+        let hash_to_group_1024 = bhp1024.hash_to_group(struct_bits.clone()).unwrap();
+        let commit_256 = bhp256.commit(struct_bits.clone(), scalar.clone()).unwrap();
+        let commit_512 = bhp512.commit(struct_bits.clone(), scalar.clone()).unwrap();
+        let commit_768 = bhp768.commit(struct_bits.clone(), scalar.clone()).unwrap();
+        let commit_1024 = bhp1024.commit(struct_bits.clone(), scalar.clone()).unwrap();
+        let commit_to_group_256 = bhp256.commit_to_group(struct_bits.clone(), scalar.clone()).unwrap();
+        let commit_to_group_512 = bhp512.commit_to_group(struct_bits.clone(), scalar.clone()).unwrap();
+        let commit_to_group_768 = bhp768.commit_to_group(struct_bits.clone(), scalar.clone()).unwrap();
+        let commit_to_group_1024 = bhp1024.commit_to_group(struct_bits.clone(), scalar.clone()).unwrap();
 
         let native_struct_pt = PlaintextNative::from_str(TEST_STRUCT).unwrap();
         let native_struct_bits = native_struct_pt.to_bits_le();

--- a/wasm/src/algorithms/bhp/mod.rs
+++ b/wasm/src/algorithms/bhp/mod.rs
@@ -35,7 +35,8 @@ mod tests {
         Group,
         Plaintext,
         Scalar,
-        native::{FieldNative, GroupNative, LiteralNative, PlaintextNative, ScalarNative},
+        Signature,
+        native::{FieldNative, GroupNative, LiteralNative, PlaintextNative, ScalarNative, SignatureNative},
         test::{TEST_STRUCT, create_native_field_vector},
         types::native::{BHP256Native, BHP512Native, BHP768Native, BHP1024Native},
     };
@@ -159,6 +160,7 @@ mod tests {
             Scalar::from_string("836504693989570607341914239820012911582004515616146791081874852343183183566scalar")
                 .unwrap()
                 .to_plaintext(),
+            Signature::from_string("sign1lcpxtgqkp238x45fk79lkx5xz7sx37f56wl0hyemhv78dgzxyspykg6u26lx2a02tvat6zaflx530qtnme34gh702wclwr20rdxrsqcl7shvwsyhygt2yvkgzeq7zz2rdat4rrsr0cd9kwm6jddjcs9lps8s80v35rwvtkgg2gxprf4dge0tcet3pe7nfxupkvfuvh3sw2gpyv0km46").to_plaintext(),
         ];
 
         let native_literals = vec![
@@ -176,6 +178,7 @@ mod tests {
                 )
                 .unwrap(),
             ),
+            LiteralNative::Signature(Box::new(SignatureNative::from_str("sign1lcpxtgqkp238x45fk79lkx5xz7sx37f56wl0hyemhv78dgzxyspykg6u26lx2a02tvat6zaflx530qtnme34gh702wclwr20rdxrsqcl7shvwsyhygt2yvkgzeq7zz2rdat4rrsr0cd9kwm6jddjcs9lps8s80v35rwvtkgg2gxprf4dge0tcet3pe7nfxupkvfuvh3sw2gpyv0km46").unwrap()))
         ];
 
         for i in 0..literals.len() {

--- a/wasm/src/algorithms/poseidon/mod.rs
+++ b/wasm/src/algorithms/poseidon/mod.rs
@@ -27,13 +27,20 @@ pub use poseidon8::Poseidon8;
 mod tests {
     use super::*;
     use crate::{
-        js_array_from_fields, native::{GroupNative, LiteralNative, PlaintextNative, ScalarNative}, test::TEST_STRUCT, types::native::{FieldNative, Poseidon2Native, Poseidon4Native, Poseidon8Native}, utilities::test::create_native_field_vector, Field, Group, Scalar
+        Address,
+        Field,
+        Group,
+        Plaintext,
+        Scalar,
+        js_array_from_fields,
+        native::{GroupNative, LiteralNative, PlaintextNative, ScalarNative},
+        test::TEST_STRUCT,
+        types::native::{FieldNative, Poseidon2Native, Poseidon4Native, Poseidon8Native},
+        utilities::test::create_native_field_vector,
     };
     use snarkvm_console::{
         algorithms::{Hash, HashMany, HashToGroup, HashToScalar},
         prelude::ToFields,
-        program::{Literal, Plaintext},
-        types::{Address, Boolean},
     };
 
     use once_cell::sync::OnceCell;
@@ -132,26 +139,21 @@ mod tests {
         let native_poseidon4 = Poseidon4Native::setup("AleoPoseidon4").unwrap();
         let native_poseidon8 = Poseidon8Native::setup("AleoPoseidon8").unwrap();
 
-        let address = Address::zero();
+        let address = Address::from_string("aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc");
 
         let literals = vec![
-            Literal::Address(address),
-            Literal::Boolean(Boolean::new(false)),
-            Literal::Field(snarkvm_console::types::Field::from_u8(2)),
-            Literal::Group(
-                snarkvm_console::types::Group::from_str(
-                    "7243206743250892049702172909169115544952822465955921992746259936160368017976group",
-                )
-                .unwrap(),
-            ),
-            Literal::Scalar(snarkvm_console::types::Scalar::from_field_lossy(&snarkvm_console::types::Field::from_u8(
-                2,
-            ))),
+            address.to_plaintext(),
+            Field::from_string("2field").unwrap().to_plaintext(),
+            Group::from_string("7243206743250892049702172909169115544952822465955921992746259936160368017976group")
+                .unwrap()
+                .to_plaintext(),
+            Scalar::from_string("836504693989570607341914239820012911582004515616146791081874852343183183566scalar")
+                .unwrap()
+                .to_plaintext(),
         ];
 
         let native_literals = vec![
-            LiteralNative::Address(address),
-            LiteralNative::Boolean(Boolean::new(false)),
+            LiteralNative::Address(address.into()),
             LiteralNative::Field(FieldNative::from_u8(2)),
             LiteralNative::Group(
                 GroupNative::from_str(
@@ -159,14 +161,19 @@ mod tests {
                 )
                 .unwrap(),
             ),
-            LiteralNative::Scalar(ScalarNative::from_field_lossy(&snarkvm_console::types::Field::from_u8(2))),
+            LiteralNative::Scalar(
+                ScalarNative::from_str(
+                    "836504693989570607341914239820012911582004515616146791081874852343183183566scalar",
+                )
+                .unwrap(),
+            ),
         ];
 
         for i in 0..literals.len() {
-            let literal_fields = Plaintext::Literal(literals[i].clone(), OnceCell::new()).to_fields().unwrap();
-            let hash2 = poseidon2.hash(js_array_from_fields!(&literal_fields)).unwrap();
-            let hash4 = poseidon4.hash(js_array_from_fields!(&literal_fields)).unwrap();
-            let hash8 = poseidon8.hash(js_array_from_fields!(&literal_fields)).unwrap();
+            let literal_plaintext = literals[i].clone();
+            let hash2 = poseidon2.hash(literal_plaintext.clone().to_fields().unwrap()).unwrap();
+            let hash4 = poseidon4.hash(literal_plaintext.clone().to_fields().unwrap()).unwrap();
+            let hash8 = poseidon8.hash(literal_plaintext.clone().to_fields().unwrap()).unwrap();
 
             let native_fields =
                 PlaintextNative::Literal(native_literals[i].clone(), OnceCell::new()).to_fields().unwrap();
@@ -179,12 +186,11 @@ mod tests {
             assert_eq!(hash8, Field::from(native_hash8));
         }
 
-        let struct_pt = Plaintext::from_str(TEST_STRUCT).unwrap();
-        let struct_fields = struct_pt.to_fields().unwrap();
+        let struct_pt = Plaintext::from_string(TEST_STRUCT).unwrap();
 
-        let hash2 = poseidon2.hash(js_array_from_fields!(&struct_fields)).unwrap();
-        let hash4 = poseidon4.hash(js_array_from_fields!(&struct_fields)).unwrap();
-        let hash8 = poseidon8.hash(js_array_from_fields!(&struct_fields)).unwrap();
+        let hash2 = poseidon2.hash(struct_pt.clone().to_fields().unwrap()).unwrap();
+        let hash4 = poseidon4.hash(struct_pt.clone().to_fields().unwrap()).unwrap();
+        let hash8 = poseidon8.hash(struct_pt.clone().to_fields().unwrap()).unwrap();
 
         let native_struct_pt = PlaintextNative::from_str(TEST_STRUCT).unwrap();
         let native_struct_fields = native_struct_pt.to_fields().unwrap();

--- a/wasm/src/algorithms/poseidon/mod.rs
+++ b/wasm/src/algorithms/poseidon/mod.rs
@@ -32,8 +32,9 @@ mod tests {
         Group,
         Plaintext,
         Scalar,
+        Signature,
         js_array_from_fields,
-        native::{GroupNative, LiteralNative, PlaintextNative, ScalarNative},
+        native::{GroupNative, LiteralNative, PlaintextNative, ScalarNative, SignatureNative},
         test::TEST_STRUCT,
         types::native::{FieldNative, Poseidon2Native, Poseidon4Native, Poseidon8Native},
         utilities::test::create_native_field_vector,
@@ -150,6 +151,7 @@ mod tests {
             Scalar::from_string("836504693989570607341914239820012911582004515616146791081874852343183183566scalar")
                 .unwrap()
                 .to_plaintext(),
+            Signature::from_string("sign1lcpxtgqkp238x45fk79lkx5xz7sx37f56wl0hyemhv78dgzxyspykg6u26lx2a02tvat6zaflx530qtnme34gh702wclwr20rdxrsqcl7shvwsyhygt2yvkgzeq7zz2rdat4rrsr0cd9kwm6jddjcs9lps8s80v35rwvtkgg2gxprf4dge0tcet3pe7nfxupkvfuvh3sw2gpyv0km46").to_plaintext(),
         ];
 
         let native_literals = vec![
@@ -167,6 +169,7 @@ mod tests {
                 )
                 .unwrap(),
             ),
+            LiteralNative::Signature(Box::new(SignatureNative::from_str("sign1lcpxtgqkp238x45fk79lkx5xz7sx37f56wl0hyemhv78dgzxyspykg6u26lx2a02tvat6zaflx530qtnme34gh702wclwr20rdxrsqcl7shvwsyhygt2yvkgzeq7zz2rdat4rrsr0cd9kwm6jddjcs9lps8s80v35rwvtkgg2gxprf4dge0tcet3pe7nfxupkvfuvh3sw2gpyv0km46").unwrap()))
         ];
 
         for i in 0..literals.len() {

--- a/wasm/src/algorithms/poseidon/mod.rs
+++ b/wasm/src/algorithms/poseidon/mod.rs
@@ -30,8 +30,9 @@ mod tests {
         Field,
         Group,
         Scalar,
+        js_array_from_fields,
         types::native::{FieldNative, Poseidon2Native, Poseidon4Native, Poseidon8Native},
-        utilities::test::{create_native_field_vector, js_array_from_fields},
+        utilities::test::create_native_field_vector,
     };
     use snarkvm_console::algorithms::{Hash, HashMany, HashToGroup, HashToScalar};
 
@@ -56,31 +57,31 @@ mod tests {
             let native_field_array = create_native_field_vector(Some(*count));
 
             // Hash the field array using all Poseidon hasher instances.
-            let hash_2 = poseidon2.hash(js_array_from_fields(&native_field_array)).unwrap();
-            let hash_4 = poseidon4.hash(js_array_from_fields(&native_field_array)).unwrap();
-            let hash_8 = poseidon8.hash(js_array_from_fields(&native_field_array)).unwrap();
-            let hash_2_scalar = poseidon2.hash_to_scalar(js_array_from_fields(&native_field_array)).unwrap();
-            let hash_4_scalar = poseidon4.hash_to_scalar(js_array_from_fields(&native_field_array)).unwrap();
-            let hash_8_scalar = poseidon8.hash_to_scalar(js_array_from_fields(&native_field_array)).unwrap();
-            let hash_2_group = poseidon2.hash_to_group(js_array_from_fields(&native_field_array)).unwrap();
-            let hash_4_group = poseidon4.hash_to_group(js_array_from_fields(&native_field_array)).unwrap();
-            let hash_8_group = poseidon8.hash_to_group(js_array_from_fields(&native_field_array)).unwrap();
+            let hash_2 = poseidon2.hash(js_array_from_fields!(&native_field_array)).unwrap();
+            let hash_4 = poseidon4.hash(js_array_from_fields!(&native_field_array)).unwrap();
+            let hash_8 = poseidon8.hash(js_array_from_fields!(&native_field_array)).unwrap();
+            let hash_2_scalar = poseidon2.hash_to_scalar(js_array_from_fields!(&native_field_array)).unwrap();
+            let hash_4_scalar = poseidon4.hash_to_scalar(js_array_from_fields!(&native_field_array)).unwrap();
+            let hash_8_scalar = poseidon8.hash_to_scalar(js_array_from_fields!(&native_field_array)).unwrap();
+            let hash_2_group = poseidon2.hash_to_group(js_array_from_fields!(&native_field_array)).unwrap();
+            let hash_4_group = poseidon4.hash_to_group(js_array_from_fields!(&native_field_array)).unwrap();
+            let hash_8_group = poseidon8.hash_to_group(js_array_from_fields!(&native_field_array)).unwrap();
             let hash_2_many = poseidon2
-                .hash_many(js_array_from_fields(&native_field_array), 2)
+                .hash_many(js_array_from_fields!(&native_field_array), 2)
                 .unwrap()
                 .to_vec()
                 .into_iter()
                 .map(|item| *Field::try_from_js_value(item).unwrap())
                 .collect::<Vec<FieldNative>>();
             let hash_4_many = poseidon4
-                .hash_many(js_array_from_fields(&native_field_array), 2)
+                .hash_many(js_array_from_fields!(&native_field_array), 2)
                 .unwrap()
                 .to_vec()
                 .into_iter()
                 .map(|item| *Field::try_from_js_value(item).unwrap())
                 .collect::<Vec<FieldNative>>();
             let hash_8_many = poseidon8
-                .hash_many(js_array_from_fields(&native_field_array), 2)
+                .hash_many(js_array_from_fields!(&native_field_array), 2)
                 .unwrap()
                 .to_vec()
                 .into_iter()

--- a/wasm/src/algorithms/poseidon/mod.rs
+++ b/wasm/src/algorithms/poseidon/mod.rs
@@ -27,15 +27,17 @@ pub use poseidon8::Poseidon8;
 mod tests {
     use super::*;
     use crate::{
-        Field,
-        Group,
-        Scalar,
-        js_array_from_fields,
-        types::native::{FieldNative, Poseidon2Native, Poseidon4Native, Poseidon8Native},
-        utilities::test::create_native_field_vector,
+        js_array_from_fields, native::{GroupNative, LiteralNative, PlaintextNative, ScalarNative}, test::TEST_STRUCT, types::native::{FieldNative, Poseidon2Native, Poseidon4Native, Poseidon8Native}, utilities::test::create_native_field_vector, Field, Group, Scalar
     };
-    use snarkvm_console::algorithms::{Hash, HashMany, HashToGroup, HashToScalar};
+    use snarkvm_console::{
+        algorithms::{Hash, HashMany, HashToGroup, HashToScalar},
+        prelude::ToFields,
+        program::{Literal, Plaintext},
+        types::{Address, Boolean},
+    };
 
+    use once_cell::sync::OnceCell;
+    use std::str::FromStr;
     use wasm_bindgen::convert::TryFromJsValue;
     use wasm_bindgen_test::*;
 
@@ -116,5 +118,83 @@ mod tests {
             assert_eq!(hash_4_many, native_hash_4_many);
             assert_eq!(hash_8_many, native_hash_8_many);
         }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_literal_psd_hashes_equal_native_hashes() {
+        // Create all instances of exported hasher structs.
+        let poseidon2 = Poseidon2::new();
+        let poseidon4 = Poseidon4::new();
+        let poseidon8 = Poseidon8::new();
+
+        // Create native instances of hasher structs.
+        let native_poseidon2 = Poseidon2Native::setup("AleoPoseidon2").unwrap();
+        let native_poseidon4 = Poseidon4Native::setup("AleoPoseidon4").unwrap();
+        let native_poseidon8 = Poseidon8Native::setup("AleoPoseidon8").unwrap();
+
+        let address = Address::zero();
+
+        let literals = vec![
+            Literal::Address(address),
+            Literal::Boolean(Boolean::new(false)),
+            Literal::Field(snarkvm_console::types::Field::from_u8(2)),
+            Literal::Group(
+                snarkvm_console::types::Group::from_str(
+                    "7243206743250892049702172909169115544952822465955921992746259936160368017976group",
+                )
+                .unwrap(),
+            ),
+            Literal::Scalar(snarkvm_console::types::Scalar::from_field_lossy(&snarkvm_console::types::Field::from_u8(
+                2,
+            ))),
+        ];
+
+        let native_literals = vec![
+            LiteralNative::Address(address),
+            LiteralNative::Boolean(Boolean::new(false)),
+            LiteralNative::Field(FieldNative::from_u8(2)),
+            LiteralNative::Group(
+                GroupNative::from_str(
+                    "7243206743250892049702172909169115544952822465955921992746259936160368017976group",
+                )
+                .unwrap(),
+            ),
+            LiteralNative::Scalar(ScalarNative::from_field_lossy(&snarkvm_console::types::Field::from_u8(2))),
+        ];
+
+        for i in 0..literals.len() {
+            let literal_fields = Plaintext::Literal(literals[i].clone(), OnceCell::new()).to_fields().unwrap();
+            let hash2 = poseidon2.hash(js_array_from_fields!(&literal_fields)).unwrap();
+            let hash4 = poseidon4.hash(js_array_from_fields!(&literal_fields)).unwrap();
+            let hash8 = poseidon8.hash(js_array_from_fields!(&literal_fields)).unwrap();
+
+            let native_fields =
+                PlaintextNative::Literal(native_literals[i].clone(), OnceCell::new()).to_fields().unwrap();
+            let native_hash2 = native_poseidon2.hash(&native_fields).unwrap();
+            let native_hash4 = native_poseidon4.hash(&native_fields).unwrap();
+            let native_hash8 = native_poseidon8.hash(&native_fields).unwrap();
+
+            assert_eq!(hash2, Field::from(native_hash2));
+            assert_eq!(hash4, Field::from(native_hash4));
+            assert_eq!(hash8, Field::from(native_hash8));
+        }
+
+        let struct_pt = Plaintext::from_str(TEST_STRUCT).unwrap();
+        let struct_fields = struct_pt.to_fields().unwrap();
+
+        let hash2 = poseidon2.hash(js_array_from_fields!(&struct_fields)).unwrap();
+        let hash4 = poseidon4.hash(js_array_from_fields!(&struct_fields)).unwrap();
+        let hash8 = poseidon8.hash(js_array_from_fields!(&struct_fields)).unwrap();
+
+        let native_struct_pt = PlaintextNative::from_str(TEST_STRUCT).unwrap();
+        let native_struct_fields = native_struct_pt.to_fields().unwrap();
+
+        let native_hash2 = native_poseidon2.hash(&native_struct_fields).unwrap();
+        let native_hash4 = native_poseidon4.hash(&native_struct_fields).unwrap();
+        let native_hash8 = native_poseidon8.hash(&native_struct_fields).unwrap();
+
+        assert_eq!(hash2, Field::from(native_hash2));
+        assert_eq!(hash4, Field::from(native_hash4));
+        assert_eq!(hash8, Field::from(native_hash8));
     }
 }

--- a/wasm/src/programs/data/ciphertext.rs
+++ b/wasm/src/programs/data/ciphertext.rs
@@ -19,11 +19,17 @@ use crate::{
     Group,
     Plaintext,
     ViewKey,
+    from_js_typed_array,
     native::{CiphertextNative, CurrentNetwork, FieldNative, FromBytes, IdentifierNative, ProgramIDNative, ToBytes},
+    to_bits_array_le,
 };
-use snarkvm_console::{network::Network, program::compute_function_id, types::U16};
+use snarkvm_console::{
+    network::Network,
+    program::{FromBits, ToBits, compute_function_id},
+    types::U16,
+};
 
-use js_sys::Uint8Array;
+use js_sys::{Array, Uint8Array};
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -115,6 +121,31 @@ impl Ciphertext {
     #[wasm_bindgen(js_name = fromBytesLe)]
     pub fn from_bytes_le(bytes: Uint8Array) -> Result<Ciphertext, String> {
         Ok(Ciphertext(CiphertextNative::from_bytes_le(&bytes.to_vec()).map_err(|e| e.to_string())?))
+    }
+
+    /// Get the left endian byte array representation of the ciphertext.
+    #[wasm_bindgen(js_name = toBytesLe)]
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let rust_bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
+        Ok(Uint8Array::from(rust_bytes.as_slice()))
+    }
+
+    /// Get a ciphertext object from a series of bits represented as a boolean array.
+    ///
+    /// @param {Array} bits A left endian boolean array representing the bits of the ciphertext.
+    ///
+    /// @returns {Ciphertext} The ciphertext object.
+    #[wasm_bindgen(js_name = "fromBitsLe")]
+    pub fn from_bits_le(bits: Array) -> Result<Ciphertext, String> {
+        let rust_bits = from_js_typed_array!(bits, as_bool, "boolean")?;
+        let native = CiphertextNative::from_bits_le(&rust_bits).map_err(|e| e.to_string())?;
+        Ok(Ciphertext(native))
+    }
+
+    /// Get the left endian boolean array representation of the bits of the ciphertext.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
     }
 
     /// Deserialize a Ciphertext string into a Ciphertext object.

--- a/wasm/src/programs/data/ciphertext.rs
+++ b/wasm/src/programs/data/ciphertext.rs
@@ -20,18 +20,21 @@ use crate::{
     Plaintext,
     ViewKey,
     from_js_typed_array,
+    from_wasm_object_array,
+    js_array_from_fields,
     native::{CiphertextNative, CurrentNetwork, FieldNative, FromBytes, IdentifierNative, ProgramIDNative, ToBytes},
     to_bits_array_le,
 };
+
 use snarkvm_console::{
     network::Network,
-    program::{FromBits, ToBits, compute_function_id},
+    program::{FromBits, FromFields, ToBits, ToFields, compute_function_id},
     types::U16,
 };
 
 use js_sys::{Array, Uint8Array};
 use std::{ops::Deref, str::FromStr};
-use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{convert::TryFromJsValue, prelude::wasm_bindgen};
 
 /// SnarkVM Ciphertext object. A Ciphertext represents an symmetrically encrypted plaintext. This
 /// object provides decryption methods to recover the plaintext from the ciphertext (given the
@@ -146,6 +149,26 @@ impl Ciphertext {
     #[wasm_bindgen(js_name = "toBitsLe")]
     pub fn to_bits_le(&self) -> Array {
         to_bits_array_le!(self)
+    }
+
+    /// Get a ciphertext object from an array of fields.
+    ///
+    /// @param {Array} fields An array of fields.
+    ///
+    /// @returns {Ciphertext} The ciphertext object.
+    #[wasm_bindgen(js_name = "fromFields")]
+    pub fn from_fields(fields: Array) -> Result<Ciphertext, String> {
+        let native_fields = from_wasm_object_array!(fields, Field)?;
+        let native = CiphertextNative::from_fields(&native_fields).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
+    /// Get the field array representation of the ciphertext.
+    #[wasm_bindgen(js_name = "toFields")]
+    pub fn to_fields(&self) -> Result<Array, String> {
+        let native = self.0.clone();
+        let native_fields = native.to_fields().map_err(|e| e.to_string())?;
+        Ok(js_array_from_fields!(&native_fields))
     }
 
     /// Deserialize a Ciphertext string into a Ciphertext object.

--- a/wasm/src/programs/data/ciphertext.rs
+++ b/wasm/src/programs/data/ciphertext.rs
@@ -25,7 +25,6 @@ use crate::{
     native::{CiphertextNative, CurrentNetwork, FieldNative, FromBytes, IdentifierNative, ProgramIDNative, ToBytes},
     to_bits_array_le,
 };
-
 use snarkvm_console::{
     network::Network,
     program::{FromBits, FromFields, ToBits, ToFields, compute_function_id},

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -19,11 +19,14 @@ use crate::{
     Ciphertext,
     Field,
     Scalar,
+    from_js_typed_array,
+    native::LiteralNative,
     plaintext_to_js_value,
     to_bits_array_le,
     types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes},
 };
-use snarkvm_console::prelude::ToBits;
+use once_cell::sync::OnceCell;
+use snarkvm_console::prelude::{FromBits, ToBits};
 
 use js_sys::{Array, Uint8Array};
 use std::{ops::Deref, str::FromStr};
@@ -100,16 +103,26 @@ impl Plaintext {
         Ok(Self(native))
     }
 
-    /// Generate a random plaintext element from a series of bytes.
-    ///
-    /// @param {Uint8Array} bytes A left endian byte array representing the plaintext.
+    /// Get the left endian byte array representation of the plaintext.
     #[wasm_bindgen(js_name = "toBytesLe")]
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
         let rust_bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
         Ok(Uint8Array::from(rust_bytes.as_slice()))
     }
 
-    /// Get the left endian boolean array representation of the plaintext.
+    /// Get a plaintext object from a series of bits represented as a boolean array.
+    ///
+    /// @param {Array} bits A left endian boolean array representing the bits plaintext.
+    ///
+    /// @returns {Plaintext} The plaintext object.
+    #[wasm_bindgen(js_name = "fromBitsLe")]
+    pub fn from_bits_le(bits: Array) -> Result<Plaintext, String> {
+        let rust_bits = from_js_typed_array!(bits, as_bool, "boolean")?;
+        let native = PlaintextNative::from_bits_le(&rust_bits).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
+    /// Get the left endian boolean array representation of the bits plaintext.
     #[wasm_bindgen(js_name = "toBitsLe")]
     pub fn to_bits_le(&self) -> Array {
         to_bits_array_le!(self)
@@ -174,6 +187,19 @@ impl From<&PlaintextNative> for Plaintext {
 impl From<&Plaintext> for PlaintextNative {
     fn from(plaintext: &Plaintext) -> Self {
         plaintext.0.clone()
+    }
+}
+
+impl From<LiteralNative> for Plaintext {
+    fn from(value: LiteralNative) -> Self {
+        let native = PlaintextNative::Literal(value, OnceCell::new());
+        Self(native)
+    }
+}
+
+impl From<&LiteralNative> for Plaintext {
+    fn from(value: &LiteralNative) -> Self {
+        Self::from(value.clone())
     }
 }
 

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -27,7 +27,6 @@ use crate::{
     to_bits_array_le,
     types::native::{IdentifierNative, PlaintextNative},
 };
-
 use snarkvm_console::prelude::{FromBits, FromBytes, FromFields, ToBits, ToBytes, ToFields};
 
 use js_sys::{Array, Uint8Array};

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -24,10 +24,9 @@ use crate::{
     types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes},
 };
 use snarkvm_console::prelude::ToBits;
-use std::ops::Deref;
 
 use js_sys::{Array, Uint8Array};
-use std::str::FromStr;
+use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
 /// SnarkVM Plaintext object. Plaintext is a fundamental monadic type used to represent Aleo

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -20,17 +20,20 @@ use crate::{
     Field,
     Scalar,
     from_js_typed_array,
-    native::LiteralNative,
+    from_wasm_object_array,
+    js_array_from_fields,
+    native::{FieldNative, LiteralNative},
     plaintext_to_js_value,
     to_bits_array_le,
-    types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes},
+    types::native::{IdentifierNative, PlaintextNative},
 };
-use once_cell::sync::OnceCell;
-use snarkvm_console::prelude::{FromBits, ToBits};
+
+use snarkvm_console::prelude::{FromBits, FromBytes, FromFields, ToBits, ToBytes, ToFields};
 
 use js_sys::{Array, Uint8Array};
+use once_cell::sync::OnceCell;
 use std::{ops::Deref, str::FromStr};
-use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
+use wasm_bindgen::{JsValue, convert::TryFromJsValue, prelude::wasm_bindgen};
 
 /// SnarkVM Plaintext object. Plaintext is a fundamental monadic type used to represent Aleo
 /// primitive types (boolean, field, group, i8, i16, i32, i64, i128, u8, u16, u32, u64, u128,
@@ -122,10 +125,30 @@ impl Plaintext {
         Ok(Self(native))
     }
 
-    /// Get the left endian boolean array representation of the bits plaintext.
+    /// Get the left endian boolean array representation of the bits of the plaintext.
     #[wasm_bindgen(js_name = "toBitsLe")]
     pub fn to_bits_le(&self) -> Array {
         to_bits_array_le!(self)
+    }
+
+    /// Get a plaintext object from an array of fields.
+    ///
+    /// @param {Array} fields An array of fields.
+    ///
+    /// @returns {Plaintext} The plaintext object.
+    #[wasm_bindgen(js_name = "fromFields")]
+    pub fn from_fields(fields: Array) -> Result<Plaintext, String> {
+        let native_fields = from_wasm_object_array!(fields, Field)?;
+        let native = PlaintextNative::from_fields(&native_fields).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
+    /// Get the field array representation of the plaintext.
+    #[wasm_bindgen(js_name = "toFields")]
+    pub fn to_fields(&self) -> Result<Array, String> {
+        let native = self.0.clone();
+        let native_fields = native.to_fields().map_err(|e| e.to_string())?;
+        Ok(js_array_from_fields!(&native_fields))
     }
 
     /// Returns the string representation of the plaintext.

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -15,7 +15,13 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    plaintext_to_js_value, to_bits_array_le, types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes}, Address, Ciphertext, Field, Scalar
+    Address,
+    Ciphertext,
+    Field,
+    Scalar,
+    plaintext_to_js_value,
+    to_bits_array_le,
+    types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes},
 };
 use snarkvm_console::prelude::ToBits;
 use std::ops::Deref;

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -15,16 +15,12 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    Address,
-    Ciphertext,
-    Field,
-    Scalar,
-    plaintext_to_js_value,
-    types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes},
+    plaintext_to_js_value, to_bits_array_le, types::native::{FromBytes, IdentifierNative, PlaintextNative, ToBytes}, Address, Ciphertext, Field, Scalar
 };
+use snarkvm_console::prelude::ToBits;
 use std::ops::Deref;
 
-use js_sys::Uint8Array;
+use js_sys::{Array, Uint8Array};
 use std::str::FromStr;
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
@@ -106,6 +102,12 @@ impl Plaintext {
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
         let rust_bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
         Ok(Uint8Array::from(rust_bytes.as_slice()))
+    }
+
+    /// Get the left endian boolean array representation of the plaintext.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
     }
 
     /// Returns the string representation of the plaintext.

--- a/wasm/src/record/record_ciphertext.rs
+++ b/wasm/src/record/record_ciphertext.rs
@@ -23,7 +23,6 @@ use crate::{
     to_bits_array_le,
     types::native::RecordCiphertextNative,
 };
-
 use snarkvm_console::prelude::{FromBytes, ToBits, ToBytes, ToFields};
 
 use js_sys::{Array, Uint8Array};

--- a/wasm/src/record/record_ciphertext.rs
+++ b/wasm/src/record/record_ciphertext.rs
@@ -14,8 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Field, GraphKey, RecordPlaintext, ViewKey, types::native::RecordCiphertextNative};
+use crate::{Field, GraphKey, RecordPlaintext, ViewKey, to_bits_array_le, types::native::RecordCiphertextNative};
+use snarkvm_console::prelude::ToBits;
+use snarkvm_wasm::utilities::ToBytes;
 
+use js_sys::{Array, Uint8Array};
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
 
@@ -72,6 +75,20 @@ impl RecordCiphertext {
     /// @returns {Field} tag of the record.
     pub fn tag(graph_key: &GraphKey, commitment: Field) -> Result<Field, String> {
         RecordCiphertextNative::tag(*graph_key.sk_tag(), *commitment).map_err(|e| e.to_string()).map(Field::from)
+    }
+
+    /// Get the left endian byte array representation of the record ciphertext.
+    #[wasm_bindgen(js_name = "toBytesLe")]
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let bytes_vec = self.0.to_bytes_le().map_err(|e| e.to_string())?;
+        let bytes = bytes_vec.as_slice();
+        Uint8Array::try_from(bytes).map_err(|e| e.to_string())
+    }
+
+    /// Get the left endian boolean array representation of the record ciphertext bits.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
     }
 }
 

--- a/wasm/src/record/record_ciphertext.rs
+++ b/wasm/src/record/record_ciphertext.rs
@@ -14,9 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Field, GraphKey, RecordPlaintext, ViewKey, to_bits_array_le, types::native::RecordCiphertextNative};
-use snarkvm_console::prelude::ToBits;
-use snarkvm_wasm::utilities::ToBytes;
+use crate::{
+    Field,
+    GraphKey,
+    RecordPlaintext,
+    ViewKey,
+    js_array_from_fields,
+    to_bits_array_le,
+    types::native::RecordCiphertextNative,
+};
+
+use snarkvm_console::prelude::{FromBytes, ToBits, ToBytes, ToFields};
 
 use js_sys::{Array, Uint8Array};
 use std::{ops::Deref, str::FromStr};
@@ -77,6 +85,18 @@ impl RecordCiphertext {
         RecordCiphertextNative::tag(*graph_key.sk_tag(), *commitment).map_err(|e| e.to_string()).map(Field::from)
     }
 
+    /// Get a record ciphertext object from a series of bytes.
+    ///
+    /// @param {Uint8Array} bytes A left endian byte array representing the record ciphertext.
+    ///
+    /// @returns {RecordCiphertext}
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: Uint8Array) -> Result<Self, String> {
+        let rust_bytes = bytes.to_vec();
+        let native = RecordCiphertextNative::from_bytes_le(&rust_bytes).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
     /// Get the left endian byte array representation of the record ciphertext.
     #[wasm_bindgen(js_name = "toBytesLe")]
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
@@ -89,6 +109,14 @@ impl RecordCiphertext {
     #[wasm_bindgen(js_name = "toBitsLe")]
     pub fn to_bits_le(&self) -> Array {
         to_bits_array_le!(self)
+    }
+
+    /// Get the field array representation of the record ciphertext.
+    #[wasm_bindgen(js_name = "toFields")]
+    pub fn to_fields(&self) -> Result<Array, String> {
+        let native = self.0.clone();
+        let native_fields = native.to_fields().map_err(|e| e.to_string())?;
+        Ok(js_array_from_fields!(&native_fields))
     }
 }
 

--- a/wasm/src/record/record_plaintext.rs
+++ b/wasm/src/record/record_plaintext.rs
@@ -35,7 +35,6 @@ use crate::{
         },
     },
 };
-
 use snarkvm_console::{
     prelude::{FromBytes, ToBits, ToBytes, ToFields},
     program::Owner,

--- a/wasm/src/record/record_plaintext.rs
+++ b/wasm/src/record/record_plaintext.rs
@@ -21,6 +21,7 @@ use crate::{
     Plaintext,
     PrivateKey,
     record_to_js_object,
+    to_bits_array_le,
     types::{
         Field,
         native::{
@@ -33,10 +34,11 @@ use crate::{
         },
     },
 };
-use snarkvm_console::program::Owner;
+use snarkvm_console::{prelude::ToBits, program::Owner};
 
 use anyhow::Context;
-use js_sys::Object;
+use js_sys::{Array, Object, Uint8Array};
+use snarkvm_wasm::utilities::ToBytes;
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
 
@@ -153,6 +155,24 @@ impl RecordPlaintext {
     #[wasm_bindgen(js_name = toString)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
+    }
+
+    /// Returns the left endian byte array representation of the record plaintext.
+    ///
+    /// @returns {Uint8Array} Byte array representation of the record plaintext.
+    #[wasm_bindgen(js_name = "toBytesLe")]
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let bytes_vec = self.0.to_bytes_le().map_err(|e| e.to_string())?;
+        let bytes = bytes_vec.as_slice();
+        Uint8Array::try_from(bytes).map_err(|e| e.to_string())
+    }
+
+    /// Returns the left endian boolean array representation of the record plaintext bits.
+    ///
+    /// @returns {Array} Boolean array representation of the record plaintext bits.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
     }
 
     /// Returns the amount of microcredits in the record

--- a/wasm/src/record/record_plaintext.rs
+++ b/wasm/src/record/record_plaintext.rs
@@ -20,6 +20,7 @@ use crate::{
     GraphKey,
     Plaintext,
     PrivateKey,
+    js_array_from_fields,
     record_to_js_object,
     to_bits_array_le,
     types::{
@@ -34,11 +35,14 @@ use crate::{
         },
     },
 };
-use snarkvm_console::{prelude::ToBits, program::Owner};
+
+use snarkvm_console::{
+    prelude::{FromBytes, ToBits, ToBytes, ToFields},
+    program::Owner,
+};
 
 use anyhow::Context;
 use js_sys::{Array, Object, Uint8Array};
-use snarkvm_wasm::utilities::ToBytes;
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
 
@@ -157,6 +161,18 @@ impl RecordPlaintext {
         self.0.to_string()
     }
 
+    /// Get a record plaintext object from a series of bytes.
+    ///
+    /// @param {Uint8Array} bytes A left endian byte array representing the record plaintext.
+    ///
+    /// @returns {RecordPlaintext} The record plaintext.
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: Uint8Array) -> Result<Self, String> {
+        let rust_bytes = bytes.to_vec();
+        let native = RecordPlaintextNative::from_bytes_le(rust_bytes.as_slice()).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+
     /// Returns the left endian byte array representation of the record plaintext.
     ///
     /// @returns {Uint8Array} Byte array representation of the record plaintext.
@@ -173,6 +189,14 @@ impl RecordPlaintext {
     #[wasm_bindgen(js_name = "toBitsLe")]
     pub fn to_bits_le(&self) -> Array {
         to_bits_array_le!(self)
+    }
+
+    /// Get the field array representation of the record plaintext.
+    #[wasm_bindgen(js_name = "toFields")]
+    pub fn to_fields(&self) -> Result<Array, String> {
+        let native = self.0.clone();
+        let native_fields = native.to_fields().map_err(|e| e.to_string())?;
+        Ok(js_array_from_fields!(&native_fields))
     }
 
     /// Returns the amount of microcredits in the record

--- a/wasm/src/types/group.rs
+++ b/wasm/src/types/group.rs
@@ -15,9 +15,11 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    Address,
     Field,
     Plaintext,
     from_js_typed_array,
+    native::AddressNative,
     to_bits_array_le,
     types::{
         Scalar,
@@ -175,5 +177,30 @@ impl From<&GroupNative> for Group {
 impl From<&Group> for GroupNative {
     fn from(group: &Group) -> Self {
         group.0
+    }
+}
+
+impl From<GroupNative> for Address {
+    fn from(value: GroupNative) -> Self {
+        let native = AddressNative::new(value);
+        Address::from(native)
+    }
+}
+
+impl From<Group> for Address {
+    fn from(value: Group) -> Self {
+        Address::from(value.0)
+    }
+}
+
+impl From<&GroupNative> for Address {
+    fn from(value: &GroupNative) -> Self {
+        Address::from(value.clone())
+    }
+}
+
+impl From<&Group> for Address {
+    fn from(value: &Group) -> Self {
+        Address::from(value.0)
     }
 }

--- a/wasm/src/types/group.rs
+++ b/wasm/src/types/group.rs
@@ -19,6 +19,7 @@ use crate::{
     Field,
     Plaintext,
     from_js_typed_array,
+    js_array_from_fields,
     native::AddressNative,
     to_bits_array_le,
     types::{
@@ -26,12 +27,14 @@ use crate::{
         native::{GroupNative, LiteralNative, PlaintextNative, Uniform},
     },
 };
-use snarkvm_console::prelude::{Double, FromBits, FromBytes, ToBits, ToBytes, Zero};
+use snarkvm_console::prelude::{Double, FromBits, FromBytes, FromFields, ToBits, ToBytes, ToFields, Zero};
 
 use js_sys::{Array, Uint8Array};
 use once_cell::sync::OnceCell;
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
+
+use super::native::FieldNative;
 
 /// Elliptic curve element.
 #[wasm_bindgen]
@@ -80,6 +83,13 @@ impl Group {
     #[wasm_bindgen(js_name = "toBitsLe")]
     pub fn to_bits_le(&self) -> Array {
         to_bits_array_le!(self)
+    }
+
+    /// Get the field array representation of the group.
+    #[wasm_bindgen(js_name = "toFields")]
+    pub fn to_fields(&self) -> Result<Array, String> {
+        let native_fields = self.0.to_fields().map_err(|e| e.to_string())?;
+        Ok(js_array_from_fields!(native_fields))
     }
 
     /// Get the x-coordinate of the group element.
@@ -202,5 +212,22 @@ impl From<&GroupNative> for Address {
 impl From<&Group> for Address {
     fn from(value: &Group) -> Self {
         Address::from(value.0)
+    }
+}
+
+impl TryFrom<Field> for Group {
+    type Error = String;
+
+    fn try_from(value: Field) -> Result<Self, Self::Error> {
+        let native = GroupNative::from_fields(&[FieldNative::from(value)]).map_err(|e| e.to_string())?;
+        Ok(Self(native))
+    }
+}
+
+impl TryFrom<&Field> for Group {
+    type Error = String;
+
+    fn try_from(value: &Field) -> Result<Self, Self::Error> {
+        Self::try_from(value.clone())
     }
 }

--- a/wasm/src/utilities/array.rs
+++ b/wasm/src/utilities/array.rs
@@ -38,3 +38,14 @@ macro_rules! from_js_typed_array {
             .collect::<Result<Vec<bool>, String>>()
     }};
 }
+
+#[macro_export]
+macro_rules! js_array_from_fields {
+    ($input:expr) => {{
+        let js_array = js_sys::Array::new();
+        $input.iter().for_each(|field| {
+            js_array.push(&wasm_bindgen::JsValue::from(Field::from(*field)));
+        });
+        js_array
+    }};
+}

--- a/wasm/src/utilities/array.rs
+++ b/wasm/src/utilities/array.rs
@@ -44,7 +44,7 @@ macro_rules! js_array_from_fields {
     ($input:expr) => {{
         let js_array = js_sys::Array::new();
         $input.iter().for_each(|field| {
-            js_array.push(&wasm_bindgen::JsValue::from(Field::from(*field)));
+            js_array.push(&wasm_bindgen::JsValue::from(Field::from(field)));
         });
         js_array
     }};

--- a/wasm/src/utilities/test/mod.rs
+++ b/wasm/src/utilities/test/mod.rs
@@ -27,7 +27,8 @@ pub const TEST_STRUCT: &str = "{
     is_active: false,
     some_field: 2field,
     some_group: 7243206743250892049702172909169115544952822465955921992746259936160368017976group,
-    some_scalar: 836504693989570607341914239820012911582004515616146791081874852343183183566scalar
+    some_scalar: 836504693989570607341914239820012911582004515616146791081874852343183183566scalar,
+    some_signature: sign1lcpxtgqkp238x45fk79lkx5xz7sx37f56wl0hyemhv78dgzxyspykg6u26lx2a02tvat6zaflx530qtnme34gh702wclwr20rdxrsqcl7shvwsyhygt2yvkgzeq7zz2rdat4rrsr0cd9kwm6jddjcs9lps8s80v35rwvtkgg2gxprf4dge0tcet3pe7nfxupkvfuvh3sw2gpyv0km46
 }";
 
 /// Create a field element and a scalar element.

--- a/wasm/src/utilities/test/mod.rs
+++ b/wasm/src/utilities/test/mod.rs
@@ -14,11 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Field, types::native::FieldNative};
+use crate::types::native::FieldNative;
 
-use js_sys::Array;
 use std::str::FromStr;
-use wasm_bindgen::JsValue;
 
 /// Create a field element to act as a generator.
 pub const FIELD_ELEMENT: &str = "6901184695964460143517399399785179769303979738604374595034454667750561389951field";
@@ -39,13 +37,4 @@ pub fn create_native_field_vector(num_fields: Option<u16>) -> Vec<FieldNative> {
         });
     }
     native_fields
-}
-
-/// Get a js_array of fields from a vector of field elements.
-pub fn js_array_from_fields(native_fields: &Vec<FieldNative>) -> Array {
-    let js_array = Array::new();
-    native_fields.iter().for_each(|field| {
-        js_array.push(&JsValue::from(Field::from(*field)));
-    });
-    js_array
 }

--- a/wasm/src/utilities/test/mod.rs
+++ b/wasm/src/utilities/test/mod.rs
@@ -21,6 +21,15 @@ use std::str::FromStr;
 /// Create a field element to act as a generator.
 pub const FIELD_ELEMENT: &str = "6901184695964460143517399399785179769303979738604374595034454667750561389951field";
 
+/// Create a test struct containing all currently supported literal types for hash testing.
+pub const TEST_STRUCT: &str = "{
+    user: aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc,
+    is_active: false,
+    some_field: 2field,
+    some_group: 7243206743250892049702172909169115544952822465955921992746259936160368017976group,
+    some_scalar: 836504693989570607341914239820012911582004515616146791081874852343183183566scalar
+}";
+
 /// Create a field element and a scalar element.
 pub fn create_native_field_vector(num_fields: Option<u16>) -> Vec<FieldNative> {
     // Create a field element generator.


### PR DESCRIPTION
## Motivation

Currently there is not an ergonomic way to get serialized representations of plaintext and ciphertext objects. Adding these methods opens up client-side hashing on addresses and structs in their plaintext and ciphertext representations.

## Test Plan

Include unit tests that compare outputs of these methods with their expected outputs.

## Related PRs