### PR TITLE
Create Leo App - specify template via command line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,16 @@ jobs:
           command: |
             yarn start
 
+  create-leo-app-cli:
+    executor: rust-node
+    steps:
+      - setup
+      - run:
+          working_directory: create-leo-app
+          command: |
+            yarn build
+            yarn add -D ts-node typescript
+            npx ts-node src/index.ts test-app --template react-leo
 
   template-node:
     executor: rust-node
@@ -170,6 +180,9 @@ workflows:
           requires:
             - sdk
       - e2e-mainnet:
+          requires:
+            - sdk
+      - create-leo-app-cli:
           requires:
             - sdk
       - template-node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
           working_directory: create-leo-app
           command: |
             yarn add -D ts-node typescript
-            npx ts-node-esm src/index.ts test-app --template react-leo
+            node --loader ts-node/esm src/index.ts test-app --template react-leo
 
   template-node:
     executor: rust-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,8 @@ jobs:
       - run:
           working_directory: create-leo-app
           command: |
-            yarn add -D ts-node typescript
-            node --loader ts-node/esm src/index.ts test-app --template react-leo
+            npm i -D tsx
+            npx tsx src/index.ts test-app --template react-leo
 
   template-node:
     executor: rust-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,8 @@ jobs:
       - run:
           working_directory: create-leo-app
           command: |
-            yarn build
             yarn add -D ts-node typescript
-            npx ts-node src/index.ts test-app --template react-leo
+            npx ts-node-esm src/index.ts test-app --template react-leo
 
   template-node:
     executor: rust-node

--- a/create-leo-app/README.md
+++ b/create-leo-app/README.md
@@ -13,14 +13,14 @@ npm create leo-app@latest
 
 Then follow the prompts!
 
-You can also directly specify the project name you want to use via additional command line options. For example, to scaffold a Leo project, run:
+You can also directly specify the project name and template you want to use via additional command line options. For example, to scaffold a Leo project using the Vanilla JavaScript template, run:
 
 ```bash
 # npm 6.x
-npm create leo-app@latest my-leo-app
+npm create leo-app@latest my-leo-app --template vanilla
 
 # npm 7+, extra double-dash is needed:
-npm create leo-app@latest my-leo-app
+npm create leo-app@latest my-leo-app -- --template vanilla
 ```
 
 Currently supported template presets include:

--- a/create-leo-app/src/index.ts
+++ b/create-leo-app/src/index.ts
@@ -92,6 +92,20 @@ async function init() {
   const getProjectName = () =>
     targetDir === "." ? path.basename(path.resolve()) : targetDir;
 
+  let selectedFramework: Framework | undefined;
+  let selectedVariant: string | undefined;
+
+  if (argTemplate && TEMPLATES.includes(argTemplate)) {
+    for (const framework of FRAMEWORKS) {
+      const match = framework.variants.find((v) => v.name === argTemplate);
+      if (match) {
+        selectedFramework = framework;
+        selectedVariant = match.name;
+        break;
+      }
+    }
+  }
+
   let result: prompts.Answers<
     "projectName" | "overwrite" | "packageName" | "framework" | "variant"
   >;
@@ -136,8 +150,7 @@ async function init() {
             isValidPackageName(dir) || "Invalid package.json name",
         },
         {
-          type:
-            argTemplate && TEMPLATES.includes(argTemplate) ? null : "select",
+          type: selectedFramework ? null : "select",
           name: "framework",
           message:
             typeof argTemplate === "string" && !TEMPLATES.includes(argTemplate)
@@ -155,8 +168,7 @@ async function init() {
           }),
         },
         {
-          type: (framework: Framework) =>
-            framework && framework.variants ? "select" : null,
+          type: selectedVariant ? null : "select",
           name: "variant",
           message: reset("Select a variant:"),
           choices: (framework: Framework) =>


### PR DESCRIPTION
This PR fixes the ability to add desired template in when runnning create leo app. 

Eg `npm create leo-app@latest my-leo-app --template vanilla` 