### PR TITLE
[Docs] Update SDK documentation

### DIFF
--- a/docs/api_reference/sdk-src_account.md
+++ b/docs/api_reference/sdk-src_account.md
@@ -9,14 +9,13 @@
 # Class `Account`
 
 Key Management class. Enables the creation of a new Aleo Account, importation of an existing account from
-an existing private key or seed, and message signing and verification functionality.
-
-An Aleo Account is generated from a randomly generated seed (number) from which an account private key, view key,
-and a public account address are derived. The private key lies at the root of an Aleo account. It is a highly
-sensitive secret and should be protected as it allows for creation of Aleo Program executions and arbitrary value
-transfers. The View Key allows for decryption of a user&#x27;s activity on the blockchain. The Address is the public
-address to which other users of Aleo can send Aleo credits and other records to. This class should only be used
-in environments where the safety of the underlying key material can be assured.
+an existing private key or seed, and message signing and verification functionality. An Aleo Account is generated
+from a randomly generated seed (number) from which an account private key, view key, and a public account address are
+derived. The private key lies at the root of an Aleo account. It is a highly sensitive secret and should be protected
+as it allows for creation of Aleo Program executions and arbitrary value transfers. The View Key allows for decryption
+of a user&#x27;s activity on the blockchain. The Address is the public address to which other users of Aleo can send Aleo
+credits and other records to. This class should only be used in environments where the safety of the underlying key
+material can be assured.
 
 ## Examples
 

--- a/docs/api_reference/sdk-src_account.md
+++ b/docs/api_reference/sdk-src_account.md
@@ -16,11 +16,13 @@ and a public account address are derived. The private key lies at the root of an
 sensitive secret and should be protected as it allows for creation of Aleo Program executions and arbitrary value
 transfers. The View Key allows for decryption of a user&#x27;s activity on the blockchain. The Address is the public
 address to which other users of Aleo can send Aleo credits and other records to. This class should only be used
-environments where the safety of the underlying key material can be assured.
+in environments where the safety of the underlying key material can be assured.
 
 ## Examples
 
 ```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
 // Create a new account
 const myRandomAccount = new Account();
 
@@ -29,19 +31,19 @@ const seed = new Uint8Array([94, 91, 52, 251, 240, 230, 226, 35, 117, 253, 224, 
 const mySeededAccount = new Account({seed: seed});
 
 // Create an account from an existing private key
-const myExistingAccount = new Account({privateKey: 'myExistingPrivateKey'})
+const myExistingAccount = new Account({privateKey: process.env.privateKey});
 
 // Sign a message
-const hello_world = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100])
-const signature = myRandomAccount.sign(hello_world)
+const hello_world = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100]);
+const signature = myRandomAccount.sign(hello_world);
 
 // Verify a signature
-myRandomAccount.verify(hello_world, signature)
+assert(myRandomAccount.verify(hello_world, signature));
 ```
 
 ## Methods
 
-### `fromCiphertext(ciphertext, password) ► PrivateKey`
+### `fromCiphertext(ciphertext, password) ► Account`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
 
@@ -49,75 +51,237 @@ Attempts to create an account from a private key ciphertext
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertext__ | [PrivateKeyCiphertext](sdk-src_wasm.md) | **
-__password__ | `string` | **
-__*return*__ | [PrivateKey](sdk-src_wasm.md) | **
+__ciphertext__ | [PrivateKeyCiphertext](sdk-src_wasm.md) | *The encrypted private key ciphertext or its string representation*
+__password__ | `string` | *The password used to decrypt the private key ciphertext*
+__*return*__ | [Account](sdk-src_account.md) | *A new Account instance created from the decrypted private key*
 
 #### Examples
 
 ```javascript
-const ciphertext = PrivateKey.newEncrypted("password");
+import { Account } from "@provablehq/sdk/testnet.js";
+
+// Create an account object from a previously encrypted ciphertext and password.
 const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
 ```
 
 ---
 
-### `encryptAccount(ciphertext) ► PrivateKeyCiphertext`
+### `privateKeyFromParams(params) ► PrivateKey`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Encrypt the account&#x27;s private key with a password
+Creates a PrivateKey from the provided parameters.
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertext__ | `string` | **
-__*return*__ | [PrivateKeyCiphertext](sdk-src_wasm.md) | **
+__params__ | `AccountParam` | *The parameters containing either a private key string or a seed*
+__*return*__ | [PrivateKey](sdk-src_wasm.md) | *A PrivateKey instance derived from the provided parameters*
+
+---
+
+### `privateKey() ► PrivateKey`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the PrivateKey associated with the account.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [PrivateKey](sdk-src_wasm.md) | *The private key of the account*
 
 #### Examples
 
 ```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const privateKey = account.privateKey();
+```
+
+---
+
+### `viewKey() ► ViewKey`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the ViewKey associated with the account.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `ViewKey` | *The view key of the account*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const viewKey = account.viewKey();
+```
+
+---
+
+### `computeKey() ► ComputeKey`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the ComputeKey associated with the account.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `ComputeKey` | *The compute key of the account*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const computeKey = account.computeKey();
+```
+
+---
+
+### `address() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the Aleo address associated with the account.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | *The public address of the account*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const address = account.address();
+```
+
+---
+
+### `clone() ► Account`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Deep clones the Account.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Account](sdk-src_account.md) | *A new Account instance with the same private key*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const clonedAccount = account.clone();
+```
+
+---
+
+### `toString() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the address of the account in a string representation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | *The string representation of the account address*
+
+---
+
+### `encryptAccount(password) ► PrivateKeyCiphertext`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Encrypts the account&#x27;s private key with a password.
+
+Parameters | Type | Description
+--- | --- | ---
+__password__ | `string` | *Password to encrypt the private key.*
+__*return*__ | [PrivateKeyCiphertext](sdk-src_wasm.md) | *The encrypted private key ciphertext*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
 const account = new Account();
 const ciphertext = account.encryptAccount("password");
+process.env.ciphertext = ciphertext.toString();
 ```
 
 ---
 
-### `decryptRecord(ciphertext) ► Record`
+### `decryptRecord(ciphertext) ► RecordPlaintext`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Decrypts a Record in ciphertext form into plaintext
+Decrypts an encrypted record string into a plaintext record object.
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertext__ | `string` | **
-__*return*__ | `Record` | **
+__ciphertext__ | `string` | *A string representing the ciphertext of a record.*
+__*return*__ | [RecordPlaintext](sdk-src_wasm.md) | *The decrypted record plaintext*
 
 #### Examples
 
 ```javascript
-const account = new Account();
-const record = account.decryptRecord("record1ciphertext");
+// Import the AleoNetworkClient and Account classes
+import { AleoNetworkClient, Account } from "@provablehq/sdk/testnet.js";
+
+// Create a connection to the Aleo network and an account
+const networkClient = new AleoNetworkClient("https://api.explorer.provable.com/v1");
+const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
+
+// Get the record ciphertexts from a transaction.
+const transaction = await networkClient.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
+const records = transaction.records();
+
+// Decrypt any records the account owns.
+const decryptedRecords = [];
+for (const record of records) {
+   if (account.decryptRecord(record)) {
+     decryptedRecords.push(record);
+   }
+}
 ```
 
 ---
 
-### `decryptRecords(ciphertexts) ► Array.<Record>`
+### `decryptRecords(ciphertexts) ► Array.<RecordPlaintext>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Decrypts an array of Records in ciphertext form into plaintext
+Decrypts an array of Record ciphertext strings into an array of record plaintext objects.
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertexts__ | `Array.<string>` | **
-__*return*__ | `Array.<Record>` | **
+__ciphertexts__ | `Array.<string>` | *An array of strings representing the ciphertexts of records.*
+__*return*__ | `Array.<RecordPlaintext>` | *An array of decrypted record plaintexts*
 
 #### Examples
 
 ```javascript
-const account = new Account();
-const record = account.decryptRecords(["record1ciphertext", "record2ciphertext"]);
+// Import the AleoNetworkClient and Account classes
+import { AleoNetworkClient, Account } from "@provablehq/sdk/testnet.js";
+
+// Create a connection to the Aleo network and an account
+const networkClient = new AleoNetworkClient("https://api.explorer.provable.com/v1");
+const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
+
+// Get the record ciphertexts from a transaction.
+const transaction = await networkClient.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
+const records = transaction.records();
+
+// Decrypt any records the account owns. If the account owns no records, the array will be empty.
+const decryptedRecords = account.decryptRecords(records);
 ```
 
 ---
@@ -126,30 +290,33 @@ const record = account.decryptRecords(["record1ciphertext", "record2ciphertext"]
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Determines whether the account owns a ciphertext record
+Determines whether the account owns a ciphertext record.
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertext__ | `RecordCipherText` | **
-__*return*__ | `boolean` | **
+__ciphertext__ | [RecordCiphertext](sdk-src_wasm.md) | *The record ciphertext to check ownership of*
+__*return*__ | `boolean` | *True if the account owns the record, false otherwise*
 
 #### Examples
 
 ```javascript
+// Import the AleoNetworkClient and Account classes
+import { AleoNetworkClient, Account } from "@provablehq/sdk/testnet.js";
+
 // Create a connection to the Aleo network and an account
-const connection = new AleoNetworkClient("https://api.explorer.provable.com/v1");
-const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+const networkClient = new AleoNetworkClient("https://api.explorer.provable.com/v1");
+const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
 
-// Get a record from the network
-const record = connection.getBlock(1234);
-const recordCipherText = record.transactions[0].execution.transitions[0].id;
+// Get the record ciphertexts from a transaction and check ownership of them.
+const transaction = await networkClient.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
+const records = transaction.records();
 
-// Check if the account owns the record
-if account.ownsRecord(recordCipherText) {
-    // Then one can do something like:
-    // Decrypt the record and check if it's spent
-    // Store the record in a local database
-    // Etc.
+// Check if the account owns any of the record ciphertexts present in the transaction.
+const ownedRecords = [];
+for (const record of records) {
+   if (account.ownsRecordCiphertext(record)) {
+     ownedRecords.push(record);
+   }
 }
 ```
 
@@ -164,15 +331,25 @@ Returns a Signature.
 
 Parameters | Type | Description
 --- | --- | ---
-__message__ | `Uint8Array` | **
-__*return*__ | [Signature](sdk-src_wasm.md) | **
+__message__ | `Uint8Array` | *Message to be signed.*
+__*return*__ | [Signature](sdk-src_wasm.md) | *Signature over the message in bytes.*
 
 #### Examples
 
 ```javascript
+// Import the Account class
+import { Account } from "@provablehq/sdk/testnet.js";
+
+// Create a connection to the Aleo network and an account
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+
+// Create an account and a message to sign.
 const account = new Account();
 const message = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100])
-account.sign(message);
+const signature = account.sign(message);
+
+// Verify the signature.
+assert(account.verify(message, signature));
 ```
 
 ---
@@ -185,22 +362,30 @@ Verifies the Signature on a message.
 
 Parameters | Type | Description
 --- | --- | ---
-__message__ | `Uint8Array` | **
-__signature__ | [Signature](sdk-src_wasm.md) | **
-__*return*__ | `boolean` | **
+__message__ | `Uint8Array` | *Message in bytes to be signed.*
+__signature__ | [Signature](sdk-src_wasm.md) | *Signature to be verified.*
+__*return*__ | `boolean` | *True if the signature is valid, false otherwise.*
 
 #### Examples
 
 ```javascript
-const account = new Account();
+// Import the Account class
+import { Account } from "@provablehq/sdk/testnet.js";
+
+// Create a connection to the Aleo network and an account
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+
+// Sign a message.
 const message = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100])
 const signature = account.sign(message);
-account.verify(message, signature);
+
+// Verify the signature.
+assert(account.verify(message, signature));
 ```
 
 ---
 
-### `fromCiphertext(ciphertext, password) ► PrivateKey`
+### `fromCiphertext(ciphertext, password) ► Account`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
 
@@ -208,75 +393,224 @@ Attempts to create an account from a private key ciphertext
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertext__ | [PrivateKeyCiphertext](sdk-src_wasm.md) | **
-__password__ | `string` | **
-__*return*__ | [PrivateKey](sdk-src_wasm.md) | **
+__ciphertext__ | [PrivateKeyCiphertext](sdk-src_wasm.md) | *The encrypted private key ciphertext or its string representation*
+__password__ | `string` | *The password used to decrypt the private key ciphertext*
+__*return*__ | [Account](sdk-src_account.md) | *A new Account instance created from the decrypted private key*
 
 #### Examples
 
 ```javascript
-const ciphertext = PrivateKey.newEncrypted("password");
+import { Account } from "@provablehq/sdk/testnet.js";
+
+// Create an account object from a previously encrypted ciphertext and password.
 const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
 ```
 
 ---
 
-### `encryptAccount(ciphertext) ► PrivateKeyCiphertext`
+### `privateKey() ► PrivateKey`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Encrypt the account&#x27;s private key with a password
+Returns the PrivateKey associated with the account.
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertext__ | `string` | **
-__*return*__ | [PrivateKeyCiphertext](sdk-src_wasm.md) | **
+__*return*__ | [PrivateKey](sdk-src_wasm.md) | *The private key of the account*
 
 #### Examples
 
 ```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const privateKey = account.privateKey();
+```
+
+---
+
+### `viewKey() ► ViewKey`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the ViewKey associated with the account.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `ViewKey` | *The view key of the account*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const viewKey = account.viewKey();
+```
+
+---
+
+### `computeKey() ► ComputeKey`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the ComputeKey associated with the account.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `ComputeKey` | *The compute key of the account*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const computeKey = account.computeKey();
+```
+
+---
+
+### `address() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the Aleo address associated with the account.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | *The public address of the account*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const address = account.address();
+```
+
+---
+
+### `clone() ► Account`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Deep clones the Account.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Account](sdk-src_account.md) | *A new Account instance with the same private key*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
+const account = new Account();
+const clonedAccount = account.clone();
+```
+
+---
+
+### `toString() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the address of the account in a string representation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | *The string representation of the account address*
+
+---
+
+### `encryptAccount(password) ► PrivateKeyCiphertext`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Encrypts the account&#x27;s private key with a password.
+
+Parameters | Type | Description
+--- | --- | ---
+__password__ | `string` | *Password to encrypt the private key.*
+__*return*__ | [PrivateKeyCiphertext](sdk-src_wasm.md) | *The encrypted private key ciphertext*
+
+#### Examples
+
+```javascript
+import { Account } from "@provablehq/sdk/testnet.js";
+
 const account = new Account();
 const ciphertext = account.encryptAccount("password");
+process.env.ciphertext = ciphertext.toString();
 ```
 
 ---
 
-### `decryptRecord(ciphertext) ► Record`
+### `decryptRecord(ciphertext) ► RecordPlaintext`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Decrypts a Record in ciphertext form into plaintext
+Decrypts an encrypted record string into a plaintext record object.
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertext__ | `string` | **
-__*return*__ | `Record` | **
+__ciphertext__ | `string` | *A string representing the ciphertext of a record.*
+__*return*__ | [RecordPlaintext](sdk-src_wasm.md) | *The decrypted record plaintext*
 
 #### Examples
 
 ```javascript
-const account = new Account();
-const record = account.decryptRecord("record1ciphertext");
+// Import the AleoNetworkClient and Account classes
+import { AleoNetworkClient, Account } from "@provablehq/sdk/testnet.js";
+
+// Create a connection to the Aleo network and an account
+const networkClient = new AleoNetworkClient("https://api.explorer.provable.com/v1");
+const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
+
+// Get the record ciphertexts from a transaction.
+const transaction = await networkClient.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
+const records = transaction.records();
+
+// Decrypt any records the account owns.
+const decryptedRecords = [];
+for (const record of records) {
+   if (account.decryptRecord(record)) {
+     decryptedRecords.push(record);
+   }
+}
 ```
 
 ---
 
-### `decryptRecords(ciphertexts) ► Array.<Record>`
+### `decryptRecords(ciphertexts) ► Array.<RecordPlaintext>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Decrypts an array of Records in ciphertext form into plaintext
+Decrypts an array of Record ciphertext strings into an array of record plaintext objects.
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertexts__ | `Array.<string>` | **
-__*return*__ | `Array.<Record>` | **
+__ciphertexts__ | `Array.<string>` | *An array of strings representing the ciphertexts of records.*
+__*return*__ | `Array.<RecordPlaintext>` | *An array of decrypted record plaintexts*
 
 #### Examples
 
 ```javascript
-const account = new Account();
-const record = account.decryptRecords(["record1ciphertext", "record2ciphertext"]);
+// Import the AleoNetworkClient and Account classes
+import { AleoNetworkClient, Account } from "@provablehq/sdk/testnet.js";
+
+// Create a connection to the Aleo network and an account
+const networkClient = new AleoNetworkClient("https://api.explorer.provable.com/v1");
+const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
+
+// Get the record ciphertexts from a transaction.
+const transaction = await networkClient.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
+const records = transaction.records();
+
+// Decrypt any records the account owns. If the account owns no records, the array will be empty.
+const decryptedRecords = account.decryptRecords(records);
 ```
 
 ---
@@ -285,30 +619,33 @@ const record = account.decryptRecords(["record1ciphertext", "record2ciphertext"]
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Determines whether the account owns a ciphertext record
+Determines whether the account owns a ciphertext record.
 
 Parameters | Type | Description
 --- | --- | ---
-__ciphertext__ | `RecordCipherText` | **
-__*return*__ | `boolean` | **
+__ciphertext__ | [RecordCiphertext](sdk-src_wasm.md) | *The record ciphertext to check ownership of*
+__*return*__ | `boolean` | *True if the account owns the record, false otherwise*
 
 #### Examples
 
 ```javascript
+// Import the AleoNetworkClient and Account classes
+import { AleoNetworkClient, Account } from "@provablehq/sdk/testnet.js";
+
 // Create a connection to the Aleo network and an account
-const connection = new AleoNetworkClient("https://api.explorer.provable.com/v1");
-const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+const networkClient = new AleoNetworkClient("https://api.explorer.provable.com/v1");
+const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
 
-// Get a record from the network
-const record = connection.getBlock(1234);
-const recordCipherText = record.transactions[0].execution.transitions[0].id;
+// Get the record ciphertexts from a transaction and check ownership of them.
+const transaction = await networkClient.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
+const records = transaction.records();
 
-// Check if the account owns the record
-if account.ownsRecord(recordCipherText) {
-    // Then one can do something like:
-    // Decrypt the record and check if it's spent
-    // Store the record in a local database
-    // Etc.
+// Check if the account owns any of the record ciphertexts present in the transaction.
+const ownedRecords = [];
+for (const record of records) {
+   if (account.ownsRecordCiphertext(record)) {
+     ownedRecords.push(record);
+   }
 }
 ```
 
@@ -323,15 +660,25 @@ Returns a Signature.
 
 Parameters | Type | Description
 --- | --- | ---
-__message__ | `Uint8Array` | **
-__*return*__ | [Signature](sdk-src_wasm.md) | **
+__message__ | `Uint8Array` | *Message to be signed.*
+__*return*__ | [Signature](sdk-src_wasm.md) | *Signature over the message in bytes.*
 
 #### Examples
 
 ```javascript
+// Import the Account class
+import { Account } from "@provablehq/sdk/testnet.js";
+
+// Create a connection to the Aleo network and an account
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+
+// Create an account and a message to sign.
 const account = new Account();
 const message = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100])
-account.sign(message);
+const signature = account.sign(message);
+
+// Verify the signature.
+assert(account.verify(message, signature));
 ```
 
 ---
@@ -344,17 +691,38 @@ Verifies the Signature on a message.
 
 Parameters | Type | Description
 --- | --- | ---
-__message__ | `Uint8Array` | **
-__signature__ | [Signature](sdk-src_wasm.md) | **
-__*return*__ | `boolean` | **
+__message__ | `Uint8Array` | *Message in bytes to be signed.*
+__signature__ | [Signature](sdk-src_wasm.md) | *Signature to be verified.*
+__*return*__ | `boolean` | *True if the signature is valid, false otherwise.*
 
 #### Examples
 
 ```javascript
-const account = new Account();
+// Import the Account class
+import { Account } from "@provablehq/sdk/testnet.js";
+
+// Create a connection to the Aleo network and an account
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+
+// Sign a message.
 const message = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100])
 const signature = account.sign(message);
-account.verify(message, signature);
+
+// Verify the signature.
+assert(account.verify(message, signature));
 ```
+
+---
+
+### `privateKeyFromParams(params) ► PrivateKey`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Creates a PrivateKey from the provided parameters.
+
+Parameters | Type | Description
+--- | --- | ---
+__params__ | `AccountParam` | *The parameters containing either a private key string or a seed*
+__*return*__ | [PrivateKey](sdk-src_wasm.md) | *A PrivateKey instance derived from the provided parameters*
 
 ---

--- a/docs/api_reference/sdk-src_network-client.md
+++ b/docs/api_reference/sdk-src_network-client.md
@@ -14,12 +14,12 @@ allow users to query public information from the Aleo blockchain and submit tran
 ## Examples
 
 ```javascript
-// Connection to a local node
-const localNetworkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined, account);
+// Connection to a local node.
+const localNetworkClient = new AleoNetworkClient("http://0.0.0.0:3030", undefined, account);
 
 // Connection to a public beacon node
 const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
-const publicnetworkClient = new AleoNetworkClient("http://localhost:3030", undefined, account);
+const publicNetworkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined, account);
 ```
 
 ## Methods
@@ -32,11 +32,14 @@ Set an account to use in networkClient calls
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | **
+__account__ | [Account](sdk-src_account.md) | *Set an account to use for record scanning functions.*
 
 #### Examples
 
 ```javascript
+import { Account, AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1");
 const account = new Account();
 networkClient.setAccount(account);
 ```
@@ -68,6 +71,18 @@ Parameters | Type | Description
 __host__ | `string` | *The address of a node hosting the Aleo API*
 __host__ | `undefined` | **
 
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a networkClient that connects to a local node.
+const networkClient = new AleoNetworkClient("http://0.0.0.0:3030", undefined);
+
+// Set the host to a public node.
+networkClient.setHost("http://api.explorer.provable.com/v1");
+```
+
 ---
 
 ### `fetchData(url)`
@@ -78,7 +93,7 @@ Fetches data from the Aleo network and returns it as a JSON object.
 
 Parameters | Type | Description
 --- | --- | ---
-__url__ | `undefined` | **
+__url__ | `undefined` | *The URL to fetch data from.*
 
 ---
 
@@ -97,7 +112,7 @@ __url__ | `undefined` | **
 
 ---
 
-### `findRecords(startHeight, endHeight, unspent, programs, amounts, maxMicrocredits, nonces, privateKey)`
+### `findRecords(startHeight, endHeight, unspent, programs, amounts, maxMicrocredits, nonces, privateKey) ► Promise.<Array.<RecordPlaintext>>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -113,10 +128,20 @@ __amounts__ | `Array.<number>` | *The amounts (in microcredits) to search for (e
 __maxMicrocredits__ | `number` | *The maximum number of microcredits to search for*
 __nonces__ | `Array.<string>` | *The nonces of already found records to exclude from the search*
 __privateKey__ | `string` | *An optional private key to use to find unspent records.*
+__*return*__ | `Promise.<Array.<RecordPlaintext>>` | *An array of records belonging to the account configured in the network client.*
 
 #### Examples
 
 ```javascript
+import { Account, AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Import an account from a ciphertext and password.
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+networkClient.setAccount(account);
+
 // Find specific amounts
 const startHeight = 500000;
 const amounts = [600000, 1000000];
@@ -129,7 +154,7 @@ const records = networkClient.findRecords(startHeight, undefined, true, ["credit
 
 ---
 
-### `findUnspentRecords(startHeight, endHeight, programs, amounts, maxMicrocredits, nonces, privateKey)`
+### `findUnspentRecords(startHeight, endHeight, programs, amounts, maxMicrocredits, nonces, privateKey) ► Promise.<Array.<RecordPlaintext>>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -144,10 +169,19 @@ __amounts__ | `Array.<number>` | *The amounts (in microcredits) to search for (e
 __maxMicrocredits__ | `number` | *The maximum number of microcredits to search for*
 __nonces__ | `Array.<string>` | *The nonces of already found records to exclude from the search*
 __privateKey__ | `string` | *An optional private key to use to find unspent records.*
+__*return*__ | `Promise.<Array.<RecordPlaintext>>` | *An array of unspent records belonging to the account configured in the network client.*
 
 #### Examples
 
 ```javascript
+import { Account, AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+
+// Create a network client and set an account to search for records with.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+networkClient.setAccount(account);
+
 // Find specific amounts
 const startHeight = 500000;
 const endHeight = 550000;
@@ -161,7 +195,7 @@ const records = networkClient.findUnspentRecords(startHeight, undefined, ["credi
 
 ---
 
-### `getBlock(blockHeight)`
+### `getBlock(blockHeight) ► Promise.<BlockJSON>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -169,7 +203,8 @@ Returns the contents of the block at the specified block height.
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHeight__ | `number` | **
+__blockHeight__ | `number` | *The height of the block to fetch*
+__*return*__ | `Promise.<BlockJSON>` | *A javascript object containing the block at the specified height*
 
 #### Examples
 
@@ -179,7 +214,7 @@ const block = networkClient.getBlock(1234);
 
 ---
 
-### `getBlockByHash(blockHash)`
+### `getBlockByHash(blockHash) ► Promise.<BlockJSON>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -187,36 +222,51 @@ Returns the contents of the block with the specified hash.
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHash__ | `string` | **
+__blockHash__ | `string` | *The hash of the block to fetch.*
+__*return*__ | `Promise.<BlockJSON>` | *A javascript object representation of the block matching the hash.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
 const block = networkClient.getBlockByHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8x0t6dr72py8r87pxupqfne5t9");
 ```
 
 ---
 
-### `getBlockRange(start, end)`
+### `getBlockRange(start, end) ► Promise.<Array.<BlockJSON>>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Returns a range of blocks between the specified block heights.
+Returns a range of blocks between the specified block heights. A maximum of 50 blocks can be fetched at a time.
 
 Parameters | Type | Description
 --- | --- | ---
-__start__ | `number` | **
-__end__ | `number` | **
+__start__ | `number` | *Starting block to fetch.*
+__end__ | `number` | *Ending block to fetch. This cannot be more than 50 blocks ahead of the start block.*
+__*return*__ | `Promise.<Array.<BlockJSON>>` | *An array of block objects*
 
 #### Examples
 
 ```javascript
-const blockRange = networkClient.getBlockRange(2050, 2100);
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Fetch 50 blocks.
+const (start, end) = (2050, 2100);
+const blockRange = networkClient.getBlockRange(start, end);
+
+let cursor = start;
+blockRange.forEach((block) => {
+  assert(block.height == cursor);
+  cursor += 1;
+ }
 ```
 
 ---
 
-### `getDeploymentTransactionIDForProgram(program) ► TransactionJSON`
+### `getDeploymentTransactionIDForProgram(program) ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -224,25 +274,55 @@ Returns the deployment transaction id associated with the specified program.
 
 Parameters | Type | Description
 --- | --- | ---
-__program__ | [Program](sdk-src_wasm.md) | **
-__*return*__ | `TransactionJSON` | **
+__program__ | [Program](sdk-src_wasm.md) | *The name of the deployed program OR a wasm Program object.*
+__*return*__ | `Promise.<string>` | *The transaction ID of the deployment transaction.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/testnet.js";
+
+// Get the transaction ID of the deployment transaction for a program.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const transactionId = networkClient.getDeploymentTransactionIDForProgram("hello_hello.aleo");
+
+// Get the transaction data for the deployment transaction.
+const transaction = networkClient.getTransactionObject(transactionId);
+
+// Get the verifying keys for the functions in the deployed program.
+const verifyingKeys = transaction.verifyingKeys();
+```
 
 ---
 
-### `getDeploymentTransactionForProgram(program) ► TransactionJSON`
+### `getDeploymentTransactionForProgram(program) ► Promise.<Transaction>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Returns the deployment transaction associated with a specified program.
+Returns the deployment transaction associated with a specified program as a JSON object.
 
 Parameters | Type | Description
 --- | --- | ---
-__program__ | [Program](sdk-src_wasm.md) | **
-__*return*__ | `TransactionJSON` | **
+__program__ | [Program](sdk-src_wasm.md) | *The name of the deployed program OR a wasm Program object.*
+__*return*__ | `Promise.<Transaction>` | *JSON representation of the deployment transaction.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient, DeploymentJSON } from "@provablehq/sdk/testnet.js";
+
+// Get the transaction ID of the deployment transaction for a program.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const transaction = networkClient.getDeploymentTransactionForProgram("hello_hello.aleo");
+
+// Get the verifying keys for each function in the deployment.
+const deployment = <DeploymentJSON>transaction.deployment;
+const verifyingKeys = deployment.verifying_keys;
+```
 
 ---
 
-### `getDeploymentTransactionObjectForProgram(program) ► TransactionJSON`
+### `getDeploymentTransactionObjectForProgram(program) ► Promise.<Transaction>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -250,20 +330,45 @@ Returns the deployment transaction associated with a specified program as a wasm
 
 Parameters | Type | Description
 --- | --- | ---
-__program__ | [Program](sdk-src_wasm.md) | **
-__*return*__ | `TransactionJSON` | **
-
----
-
-### `getLatestBlock()`
-
-![modifier: public](images/badges/modifier-public.svg)
-
-Returns the contents of the latest block.
+__program__ | [Program](sdk-src_wasm.md) | *The name of the deployed program OR a wasm Program object.*
+__*return*__ | `Promise.<Transaction>` | *Wasm object representation of the deployment transaction.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/testnet.js";
+
+// Get the transaction ID of the deployment transaction for a program.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const transactionId = networkClient.getDeploymentTransactionIDForProgram("hello_hello.aleo");
+
+// Get the transaction data for the deployment transaction.
+const transaction = networkClient.getDeploymentTransactionObjectForProgram(transactionId);
+
+// Get the verifying keys for the functions in the deployed program.
+const verifyingKeys = transaction.verifyingKeys();
+```
+
+---
+
+### `getLatestBlock() ► Promise.<BlockJSON>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the contents of the latest block as JSON.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<BlockJSON>` | *A javascript object containing the latest block*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/testnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const latestHeight = networkClient.getLatestBlock();
 ```
 
@@ -279,51 +384,90 @@ Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `Promise.<object>` | *A javascript object containing the latest committee*
 
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Create a network client and get the latest committee.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const latestCommittee = await networkClient.getLatestCommittee();
+```
+
 ---
 
 ### `getCommitteeByBlockHeight(blockHeight) ► Promise.<object>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Returns the committe at the specified block height.
+Returns the committee at the specified block height.
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHeight__ | `number` | **
+__blockHeight__ | `number` | *The height of the block to fetch the committee for*
 __*return*__ | `Promise.<object>` | *A javascript object containing the committee*
 
 #### Examples
 
 ```javascript
-const committee = await networkClient.getCommitteByBlockHeight(1234);
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Create a network client and get the committee for a specific block.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const committee = await networkClient.getCommitteeByBlockHeight(1234);
 ```
 
 ---
 
-### `getLatestHeight()`
+### `getLatestHeight() ► Promise.<number>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
 Returns the latest block height.
 
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<number>` | *The latest block height.*
+
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const latestHeight = networkClient.getLatestHeight();
 ```
 
 ---
 
-### `getLatestBlockHash()`
+### `getLatestBlockHash() ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
 Returns the latest block hash.
 
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<string>` | *The latest block hash.*
+
 #### Examples
 
 ```javascript
-const latestHash - newtworkClient.getLatestBlockHash();
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Get the latest block hash.
+const latestHash = networkClient.getLatestBlockHash();
 ```
 
 ---
@@ -342,6 +486,11 @@ __*return*__ | `Promise.<string>` | *Source code of the program*
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const program = networkClient.getProgram("hello_hello.aleo");
 const expectedSource = "program hello_hello.aleo;\n\nfunction hello:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n"
 assert.equal(program, expectedSource);
@@ -363,6 +512,11 @@ __*return*__ | `Promise.<Program>` | *Source code of the program*
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const programID = "hello_hello.aleo";
 const programSource = "program hello_hello.aleo;\n\nfunction hello:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n"
 
@@ -371,7 +525,7 @@ const programObjectFromID = await networkClient.getProgramObject(programID);
 const programObjectFromSource = await networkClient.getProgramObject(programSource);
 
 // Both program objects should be equal
-assert.equal(programObjectFromID.to_string(), programObjectFromSource.to_string());
+assert(programObjectFromID.to_string() === programObjectFromSource.to_string());
 ```
 
 ---
@@ -390,11 +544,16 @@ __*return*__ | `Promise.<ProgramImports>` | *Object of the form { &quot;program_
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
 const double_test_source = "import multiply_test.aleo;\n\nprogram double_test.aleo;\n\nfunction double_it:\n    input r0 as u32.private;\n    call multiply_test.aleo/multiply 2u32 r0 into r1;\n    output r1 as u32.private;\n"
 const double_test = Program.fromString(double_test_source);
 const expectedImports = {
     "multiply_test.aleo": "program multiply_test.aleo;\n\nfunction multiply:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    mul r0 r1 into r2;\n    output r2 as u32.private;\n"
 }
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
 
 // Imports can be fetched using the program ID, source code, or program object
 let programImports = await networkClient.getProgramImports("double_test.aleo");
@@ -425,14 +584,19 @@ __*return*__ | `Array.<string>` | *- The list of program names that the program 
 #### Examples
 
 ```javascript
-const programImportsNames = networkClient.getProgramImports("double_test.aleo");
-const expectedImportsNames = ["multiply_test.aleo"];
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+const programImportsNames = networkClient.getProgramImports("wrapped_credits.aleo");
+const expectedImportsNames = ["credits.aleo"];
 assert.deepStrictEqual(programImportsNames, expectedImportsNames);
 ```
 
 ---
 
-### `getProgramMappingNames(programId)`
+### `getProgramMappingNames(programId) ► Promise.<Array.<string>>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -441,10 +605,16 @@ Returns the names of the mappings of a program.
 Parameters | Type | Description
 --- | --- | ---
 __programId__ | `string` | *The program ID to get the mappings of (e.g. &quot;credits.aleo&quot;)*
+__*return*__ | `Promise.<Array.<string>>` | *- The names of the mappings of the program.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const mappings = networkClient.getProgramMappingNames("credits.aleo");
 const expectedMappings = [
   "committee",
@@ -470,38 +640,46 @@ Parameters | Type | Description
 --- | --- | ---
 __programId__ | `string` | *The program ID to get the mapping value of (e.g. &quot;credits.aleo&quot;)*
 __mappingName__ | `string` | *The name of the mapping to get the value of (e.g. &quot;account&quot;)*
-__key__ | `string` | *The key of the mapping to get the value of (e.g. &quot;aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px&quot;)*
+__key__ | `string` | *The key to look up in the mapping (e.g. an address for the &quot;account&quot; mapping)*
 __*return*__ | `Promise.<string>` | *String representation of the value of the mapping*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 // Get public balance of an account
 const mappingValue = networkClient.getMappingValue("credits.aleo", "account", "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px");
 const expectedValue = "0u64";
-assert.equal(mappingValue, expectedValue);
+assert(mappingValue === expectedValue);
 ```
 
 ---
 
-### `getProgramMappingPlaintext(programId, mappingName, key) ► Promise.<string>`
+### `getProgramMappingPlaintext(programId, mappingName, key) ► Promise.<Plaintext>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Returns the value of a mapping as a wasm Plaintext object. Returning an
-object in this format allows it to be converted to a Js type and for its
-internal members to be inspected if it&#x27;s a struct or array.
+Returns the value of a mapping as a wasm Plaintext object. Returning an object in this format allows it to be converted to a Js type and for its internal members to be inspected if it&#x27;s a struct or array.
 
 Parameters | Type | Description
 --- | --- | ---
 __programId__ | `string` | *The program ID to get the mapping value of (e.g. &quot;credits.aleo&quot;)*
-__mappingName__ | `string` | *The name of the mapping to get the value of (e.g. &quot;account&quot;)*
-__key__ | `string` | *The key of the mapping to get the value of (e.g. &quot;aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px&quot;)*
-__*return*__ | `Promise.<string>` | *String representation of the value of the mapping*
+__mappingName__ | `string` | *The name of the mapping to get the value of (e.g. &quot;bonded&quot;)*
+__key__ | `string` | *The key to look up in the mapping (e.g. an address for the &quot;bonded&quot; mapping)*
+__*return*__ | `Promise.<Plaintext>` | *String representation of the value of the mapping*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 // Get the bond state as an account.
 const unbondedState = networkClient.getMappingPlaintext("credits.aleo", "bonded", "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px");
 
@@ -518,14 +696,14 @@ const unbondedStateObject = unbondedState.toObject();
 
 const expectedState = {
     validator: "aleo1u6940v5m0fzud859xx2c9tj2gjg6m5qrd28n636e6fdd2akvfcgqs34mfd",
-    microcredits: BigInt("9007199254740991")
+    microcredits: BigInt(9007199254740991)
 };
 assert.equal(unbondedState, expectedState);
 ```
 
 ---
 
-### `getPublicBalance(address)`
+### `getPublicBalance(address) ► Promise.<number>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -533,32 +711,51 @@ Returns the public balance of an address from the account mapping in credits.ale
 
 Parameters | Type | Description
 --- | --- | ---
-__address__ | `string` | **
+__address__ | [Address](sdk-src_wasm.md) | *A string or wasm object representing an address.*
+__*return*__ | `Promise.<number>` | *The public balance of the address in microcredits.*
 
 #### Examples
 
 ```javascript
-const account = new Account();
-const publicBalance = networkClient.getPublicBalance(account.address());
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Get the balance of an account from either an address object or address string.
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+const publicBalance = await networkClient.getPublicBalance(account.address());
+const publicBalanceFromString = await networkClient.getPublicBalance(account.address().to_string());
+assert(publicBalance === publicBalanceFromString);
 ```
 
 ---
 
-### `getStateRoot()`
+### `getStateRoot() ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
 Returns the latest state/merkle root of the Aleo blockchain.
 
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<string>` | *A string representing the latest state root of the Aleo blockchain.*
+
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Get the latest state root.
 const stateRoot = networkClient.getStateRoot();
 ```
 
 ---
 
-### `getTransaction(transactionId)`
+### `getTransaction(transactionId) ► Promise.<TransactionJSON>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -566,17 +763,23 @@ Returns a transaction by its unique identifier.
 
 Parameters | Type | Description
 --- | --- | ---
-__transactionId__ | `string` | **
+__transactionId__ | `string` | *The transaction ID to fetch.*
+__*return*__ | `Promise.<TransactionJSON>` | *A json representation of the transaction.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const transaction = networkClient.getTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
 ```
 
 ---
 
-### `getConfirmedTransaction(transactionId)`
+### `getConfirmedTransaction(transactionId) ► Promise.<ConfirmedTransactionJSON>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -584,17 +787,24 @@ Returns a confirmed transaction by its unique identifier.
 
 Parameters | Type | Description
 --- | --- | ---
-__transactionId__ | `string` | **
+__transactionId__ | `string` | *The transaction ID to fetch.*
+__*return*__ | `Promise.<ConfirmedTransactionJSON>` | *A json object containing the confirmed transaction.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const transaction = networkClient.getConfirmedTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
+assert.equal(transaction.status, "confirmed");
 ```
 
 ---
 
-### `getTransactionObject(transactionId)`
+### `getTransactionObject(transactionId) ► Promise.<Transaction>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -603,17 +813,18 @@ outputs, and records to be searched for and displayed.
 
 Parameters | Type | Description
 --- | --- | ---
-__transactionId__ | `string` | **
+__transactionId__ | `string` | *The unique identifier of the transaction to fetch*
+__*return*__ | `Promise.<Transaction>` | *A wasm object representation of the transaction.*
 
 #### Examples
 
 ```javascript
 const transactionObject = networkClient.getTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
 // Get the transaction inputs as a JS array.
-const transactionOutputs = transactionObject.inputs(true);
+const transactionInputs = transactionObject.inputs(true);
 
 // Get the transaction outputs as a JS object.
-const transactionInputs = transactionObject.outputs(true);
+const transactionOutputs = transactionObject.outputs(true);
 
 // Get any records generated in transitions in the transaction as a JS object.
 const records = transactionObject.records();
@@ -625,13 +836,10 @@ assert.equal(transactionType, "Execute");
 // Get a JS representation of all inputs, outputs, and transaction metadata.
 const transactionSummary = transactionObject.summary();
 ```
-```javascript
-const transaction = networkClient.getTransactionObject("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
-```
 
 ---
 
-### `getTransactions(blockHeight)`
+### `getTransactions(blockHeight) ► Promise.<Array.<ConfirmedTransactionJSON>>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -639,17 +847,23 @@ Returns the transactions present at the specified block height.
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHeight__ | `number` | **
+__blockHeight__ | `number` | *The block height to fetch the confirmed transactions at.*
+__*return*__ | `Promise.<Array.<ConfirmedTransactionJSON>>` | *An array of confirmed transactions (in JSON format) for the block height.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const transactions = networkClient.getTransactions(654);
 ```
 
 ---
 
-### `getTransactionsByBlockHash(blockHash)`
+### `getTransactionsByBlockHash(blockHash) ► Promise.<Array.<ConfirmedTransactionJSON>>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -657,31 +871,47 @@ Returns the confirmed transactions present in the block with the specified block
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHash__ | `string` | **
+__blockHash__ | `string` | *The block hash to fetch the confirmed transactions at.*
+__*return*__ | `Promise.<Array.<ConfirmedTransactionJSON>>` | *An array of confirmed transactions (in JSON format) for the block hash.*
 
 #### Examples
 
 ```javascript
-const transactions = networkClient.getTransactionsByHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8x0t6dr72py8r87pxupqfne5t9");
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+const transactions = networkClient.getTransactionsByBlockHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8x0t6dr72py8r87pxupqfne5t9");
 ```
 
 ---
 
-### `getTransactionsInMempool()`
+### `getTransactionsInMempool() ► Promise.<Array.<TransactionJSON>>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
 Returns the transactions in the memory pool. This method requires access to a validator&#x27;s REST API.
 
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<Array.<TransactionJSON>>` | *An array of transactions (in JSON format) currently in the mempool.*
+
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Get the current transactions in the mempool.
 const transactions = networkClient.getTransactionsInMempool();
 ```
 
 ---
 
-### `getTransitionId(inputOrOutputID)`
+### `getTransitionId(inputOrOutputID) ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -689,7 +919,8 @@ Returns the transition ID of the transition corresponding to the ID of the input
 
 Parameters | Type | Description
 --- | --- | ---
-__inputOrOutputID__ | `string` | *ID of the input or output.*
+__inputOrOutputID__ | `string` | *The unique identifier of the input or output to find the transition ID for*
+__*return*__ | `Promise.<string>` | *- The transition ID of the input or output ID.*
 
 #### Examples
 
@@ -699,7 +930,7 @@ const transitionId = networkClient.getTransitionId("2429232855236830926144356377
 
 ---
 
-### `submitTransaction(transaction) ► string`
+### `submitTransaction(transaction) ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -707,12 +938,12 @@ Submit an execute or deployment transaction to the Aleo network.
 
 Parameters | Type | Description
 --- | --- | ---
-__transaction__ | [Transaction](sdk-src_wasm.md) | *The transaction to submit to the network*
-__*return*__ | `string` | *- The transaction id of the submitted transaction or the resulting error*
+__transaction__ | [Transaction](sdk-src_wasm.md) | *The transaction to submit, either as a Transaction object or string representation*
+__*return*__ | `Promise.<string>` | *- The transaction id of the submitted transaction or the resulting error*
 
 ---
 
-### `submitSolution(solution)`
+### `submitSolution(solution) ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -720,19 +951,45 @@ Submit a solution to the Aleo network.
 
 Parameters | Type | Description
 --- | --- | ---
-__solution__ | `string` | *The string representation of the solution desired to be submitted to the network.*
+__solution__ | `string` | *The string representation of the solution to submit*
+__*return*__ | `Promise.<string>` | *The solution id of the submitted solution or the resulting error.*
 
 ---
 
-### `waitForTransactionConfirmation(solution)`
+### `waitForTransactionConfirmation(transactionId, checkInterval, timeout) ► Promise.<Transaction>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Await a transaction to be confirmed on the Aleo network.
+Await a submitted transaction to be confirmed or rejected on the Aleo network.
 
 Parameters | Type | Description
 --- | --- | ---
-__solution__ | `string` | *The string representation of the solution desired to be submitted to the network.*
+__transactionId__ | `string` | *The transaction ID to wait for confirmation*
+__checkInterval__ | `number` | *The interval in milliseconds to check for confirmation (default: 2000)*
+__timeout__ | `number` | *The maximum time in milliseconds to wait for confirmation (default: 45000)*
+__*return*__ | `Promise.<Transaction>` | *The confirmed transaction object that returns if the transaction is confirmed.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient, Account, ProgramManager } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client and program manager.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const programManager = new ProgramManager(networkClient);
+
+// Set the account for the program manager.
+programManager.setAccount(Account.fromCiphertext(process.env.ciphertext, process.env.password));
+
+// Build a transfer transaction.
+const tx = await programManager.buildTransferPublicTransaction(100, "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px", 0);
+
+// Submit the transaction to the network.
+const transactionId = await networkClient.submitTransaction(tx);
+
+// Wait for the transaction to be confirmed.
+const transaction = await networkClient.waitForTransactionConfirmation(transactionId);
+```
 
 ---
 
@@ -744,11 +1001,14 @@ Set an account to use in networkClient calls
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | **
+__account__ | [Account](sdk-src_account.md) | *Set an account to use for record scanning functions.*
 
 #### Examples
 
 ```javascript
+import { Account, AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1");
 const account = new Account();
 networkClient.setAccount(account);
 ```
@@ -784,6 +1044,18 @@ Parameters | Type | Description
 __host__ | `string` | *The address of a node hosting the Aleo API*
 __host__ | `undefined` | **
 
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a networkClient that connects to a local node.
+const networkClient = new AleoNetworkClient("http://0.0.0.0:3030", undefined);
+
+// Set the host to a public node.
+networkClient.setHost("http://api.explorer.provable.com/v1");
+```
+
 ---
 
 ### `fetchData(url) ► Promise.<Type>`
@@ -794,7 +1066,7 @@ Fetches data from the Aleo network and returns it as a JSON object.
 
 Parameters | Type | Description
 --- | --- | ---
-__url__ | `undefined` | **
+__url__ | `undefined` | *The URL to fetch data from.*
 __*return*__ | `Promise.<Type>` | **
 
 ---
@@ -831,11 +1103,20 @@ __amounts__ | `Array.<number>` | *The amounts (in microcredits) to search for (e
 __maxMicrocredits__ | `number` | *The maximum number of microcredits to search for*
 __nonces__ | `Array.<string>` | *The nonces of already found records to exclude from the search*
 __privateKey__ | `string` | *An optional private key to use to find unspent records.*
-__*return*__ | `Promise.<Array.<RecordPlaintext>>` | **
+__*return*__ | `Promise.<Array.<RecordPlaintext>>` | *An array of records belonging to the account configured in the network client.*
 
 #### Examples
 
 ```javascript
+import { Account, AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Import an account from a ciphertext and password.
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+networkClient.setAccount(account);
+
 // Find specific amounts
 const startHeight = 500000;
 const amounts = [600000, 1000000];
@@ -863,11 +1144,19 @@ __amounts__ | `Array.<number>` | *The amounts (in microcredits) to search for (e
 __maxMicrocredits__ | `number` | *The maximum number of microcredits to search for*
 __nonces__ | `Array.<string>` | *The nonces of already found records to exclude from the search*
 __privateKey__ | `string` | *An optional private key to use to find unspent records.*
-__*return*__ | `Promise.<Array.<RecordPlaintext>>` | **
+__*return*__ | `Promise.<Array.<RecordPlaintext>>` | *An array of unspent records belonging to the account configured in the network client.*
 
 #### Examples
 
 ```javascript
+import { Account, AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+
+// Create a network client and set an account to search for records with.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+networkClient.setAccount(account);
+
 // Find specific amounts
 const startHeight = 500000;
 const endHeight = 550000;
@@ -889,8 +1178,8 @@ Returns the contents of the block at the specified block height.
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHeight__ | `number` | **
-__*return*__ | `Promise.<BlockJSON>` | **
+__blockHeight__ | `number` | *The height of the block to fetch*
+__*return*__ | `Promise.<BlockJSON>` | *A javascript object containing the block at the specified height*
 
 #### Examples
 
@@ -908,12 +1197,15 @@ Returns the contents of the block with the specified hash.
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHash__ | `string` | **
-__*return*__ | `Promise.<BlockJSON>` | **
+__blockHash__ | `string` | *The hash of the block to fetch.*
+__*return*__ | `Promise.<BlockJSON>` | *A javascript object representation of the block matching the hash.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
 const block = networkClient.getBlockByHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8x0t6dr72py8r87pxupqfne5t9");
 ```
 
@@ -923,23 +1215,33 @@ const block = networkClient.getBlockByHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Returns a range of blocks between the specified block heights.
+Returns a range of blocks between the specified block heights. A maximum of 50 blocks can be fetched at a time.
 
 Parameters | Type | Description
 --- | --- | ---
-__start__ | `number` | **
-__end__ | `number` | **
-__*return*__ | `Promise.<Array.<BlockJSON>>` | **
+__start__ | `number` | *Starting block to fetch.*
+__end__ | `number` | *Ending block to fetch. This cannot be more than 50 blocks ahead of the start block.*
+__*return*__ | `Promise.<Array.<BlockJSON>>` | *An array of block objects*
 
 #### Examples
 
 ```javascript
-const blockRange = networkClient.getBlockRange(2050, 2100);
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Fetch 50 blocks.
+const (start, end) = (2050, 2100);
+const blockRange = networkClient.getBlockRange(start, end);
+
+let cursor = start;
+blockRange.forEach((block) => {
+  assert(block.height == cursor);
+  cursor += 1;
+ }
 ```
 
 ---
 
-### `getDeploymentTransactionIDForProgram(program) ► TransactionJSON`
+### `getDeploymentTransactionIDForProgram(program) ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -947,25 +1249,55 @@ Returns the deployment transaction id associated with the specified program.
 
 Parameters | Type | Description
 --- | --- | ---
-__program__ | [Program](sdk-src_wasm.md) | **
-__*return*__ | `TransactionJSON` | **
+__program__ | [Program](sdk-src_wasm.md) | *The name of the deployed program OR a wasm Program object.*
+__*return*__ | `Promise.<string>` | *The transaction ID of the deployment transaction.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/testnet.js";
+
+// Get the transaction ID of the deployment transaction for a program.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const transactionId = networkClient.getDeploymentTransactionIDForProgram("hello_hello.aleo");
+
+// Get the transaction data for the deployment transaction.
+const transaction = networkClient.getTransactionObject(transactionId);
+
+// Get the verifying keys for the functions in the deployed program.
+const verifyingKeys = transaction.verifyingKeys();
+```
 
 ---
 
-### `getDeploymentTransactionForProgram(program) ► TransactionJSON`
+### `getDeploymentTransactionForProgram(program) ► Promise.<Transaction>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Returns the deployment transaction associated with a specified program.
+Returns the deployment transaction associated with a specified program as a JSON object.
 
 Parameters | Type | Description
 --- | --- | ---
-__program__ | [Program](sdk-src_wasm.md) | **
-__*return*__ | `TransactionJSON` | **
+__program__ | [Program](sdk-src_wasm.md) | *The name of the deployed program OR a wasm Program object.*
+__*return*__ | `Promise.<Transaction>` | *JSON representation of the deployment transaction.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient, DeploymentJSON } from "@provablehq/sdk/testnet.js";
+
+// Get the transaction ID of the deployment transaction for a program.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const transaction = networkClient.getDeploymentTransactionForProgram("hello_hello.aleo");
+
+// Get the verifying keys for each function in the deployment.
+const deployment = <DeploymentJSON>transaction.deployment;
+const verifyingKeys = deployment.verifying_keys;
+```
 
 ---
 
-### `getDeploymentTransactionObjectForProgram(program) ► TransactionJSON`
+### `getDeploymentTransactionObjectForProgram(program) ► Promise.<Transaction>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -973,8 +1305,24 @@ Returns the deployment transaction associated with a specified program as a wasm
 
 Parameters | Type | Description
 --- | --- | ---
-__program__ | [Program](sdk-src_wasm.md) | **
-__*return*__ | `TransactionJSON` | **
+__program__ | [Program](sdk-src_wasm.md) | *The name of the deployed program OR a wasm Program object.*
+__*return*__ | `Promise.<Transaction>` | *Wasm object representation of the deployment transaction.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/testnet.js";
+
+// Get the transaction ID of the deployment transaction for a program.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const transactionId = networkClient.getDeploymentTransactionIDForProgram("hello_hello.aleo");
+
+// Get the transaction data for the deployment transaction.
+const transaction = networkClient.getDeploymentTransactionObjectForProgram(transactionId);
+
+// Get the verifying keys for the functions in the deployed program.
+const verifyingKeys = transaction.verifyingKeys();
+```
 
 ---
 
@@ -982,15 +1330,20 @@ __*return*__ | `TransactionJSON` | **
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Returns the contents of the latest block.
+Returns the contents of the latest block as JSON.
 
 Parameters | Type | Description
 --- | --- | ---
-__*return*__ | `Promise.<BlockJSON>` | **
+__*return*__ | `Promise.<BlockJSON>` | *A javascript object containing the latest block*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/testnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const latestHeight = networkClient.getLatestBlock();
 ```
 
@@ -1006,23 +1359,43 @@ Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `Promise.<object>` | *A javascript object containing the latest committee*
 
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Create a network client and get the latest committee.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const latestCommittee = await networkClient.getLatestCommittee();
+```
+
 ---
 
 ### `getCommitteeByBlockHeight(blockHeight) ► Promise.<object>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Returns the committe at the specified block height.
+Returns the committee at the specified block height.
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHeight__ | `number` | **
+__blockHeight__ | `number` | *The height of the block to fetch the committee for*
 __*return*__ | `Promise.<object>` | *A javascript object containing the committee*
 
 #### Examples
 
 ```javascript
-const committee = await networkClient.getCommitteByBlockHeight(1234);
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Create a network client and get the committee for a specific block.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const committee = await networkClient.getCommitteeByBlockHeight(1234);
 ```
 
 ---
@@ -1035,11 +1408,16 @@ Returns the latest block height.
 
 Parameters | Type | Description
 --- | --- | ---
-__*return*__ | `Promise.<number>` | **
+__*return*__ | `Promise.<number>` | *The latest block height.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const latestHeight = networkClient.getLatestHeight();
 ```
 
@@ -1053,12 +1431,18 @@ Returns the latest block hash.
 
 Parameters | Type | Description
 --- | --- | ---
-__*return*__ | `Promise.<string>` | **
+__*return*__ | `Promise.<string>` | *The latest block hash.*
 
 #### Examples
 
 ```javascript
-const latestHash - newtworkClient.getLatestBlockHash();
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Get the latest block hash.
+const latestHash = networkClient.getLatestBlockHash();
 ```
 
 ---
@@ -1077,6 +1461,11 @@ __*return*__ | `Promise.<string>` | *Source code of the program*
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const program = networkClient.getProgram("hello_hello.aleo");
 const expectedSource = "program hello_hello.aleo;\n\nfunction hello:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n"
 assert.equal(program, expectedSource);
@@ -1098,6 +1487,11 @@ __*return*__ | `Promise.<Program>` | *Source code of the program*
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const programID = "hello_hello.aleo";
 const programSource = "program hello_hello.aleo;\n\nfunction hello:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n"
 
@@ -1106,7 +1500,7 @@ const programObjectFromID = await networkClient.getProgramObject(programID);
 const programObjectFromSource = await networkClient.getProgramObject(programSource);
 
 // Both program objects should be equal
-assert.equal(programObjectFromID.to_string(), programObjectFromSource.to_string());
+assert(programObjectFromID.to_string() === programObjectFromSource.to_string());
 ```
 
 ---
@@ -1125,11 +1519,16 @@ __*return*__ | `Promise.<ProgramImports>` | *Object of the form { &quot;program_
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
 const double_test_source = "import multiply_test.aleo;\n\nprogram double_test.aleo;\n\nfunction double_it:\n    input r0 as u32.private;\n    call multiply_test.aleo/multiply 2u32 r0 into r1;\n    output r1 as u32.private;\n"
 const double_test = Program.fromString(double_test_source);
 const expectedImports = {
     "multiply_test.aleo": "program multiply_test.aleo;\n\nfunction multiply:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    mul r0 r1 into r2;\n    output r2 as u32.private;\n"
 }
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
 
 // Imports can be fetched using the program ID, source code, or program object
 let programImports = await networkClient.getProgramImports("double_test.aleo");
@@ -1160,8 +1559,13 @@ __*return*__ | `Array.<string>` | *- The list of program names that the program 
 #### Examples
 
 ```javascript
-const programImportsNames = networkClient.getProgramImports("double_test.aleo");
-const expectedImportsNames = ["multiply_test.aleo"];
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+const programImportsNames = networkClient.getProgramImports("wrapped_credits.aleo");
+const expectedImportsNames = ["credits.aleo"];
 assert.deepStrictEqual(programImportsNames, expectedImportsNames);
 ```
 
@@ -1176,11 +1580,16 @@ Returns the names of the mappings of a program.
 Parameters | Type | Description
 --- | --- | ---
 __programId__ | `string` | *The program ID to get the mappings of (e.g. &quot;credits.aleo&quot;)*
-__*return*__ | `Promise.<Array.<string>>` | **
+__*return*__ | `Promise.<Array.<string>>` | *- The names of the mappings of the program.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const mappings = networkClient.getProgramMappingNames("credits.aleo");
 const expectedMappings = [
   "committee",
@@ -1206,38 +1615,46 @@ Parameters | Type | Description
 --- | --- | ---
 __programId__ | `string` | *The program ID to get the mapping value of (e.g. &quot;credits.aleo&quot;)*
 __mappingName__ | `string` | *The name of the mapping to get the value of (e.g. &quot;account&quot;)*
-__key__ | `string` | *The key of the mapping to get the value of (e.g. &quot;aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px&quot;)*
+__key__ | `string` | *The key to look up in the mapping (e.g. an address for the &quot;account&quot; mapping)*
 __*return*__ | `Promise.<string>` | *String representation of the value of the mapping*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 // Get public balance of an account
 const mappingValue = networkClient.getMappingValue("credits.aleo", "account", "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px");
 const expectedValue = "0u64";
-assert.equal(mappingValue, expectedValue);
+assert(mappingValue === expectedValue);
 ```
 
 ---
 
-### `getProgramMappingPlaintext(programId, mappingName, key) ► Promise.<string>`
+### `getProgramMappingPlaintext(programId, mappingName, key) ► Promise.<Plaintext>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Returns the value of a mapping as a wasm Plaintext object. Returning an
-object in this format allows it to be converted to a Js type and for its
-internal members to be inspected if it&#x27;s a struct or array.
+Returns the value of a mapping as a wasm Plaintext object. Returning an object in this format allows it to be converted to a Js type and for its internal members to be inspected if it&#x27;s a struct or array.
 
 Parameters | Type | Description
 --- | --- | ---
 __programId__ | `string` | *The program ID to get the mapping value of (e.g. &quot;credits.aleo&quot;)*
-__mappingName__ | `string` | *The name of the mapping to get the value of (e.g. &quot;account&quot;)*
-__key__ | `string` | *The key of the mapping to get the value of (e.g. &quot;aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px&quot;)*
-__*return*__ | `Promise.<string>` | *String representation of the value of the mapping*
+__mappingName__ | `string` | *The name of the mapping to get the value of (e.g. &quot;bonded&quot;)*
+__key__ | `string` | *The key to look up in the mapping (e.g. an address for the &quot;bonded&quot; mapping)*
+__*return*__ | `Promise.<Plaintext>` | *String representation of the value of the mapping*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 // Get the bond state as an account.
 const unbondedState = networkClient.getMappingPlaintext("credits.aleo", "bonded", "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px");
 
@@ -1254,7 +1671,7 @@ const unbondedStateObject = unbondedState.toObject();
 
 const expectedState = {
     validator: "aleo1u6940v5m0fzud859xx2c9tj2gjg6m5qrd28n636e6fdd2akvfcgqs34mfd",
-    microcredits: BigInt("9007199254740991")
+    microcredits: BigInt(9007199254740991)
 };
 assert.equal(unbondedState, expectedState);
 ```
@@ -1269,14 +1686,22 @@ Returns the public balance of an address from the account mapping in credits.ale
 
 Parameters | Type | Description
 --- | --- | ---
-__address__ | `string` | **
-__*return*__ | `Promise.<number>` | **
+__address__ | [Address](sdk-src_wasm.md) | *A string or wasm object representing an address.*
+__*return*__ | `Promise.<number>` | *The public balance of the address in microcredits.*
 
 #### Examples
 
 ```javascript
-const account = new Account();
-const publicBalance = networkClient.getPublicBalance(account.address());
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Get the balance of an account from either an address object or address string.
+const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+const publicBalance = await networkClient.getPublicBalance(account.address());
+const publicBalanceFromString = await networkClient.getPublicBalance(account.address().to_string());
+assert(publicBalance === publicBalanceFromString);
 ```
 
 ---
@@ -1289,11 +1714,17 @@ Returns the latest state/merkle root of the Aleo blockchain.
 
 Parameters | Type | Description
 --- | --- | ---
-__*return*__ | `Promise.<string>` | **
+__*return*__ | `Promise.<string>` | *A string representing the latest state root of the Aleo blockchain.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Get the latest state root.
 const stateRoot = networkClient.getStateRoot();
 ```
 
@@ -1307,12 +1738,17 @@ Returns a transaction by its unique identifier.
 
 Parameters | Type | Description
 --- | --- | ---
-__transactionId__ | `string` | **
-__*return*__ | `Promise.<TransactionJSON>` | **
+__transactionId__ | `string` | *The transaction ID to fetch.*
+__*return*__ | `Promise.<TransactionJSON>` | *A json representation of the transaction.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const transaction = networkClient.getTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
 ```
 
@@ -1326,13 +1762,19 @@ Returns a confirmed transaction by its unique identifier.
 
 Parameters | Type | Description
 --- | --- | ---
-__transactionId__ | `string` | **
-__*return*__ | `Promise.<ConfirmedTransactionJSON>` | **
+__transactionId__ | `string` | *The transaction ID to fetch.*
+__*return*__ | `Promise.<ConfirmedTransactionJSON>` | *A json object containing the confirmed transaction.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const transaction = networkClient.getConfirmedTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
+assert.equal(transaction.status, "confirmed");
 ```
 
 ---
@@ -1346,18 +1788,18 @@ outputs, and records to be searched for and displayed.
 
 Parameters | Type | Description
 --- | --- | ---
-__transactionId__ | `string` | **
-__*return*__ | `Promise.<Transaction>` | **
+__transactionId__ | `string` | *The unique identifier of the transaction to fetch*
+__*return*__ | `Promise.<Transaction>` | *A wasm object representation of the transaction.*
 
 #### Examples
 
 ```javascript
 const transactionObject = networkClient.getTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
 // Get the transaction inputs as a JS array.
-const transactionOutputs = transactionObject.inputs(true);
+const transactionInputs = transactionObject.inputs(true);
 
 // Get the transaction outputs as a JS object.
-const transactionInputs = transactionObject.outputs(true);
+const transactionOutputs = transactionObject.outputs(true);
 
 // Get any records generated in transitions in the transaction as a JS object.
 const records = transactionObject.records();
@@ -1368,9 +1810,6 @@ assert.equal(transactionType, "Execute");
 
 // Get a JS representation of all inputs, outputs, and transaction metadata.
 const transactionSummary = transactionObject.summary();
-```
-```javascript
-const transaction = networkClient.getTransactionObject("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
 ```
 
 ---
@@ -1383,12 +1822,17 @@ Returns the transactions present at the specified block height.
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHeight__ | `number` | **
-__*return*__ | `Promise.<Array.<ConfirmedTransactionJSON>>` | **
+__blockHeight__ | `number` | *The block height to fetch the confirmed transactions at.*
+__*return*__ | `Promise.<Array.<ConfirmedTransactionJSON>>` | *An array of confirmed transactions (in JSON format) for the block height.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
 const transactions = networkClient.getTransactions(654);
 ```
 
@@ -1402,13 +1846,18 @@ Returns the confirmed transactions present in the block with the specified block
 
 Parameters | Type | Description
 --- | --- | ---
-__blockHash__ | `string` | **
-__*return*__ | `Promise.<Array.<ConfirmedTransactionJSON>>` | **
+__blockHash__ | `string` | *The block hash to fetch the confirmed transactions at.*
+__*return*__ | `Promise.<Array.<ConfirmedTransactionJSON>>` | *An array of confirmed transactions (in JSON format) for the block hash.*
 
 #### Examples
 
 ```javascript
-const transactions = networkClient.getTransactionsByHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8x0t6dr72py8r87pxupqfne5t9");
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+const transactions = networkClient.getTransactionsByBlockHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8x0t6dr72py8r87pxupqfne5t9");
 ```
 
 ---
@@ -1421,11 +1870,17 @@ Returns the transactions in the memory pool. This method requires access to a va
 
 Parameters | Type | Description
 --- | --- | ---
-__*return*__ | `Promise.<Array.<TransactionJSON>>` | **
+__*return*__ | `Promise.<Array.<TransactionJSON>>` | *An array of transactions (in JSON format) currently in the mempool.*
 
 #### Examples
 
 ```javascript
+import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+
+// Get the current transactions in the mempool.
 const transactions = networkClient.getTransactionsInMempool();
 ```
 
@@ -1439,8 +1894,8 @@ Returns the transition ID of the transition corresponding to the ID of the input
 
 Parameters | Type | Description
 --- | --- | ---
-__inputOrOutputID__ | `string` | *ID of the input or output.*
-__*return*__ | `Promise.<string>` | **
+__inputOrOutputID__ | `string` | *The unique identifier of the input or output to find the transition ID for*
+__*return*__ | `Promise.<string>` | *- The transition ID of the input or output ID.*
 
 #### Examples
 
@@ -1450,7 +1905,7 @@ const transitionId = networkClient.getTransitionId("2429232855236830926144356377
 
 ---
 
-### `submitTransaction(transaction) ► string`
+### `submitTransaction(transaction) ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -1458,8 +1913,8 @@ Submit an execute or deployment transaction to the Aleo network.
 
 Parameters | Type | Description
 --- | --- | ---
-__transaction__ | [Transaction](sdk-src_wasm.md) | *The transaction to submit to the network*
-__*return*__ | `string` | *- The transaction id of the submitted transaction or the resulting error*
+__transaction__ | [Transaction](sdk-src_wasm.md) | *The transaction to submit, either as a Transaction object or string representation*
+__*return*__ | `Promise.<string>` | *- The transaction id of the submitted transaction or the resulting error*
 
 ---
 
@@ -1471,20 +1926,44 @@ Submit a solution to the Aleo network.
 
 Parameters | Type | Description
 --- | --- | ---
-__solution__ | `string` | *The string representation of the solution desired to be submitted to the network.*
-__*return*__ | `Promise.<string>` | **
+__solution__ | `string` | *The string representation of the solution to submit*
+__*return*__ | `Promise.<string>` | *The solution id of the submitted solution or the resulting error.*
 
 ---
 
-### `waitForTransactionConfirmation(solution) ► Promise.<Transaction>`
+### `waitForTransactionConfirmation(transactionId, checkInterval, timeout) ► Promise.<Transaction>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Await a transaction to be confirmed on the Aleo network.
+Await a submitted transaction to be confirmed or rejected on the Aleo network.
 
 Parameters | Type | Description
 --- | --- | ---
-__solution__ | `string` | *The string representation of the solution desired to be submitted to the network.*
-__*return*__ | `Promise.<Transaction>` | **
+__transactionId__ | `string` | *The transaction ID to wait for confirmation*
+__checkInterval__ | `number` | *The interval in milliseconds to check for confirmation (default: 2000)*
+__timeout__ | `number` | *The maximum time in milliseconds to wait for confirmation (default: 45000)*
+__*return*__ | `Promise.<Transaction>` | *The confirmed transaction object that returns if the transaction is confirmed.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient, Account, ProgramManager } from "@provablehq/sdk/mainnet.js";
+
+// Create a network client and program manager.
+const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+const programManager = new ProgramManager(networkClient);
+
+// Set the account for the program manager.
+programManager.setAccount(Account.fromCiphertext(process.env.ciphertext, process.env.password));
+
+// Build a transfer transaction.
+const tx = await programManager.buildTransferPublicTransaction(100, "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px", 0);
+
+// Submit the transaction to the network.
+const transactionId = await networkClient.submitTransaction(tx);
+
+// Wait for the transaction to be confirmed.
+const transaction = await networkClient.waitForTransactionConfirmation(transactionId);
+```
 
 ---

--- a/docs/api_reference/sdk-src_wasm.md
+++ b/docs/api_reference/sdk-src_wasm.md
@@ -51,6 +51,106 @@ __*return*__ | [Address](sdk-src_wasm.md) | **
 
 ---
 
+### `fromBytesLe(bytes) ► Address`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get an address from a series of bytes.
+
+Parameters | Type | Description
+--- | --- | ---
+__bytes__ | `Uint8Array` | *A left endian byte array representing the address.*
+__*return*__ | [Address](sdk-src_wasm.md) | *The address object.*
+
+---
+
+### `toBytesLe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the left endian byte array representation of the address.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | **
+
+---
+
+### `fromBitsLe(bits) ► Address`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get an address from a series of bits represented as a boolean array.
+
+Parameters | Type | Description
+--- | --- | ---
+__bits__ | `Array` | *A left endian boolean array representing the bits of the address.*
+__*return*__ | [Address](sdk-src_wasm.md) | *The address object.*
+
+---
+
+### `toBitsLe() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the left endian boolean array representation of the bits of the address.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
+### `fromFields(fields) ► Plaintext`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get an address object from an array of fields.
+
+Parameters | Type | Description
+--- | --- | ---
+__fields__ | `Array` | *An array of fields.*
+__*return*__ | [Plaintext](sdk-src_wasm.md) | *The address object.*
+
+---
+
+### `toFields() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the field array representation of the address.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
+### `fromGroup(group) ► Address`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get an address object from a group.
+
+Parameters | Type | Description
+--- | --- | ---
+__group__ | [Group](sdk-src_wasm.md) | *The group object.*
+__*return*__ | [Address](sdk-src_wasm.md) | *The address object.*
+
+---
+
+### `toGroup() ► Group`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the group representation of the address object.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
 ### `from_string(address) ► Address`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
@@ -74,6 +174,18 @@ Parameters | Type | Description
 --- | --- | ---
 __Address__ | [Address](sdk-src_wasm.md) | **
 __*return*__ | `string` | *String representation of the address*
+
+---
+
+### `toPlaintext() ► Plaintext`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the plaintext representation of the address.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Plaintext](sdk-src_wasm.md) | **
 
 ---
 
@@ -169,6 +281,68 @@ Parameters | Type | Description
 --- | --- | ---
 __bytes__ | `Uint8Array` | *The byte array representing the Ciphertext.*
 __*return*__ | [Ciphertext](sdk-src_wasm.md) | *The Ciphertext object.*
+
+---
+
+### `toBytesLe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the left endian byte array representation of the ciphertext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | **
+
+---
+
+### `fromBitsLe(bits) ► Ciphertext`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get a ciphertext object from a series of bits represented as a boolean array.
+
+Parameters | Type | Description
+--- | --- | ---
+__bits__ | `Array` | *A left endian boolean array representing the bits of the ciphertext.*
+__*return*__ | [Ciphertext](sdk-src_wasm.md) | *The ciphertext object.*
+
+---
+
+### `toBitsLe() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the left endian boolean array representation of the bits of the ciphertext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
+### `fromFields(fields) ► Ciphertext`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get a ciphertext object from an array of fields.
+
+Parameters | Type | Description
+--- | --- | ---
+__fields__ | `Array` | *An array of fields.*
+__*return*__ | [Ciphertext](sdk-src_wasm.md) | *The ciphertext object.*
+
+---
+
+### `toFields() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the field array representation of the ciphertext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
 
 ---
 
@@ -695,6 +869,18 @@ __*return*__ | `Array.<any>` | **
 
 ---
 
+### `toFields() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the field array representation of the group.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
 ### `toXCoordinate() ► Field`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -1055,16 +1241,65 @@ __*return*__ | [Plaintext](sdk-src_wasm.md) | *The plaintext object.*
 
 ---
 
-### `toBytesLe(bytes) ► Uint8Array`
+### `toBytesLe() ► Uint8Array`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Generate a random plaintext element from a series of bytes.
+Get the left endian byte array representation of the plaintext.
 
 Parameters | Type | Description
 --- | --- | ---
-__bytes__ | `Uint8Array` | *A left endian byte array representing the plaintext.*
 __*return*__ | `Uint8Array` | **
+
+---
+
+### `fromBitsLe(bits) ► Plaintext`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get a plaintext object from a series of bits represented as a boolean array.
+
+Parameters | Type | Description
+--- | --- | ---
+__bits__ | `Array` | *A left endian boolean array representing the bits plaintext.*
+__*return*__ | [Plaintext](sdk-src_wasm.md) | *The plaintext object.*
+
+---
+
+### `toBitsLe() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the left endian boolean array representation of the bits of the plaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
+### `fromFields(fields) ► Plaintext`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get a plaintext object from an array of fields.
+
+Parameters | Type | Description
+--- | --- | ---
+__fields__ | `Array` | *An array of fields.*
+__*return*__ | [Plaintext](sdk-src_wasm.md) | *The plaintext object.*
+
+---
+
+### `toFields() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the field array representation of the plaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
 
 ---
 
@@ -2068,6 +2303,55 @@ __*return*__ | [Field](sdk-src_wasm.md) | *tag of the record.*
 
 ---
 
+### `fromBytesLe(bytes) ► RecordCiphertext`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get a record ciphertext object from a series of bytes.
+
+Parameters | Type | Description
+--- | --- | ---
+__bytes__ | `Uint8Array` | *A left endian byte array representing the record ciphertext.*
+__*return*__ | [RecordCiphertext](sdk-src_wasm.md) | **
+
+---
+
+### `toBytesLe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the left endian byte array representation of the record ciphertext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | **
+
+---
+
+### `toBitsLe() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the left endian boolean array representation of the record ciphertext bits.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
+### `toFields() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the field array representation of the record ciphertext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
 # Class `RecordPlaintext`
 
 Plaintext representation of an Aleo record
@@ -2169,6 +2453,55 @@ Returns the record plaintext string
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `string` | *String representation of the record plaintext*
+
+---
+
+### `fromBytesLe(bytes) ► RecordPlaintext`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get a record plaintext object from a series of bytes.
+
+Parameters | Type | Description
+--- | --- | ---
+__bytes__ | `Uint8Array` | *A left endian byte array representing the record plaintext.*
+__*return*__ | [RecordPlaintext](sdk-src_wasm.md) | *The record plaintext.*
+
+---
+
+### `toBytesLe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the left endian byte array representation of the record plaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | *Byte array representation of the record plaintext.*
+
+---
+
+### `toBitsLe() ► Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the left endian boolean array representation of the record plaintext bits.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array` | *Boolean array representation of the record plaintext bits.*
+
+---
+
+### `toFields() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the field array representation of the record plaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
 
 ---
 
@@ -2538,6 +2871,68 @@ __*return*__ | `boolean` | *True if the signature is valid, false otherwise*
 
 ---
 
+### `fromBytesLe(bytes) ► Signature`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get a signature from a series of bytes.
+
+Parameters | Type | Description
+--- | --- | ---
+__bytes__ | `Uint8Array` | *A left endian byte array representing the signature.*
+__*return*__ | [Signature](sdk-src_wasm.md) | *The signature object.*
+
+---
+
+### `toBytesLe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the left endian byte array representation of the signature.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | **
+
+---
+
+### `fromBitsLe(bits) ► Signature`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get a signature from a series of bits represented as a boolean array.
+
+Parameters | Type | Description
+--- | --- | ---
+__bits__ | `Array` | *A left endian boolean array representing the bits of the signature.*
+__*return*__ | [Signature](sdk-src_wasm.md) | *The signature object.*
+
+---
+
+### `toBitsLe() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the left endian boolean array representation of the bits of the signature.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
+### `toFields() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the field array representation of the signature.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
 ### `from_string(signature) ► Signature`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
@@ -2560,6 +2955,18 @@ Get a string representation of a signature
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `string` | *String representation of a signature*
+
+---
+
+### `toPlaintext() ► Plaintext`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the plaintext representation of the signature.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Plaintext](sdk-src_wasm.md) | **
 
 ---
 

--- a/docs/api_reference/toc.md
+++ b/docs/api_reference/toc.md
@@ -4,14 +4,13 @@
 
 * ![category:other](https://img.shields.io/badge/category-other-blue.svg?style=flat-square)
   * [src/account](sdk-src_account.md) - _Key Management class. Enables the creation of a new Aleo Account, importation of an existing account from
-an existing private key or seed, and message signing and verification functionality.
-
-An Aleo Account is generated from a randomly generated seed (number) from which an account private key, view key,
-and a public account address are derived. The private key lies at the root of an Aleo account. It is a highly
-sensitive secret and should be protected as it allows for creation of Aleo Program executions and arbitrary value
-transfers. The View Key allows for decryption of a user&#x27;s activity on the blockchain. The Address is the public
-address to which other users of Aleo can send Aleo credits and other records to. This class should only be used
-in environments where the safety of the underlying key material can be assured._
+an existing private key or seed, and message signing and verification functionality. An Aleo Account is generated
+from a randomly generated seed (number) from which an account private key, view key, and a public account address are
+derived. The private key lies at the root of an Aleo account. It is a highly sensitive secret and should be protected
+as it allows for creation of Aleo Program executions and arbitrary value transfers. The View Key allows for decryption
+of a user&#x27;s activity on the blockchain. The Address is the public address to which other users of Aleo can send Aleo
+credits and other records to. This class should only be used in environments where the safety of the underlying key
+material can be assured._
   * [src/function-key-provider](sdk-src_function-key-provider.md) - _AleoKeyProvider class. Implements the KeyProvider interface. Enables the retrieval of Aleo program proving and
 verifying keys for the credits.aleo program over http from official Aleo sources and storing and retrieving function
 keys from a local memory cache._

--- a/docs/api_reference/toc.md
+++ b/docs/api_reference/toc.md
@@ -11,7 +11,7 @@ and a public account address are derived. The private key lies at the root of an
 sensitive secret and should be protected as it allows for creation of Aleo Program executions and arbitrary value
 transfers. The View Key allows for decryption of a user&#x27;s activity on the blockchain. The Address is the public
 address to which other users of Aleo can send Aleo credits and other records to. This class should only be used
-environments where the safety of the underlying key material can be assured._
+in environments where the safety of the underlying key material can be assured._
   * [src/function-key-provider](sdk-src_function-key-provider.md) - _AleoKeyProvider class. Implements the KeyProvider interface. Enables the retrieval of Aleo program proving and
 verifying keys for the credits.aleo program over http from official Aleo sources and storing and retrieving function
 keys from a local memory cache._

--- a/sdk/src/account.ts
+++ b/sdk/src/account.ts
@@ -16,14 +16,13 @@ interface AccountParam {
 
 /**
  * Key Management class. Enables the creation of a new Aleo Account, importation of an existing account from
- * an existing private key or seed, and message signing and verification functionality.
- *
- * An Aleo Account is generated from a randomly generated seed (number) from which an account private key, view key,
- * and a public account address are derived. The private key lies at the root of an Aleo account. It is a highly
- * sensitive secret and should be protected as it allows for creation of Aleo Program executions and arbitrary value
- * transfers. The View Key allows for decryption of a user's activity on the blockchain. The Address is the public
- * address to which other users of Aleo can send Aleo credits and other records to. This class should only be used
- * in environments where the safety of the underlying key material can be assured.
+ * an existing private key or seed, and message signing and verification functionality. An Aleo Account is generated
+ * from a randomly generated seed (number) from which an account private key, view key, and a public account address are
+ * derived. The private key lies at the root of an Aleo account. It is a highly sensitive secret and should be protected
+ * as it allows for creation of Aleo Program executions and arbitrary value transfers. The View Key allows for decryption
+ * of a user's activity on the blockchain. The Address is the public address to which other users of Aleo can send Aleo
+ * credits and other records to. This class should only be used in environments where the safety of the underlying key
+ * material can be assured.
  *
  * @example
  * import { Account } from "@provablehq/sdk/testnet.js";

--- a/sdk/src/account.ts
+++ b/sdk/src/account.ts
@@ -6,6 +6,7 @@ import {
   ViewKey,
   PrivateKeyCiphertext,
   RecordCiphertext,
+  RecordPlaintext,
 } from "./wasm";
 
 interface AccountParam {
@@ -22,9 +23,11 @@ interface AccountParam {
  * sensitive secret and should be protected as it allows for creation of Aleo Program executions and arbitrary value
  * transfers. The View Key allows for decryption of a user's activity on the blockchain. The Address is the public
  * address to which other users of Aleo can send Aleo credits and other records to. This class should only be used
- * environments where the safety of the underlying key material can be assured.
+ * in environments where the safety of the underlying key material can be assured.
  *
  * @example
+ * import { Account } from "@provablehq/sdk/testnet.js";
+ *
  * // Create a new account
  * const myRandomAccount = new Account();
  *
@@ -33,14 +36,14 @@ interface AccountParam {
  * const mySeededAccount = new Account({seed: seed});
  *
  * // Create an account from an existing private key
- * const myExistingAccount = new Account({privateKey: 'myExistingPrivateKey'})
+ * const myExistingAccount = new Account({privateKey: process.env.privateKey});
  *
  * // Sign a message
- * const hello_world = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100])
- * const signature = myRandomAccount.sign(hello_world)
+ * const hello_world = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100]);
+ * const signature = myRandomAccount.sign(hello_world);
  *
  * // Verify a signature
- * myRandomAccount.verify(hello_world, signature)
+ * assert(myRandomAccount.verify(hello_world, signature));
  */
 export class Account {
   _privateKey: PrivateKey;
@@ -62,15 +65,17 @@ export class Account {
 
   /**
    * Attempts to create an account from a private key ciphertext
-   * @param {PrivateKeyCiphertext | string} ciphertext
-   * @param {string} password
-   * @returns {PrivateKey}
+   * @param {PrivateKeyCiphertext | string} ciphertext The encrypted private key ciphertext or its string representation
+   * @param {string} password The password used to decrypt the private key ciphertext
+   * @returns {Account} A new Account instance created from the decrypted private key
    *
    * @example
-   * const ciphertext = PrivateKey.newEncrypted("password");
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
+   * // Create an account object from a previously encrypted ciphertext and password.
    * const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
    */
-  public static fromCiphertext(ciphertext: PrivateKeyCiphertext | string, password: string) {
+  public static fromCiphertext(ciphertext: PrivateKeyCiphertext | string, password: string): Account {
     try {
       ciphertext = (typeof ciphertext === "string") ? PrivateKeyCiphertext.fromString(ciphertext) : ciphertext;
       const _privateKey = PrivateKey.fromPrivateKeyCiphertext(ciphertext, password);
@@ -80,7 +85,12 @@ export class Account {
     }
   }
 
-  private privateKeyFromParams(params: AccountParam) {
+  /**
+   * Creates a PrivateKey from the provided parameters.
+   * @param {AccountParam} params The parameters containing either a private key string or a seed
+   * @returns {PrivateKey} A PrivateKey instance derived from the provided parameters
+   */
+  private privateKeyFromParams(params: AccountParam): PrivateKey {
     if (params.seed) {
       return PrivateKey.from_seed_unchecked(params.seed);
     }
@@ -90,92 +100,183 @@ export class Account {
     return new PrivateKey();
   }
 
-  privateKey() {
+  /**
+   * Returns the PrivateKey associated with the account.
+   * @returns {PrivateKey} The private key of the account
+   *
+   * @example
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
+   * const account = new Account();
+   * const privateKey = account.privateKey();
+   */
+  privateKey(): PrivateKey {
     return this._privateKey;
   }
 
-  viewKey() {
+  /**
+   * Returns the ViewKey associated with the account.
+   * @returns {ViewKey} The view key of the account
+   *
+   * @example
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
+   * const account = new Account();
+   * const viewKey = account.viewKey();
+   */
+  viewKey(): ViewKey {
     return this._viewKey;
   }
 
-  computeKey() {
+  /**
+   * Returns the ComputeKey associated with the account.
+   * @returns {ComputeKey} The compute key of the account
+   *
+   * @example
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
+   * const account = new Account();
+   * const computeKey = account.computeKey();
+   */
+  computeKey(): ComputeKey {
     return this._computeKey;
   }
 
-  address() {
+  /**
+   * Returns the Aleo address associated with the account.
+   * @returns {Address} The public address of the account
+   *
+   * @example
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
+   * const account = new Account();
+   * const address = account.address();
+   */
+  address(): Address {
     return this._address;
   }
 
-  clone() {
+  /**
+   * Deep clones the Account.
+   * @returns {Account} A new Account instance with the same private key
+   *
+   * @example
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
+   * const account = new Account();
+   * const clonedAccount = account.clone();
+   */
+  clone(): Account {
     return new Account({ privateKey: this._privateKey.to_string() });
   }
 
-  toString() {
+  /**
+   * Returns the address of the account in a string representation.
+   *
+   * @returns {string} The string representation of the account address
+   */
+  toString(): string {
     return this.address().to_string()
   }
 
   /**
-   * Encrypt the account's private key with a password
-   * @param {string} ciphertext
-   * @returns {PrivateKeyCiphertext}
+   * Encrypts the account's private key with a password.
+   *
+   * @param {string} password Password to encrypt the private key.
+   * @returns {PrivateKeyCiphertext} The encrypted private key ciphertext
    *
    * @example
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
    * const account = new Account();
    * const ciphertext = account.encryptAccount("password");
+   * process.env.ciphertext = ciphertext.toString();
    */
-  encryptAccount(password: string) {
+  encryptAccount(password: string): PrivateKeyCiphertext {
     return this._privateKey.toCiphertext(password);
   }
 
   /**
-   * Decrypts a Record in ciphertext form into plaintext
-   * @param {string} ciphertext
-   * @returns {Record}
+   * Decrypts an encrypted record string into a plaintext record object.
+   *
+   * @param {string} ciphertext A string representing the ciphertext of a record.
+   * @returns {RecordPlaintext} The decrypted record plaintext
    *
    * @example
-   * const account = new Account();
-   * const record = account.decryptRecord("record1ciphertext");
+   * // Import the AleoNetworkClient and Account classes
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/testnet.js";
+   *
+   * // Create a connection to the Aleo network and an account
+   * const networkClient = new AleoNetworkClient("https://api.explorer.provable.com/v1");
+   * const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
+   *
+   * // Get the record ciphertexts from a transaction.
+   * const transaction = await networkClient.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
+   * const records = transaction.records();
+   *
+   * // Decrypt any records the account owns.
+   * const decryptedRecords = [];
+   * for (const record of records) {
+   *    if (account.decryptRecord(record)) {
+   *      decryptedRecords.push(record);
+   *    }
+   * }
    */
-  decryptRecord(ciphertext: string) {
+  decryptRecord(ciphertext: string): RecordPlaintext {
     return this._viewKey.decrypt(ciphertext);
   }
 
   /**
-   * Decrypts an array of Records in ciphertext form into plaintext
-   * @param {string[]} ciphertexts
-   * @returns {Record[]}
+   * Decrypts an array of Record ciphertext strings into an array of record plaintext objects.
+   *
+   * @param {string[]} ciphertexts An array of strings representing the ciphertexts of records.
+   * @returns {RecordPlaintext[]} An array of decrypted record plaintexts
    *
    * @example
-   * const account = new Account();
-   * const record = account.decryptRecords(["record1ciphertext", "record2ciphertext"]);
+   * // Import the AleoNetworkClient and Account classes
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/testnet.js";
+   *
+   * // Create a connection to the Aleo network and an account
+   * const networkClient = new AleoNetworkClient("https://api.explorer.provable.com/v1");
+   * const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
+   *
+   * // Get the record ciphertexts from a transaction.
+   * const transaction = await networkClient.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
+   * const records = transaction.records();
+   *
+   * // Decrypt any records the account owns. If the account owns no records, the array will be empty.
+   * const decryptedRecords = account.decryptRecords(records);
    */
-  decryptRecords(ciphertexts: string[]) {
+  decryptRecords(ciphertexts: string[]): RecordPlaintext[] {
     return ciphertexts.map((ciphertext) => this._viewKey.decrypt(ciphertext));
   }
 
   /**
-   * Determines whether the account owns a ciphertext record
-   * @param {RecordCipherText | string} ciphertext
-   * @returns {boolean}
+   * Determines whether the account owns a ciphertext record.
+   * @param {RecordCiphertext | string} ciphertext The record ciphertext to check ownership of
+   * @returns {boolean} True if the account owns the record, false otherwise
    *
    * @example
+   * // Import the AleoNetworkClient and Account classes
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/testnet.js";
+   *
    * // Create a connection to the Aleo network and an account
-   * const connection = new AleoNetworkClient("https://api.explorer.provable.com/v1");
-   * const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+   * const networkClient = new AleoNetworkClient("https://api.explorer.provable.com/v1");
+   * const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
    *
-   * // Get a record from the network
-   * const record = connection.getBlock(1234);
-   * const recordCipherText = record.transactions[0].execution.transitions[0].id;
+   * // Get the record ciphertexts from a transaction and check ownership of them.
+   * const transaction = await networkClient.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
+   * const records = transaction.records();
    *
-   * // Check if the account owns the record
-   * if account.ownsRecord(recordCipherText) {
-   *     // Then one can do something like:
-   *     // Decrypt the record and check if it's spent
-   *     // Store the record in a local database
-   *     // Etc.
+   * // Check if the account owns any of the record ciphertexts present in the transaction.
+   * const ownedRecords = [];
+   * for (const record of records) {
+   *    if (account.ownsRecordCiphertext(record)) {
+   *      ownedRecords.push(record);
+   *    }
    * }
    */
-  ownsRecordCiphertext(ciphertext: RecordCiphertext | string) {
+  ownsRecordCiphertext(ciphertext: RecordCiphertext | string): boolean {
     if (typeof ciphertext === 'string') {
       try {
         const ciphertextObject = RecordCiphertext.fromString(ciphertext);
@@ -194,33 +295,50 @@ export class Account {
    * Signs a message with the account's private key.
    * Returns a Signature.
    *
-   * @param {Uint8Array} message
-   * @returns {Signature}
+   * @param {Uint8Array} message Message to be signed.
+   * @returns {Signature} Signature over the message in bytes.
    *
    * @example
+   * // Import the Account class
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
+   * // Create a connection to the Aleo network and an account
+   * const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+   *
+   * // Create an account and a message to sign.
    * const account = new Account();
    * const message = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100])
-   * account.sign(message);
+   * const signature = account.sign(message);
+   *
+   * // Verify the signature.
+   * assert(account.verify(message, signature));
    */
-  sign(message: Uint8Array) {
+  sign(message: Uint8Array): Signature {
     return this._privateKey.sign(message);
   }
 
   /**
    * Verifies the Signature on a message.
    *
-   * @param {Uint8Array} message
-   * @param {Signature} signature
-   * @returns {boolean}
+   * @param {Uint8Array} message Message in bytes to be signed.
+   * @param {Signature} signature Signature to be verified.
+   * @returns {boolean} True if the signature is valid, false otherwise.
    *
    * @example
-   * const account = new Account();
+   * // Import the Account class
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
+   * // Create a connection to the Aleo network and an account
+   * const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+   *
+   * // Sign a message.
    * const message = Uint8Array.from([104, 101, 108, 108, 111 119, 111, 114, 108, 100])
    * const signature = account.sign(message);
-   * account.verify(message, signature);
+   *
+   * // Verify the signature.
+   * assert(account.verify(message, signature));
    */
-  verify(message: Uint8Array, signature: Signature) {
+  verify(message: Uint8Array, signature: Signature): boolean {
     return this._address.verify(message, signature);
   }
-
 }

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -25,12 +25,12 @@ interface AleoNetworkClientOptions {
  *
  * @param {string} host
  * @example
- * // Connection to a local node
- * const localNetworkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined, account);
+ * // Connection to a local node.
+ * const localNetworkClient = new AleoNetworkClient("http://0.0.0.0:3030", undefined, account);
  *
  * // Connection to a public beacon node
  * const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
- * const publicnetworkClient = new AleoNetworkClient("http://localhost:3030", undefined, account);
+ * const publicNetworkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined, account);
  */
 class AleoNetworkClient {
   host: string;
@@ -54,8 +54,11 @@ class AleoNetworkClient {
   /**
    * Set an account to use in networkClient calls
    *
-   * @param {Account} account
+   * @param {Account} account Set an account to use for record scanning functions.
    * @example
+   * import { Account, AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1");
    * const account = new Account();
    * networkClient.setAccount(account);
    */
@@ -78,6 +81,15 @@ class AleoNetworkClient {
    *
    * @param {string} host The address of a node hosting the Aleo API
    * @param host
+   *
+   * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a networkClient that connects to a local node.
+   * const networkClient = new AleoNetworkClient("http://0.0.0.0:3030", undefined);
+   *
+   * // Set the host to a public node.
+   * networkClient.setHost("http://api.explorer.provable.com/v1");
    */
   setHost(host: string) {
     this.host = host + "/%%NETWORK%%";
@@ -86,7 +98,7 @@ class AleoNetworkClient {
   /**
    * Fetches data from the Aleo network and returns it as a JSON object.
    *
-   * @param url
+   * @param url The URL to fetch data from.
    */
   async fetchData<Type>(
       url = "/",
@@ -130,8 +142,18 @@ class AleoNetworkClient {
    * @param {number} maxMicrocredits - The maximum number of microcredits to search for
    * @param {string[]} nonces - The nonces of already found records to exclude from the search
    * @param {string | PrivateKey} privateKey - An optional private key to use to find unspent records.
+   * @returns {Promise<Array<RecordPlaintext>>} An array of records belonging to the account configured in the network client.
    *
    * @example
+   * import { Account, AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Import an account from a ciphertext and password.
+   * const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * networkClient.setAccount(account);
+   *
    * // Find specific amounts
    * const startHeight = 500000;
    * const amounts = [600000, 1000000];
@@ -333,8 +355,17 @@ class AleoNetworkClient {
    * @param {number} maxMicrocredits - The maximum number of microcredits to search for
    * @param {string[]} nonces - The nonces of already found records to exclude from the search
    * @param {string | PrivateKey} privateKey - An optional private key to use to find unspent records.
+   * @returns {Promise<Array<RecordPlaintext>>} An array of unspent records belonging to the account configured in the network client.
    *
    * @example
+   * import { Account, AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+   *
+   * // Create a network client and set an account to search for records with.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * networkClient.setAccount(account);
+   *
    * // Find specific amounts
    * const startHeight = 500000;
    * const endHeight = 550000;
@@ -360,7 +391,9 @@ class AleoNetworkClient {
   /**
    * Returns the contents of the block at the specified block height.
    *
-   * @param {number} blockHeight
+   * @param {number} blockHeight - The height of the block to fetch
+   * @returns {Promise<BlockJSON>} A javascript object containing the block at the specified height
+   * 
    * @example
    * const block = networkClient.getBlock(1234);
    */
@@ -376,8 +409,13 @@ class AleoNetworkClient {
   /**
    * Returns the contents of the block with the specified hash.
    * 
-   * @param {string} blockHash
+   * @param {string} blockHash The hash of the block to fetch.
+   * @returns {Promise<BlockJSON>} A javascript object representation of the block matching the hash.
+   * 
    * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
    * const block = networkClient.getBlockByHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8x0t6dr72py8r87pxupqfne5t9");
    */
   async getBlockByHash(blockHash: string): Promise<BlockJSON> {
@@ -390,17 +428,29 @@ class AleoNetworkClient {
   }
 
   /**
-   * Returns a range of blocks between the specified block heights.
+   * Returns a range of blocks between the specified block heights. A maximum of 50 blocks can be fetched at a time.
    *
-   * @param {number} start
-   * @param {number} end
+   * @param {number} start Starting block to fetch.
+   * @param {number} end Ending block to fetch. This cannot be more than 50 blocks ahead of the start block.
+   * @returns {Promise<Array<BlockJSON>>} An array of block objects
+   *
    * @example
-   * const blockRange = networkClient.getBlockRange(2050, 2100);
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Fetch 50 blocks.
+   * const (start, end) = (2050, 2100);
+   * const blockRange = networkClient.getBlockRange(start, end);
+   *
+   * let cursor = start;
+   * blockRange.forEach((block) => {
+   *   assert(block.height == cursor);
+   *   cursor += 1;
+   *  }
    */
   async getBlockRange(start: number, end: number): Promise<Array<BlockJSON>> {
     try {
       return await this.fetchData<Array<BlockJSON>>("/blocks?start=" + start + "&end=" + end);
-    } catch (error) {;
+    } catch (error) {
       throw new Error(`Error fetching blocks between ${start} and ${end}: ${error}`);
     }
   }
@@ -408,8 +458,21 @@ class AleoNetworkClient {
   /**
    * Returns the deployment transaction id associated with the specified program.
    *
-   * @param {Program | string} program
-   * @returns {TransactionJSON}
+   * @param {Program | string} program The name of the deployed program OR a wasm Program object.
+   * @returns {Promise<string>} The transaction ID of the deployment transaction.
+   *
+   * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/testnet.js";
+   *
+   * // Get the transaction ID of the deployment transaction for a program.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * const transactionId = networkClient.getDeploymentTransactionIDForProgram("hello_hello.aleo");
+   *
+   * // Get the transaction data for the deployment transaction.
+   * const transaction = networkClient.getTransactionObject(transactionId);
+   *
+   * // Get the verifying keys for the functions in the deployed program.
+   * const verifyingKeys = transaction.verifyingKeys();
    */
   async getDeploymentTransactionIDForProgram(program: Program | string): Promise<string> {
     if (program instanceof Program) {
@@ -424,10 +487,21 @@ class AleoNetworkClient {
   }
 
   /**
-   * Returns the deployment transaction associated with a specified program.
+   * Returns the deployment transaction associated with a specified program as a JSON object.
    *
-   * @param {Program | string} program
-   * @returns {TransactionJSON}
+   * @param {Program | string} program The name of the deployed program OR a wasm Program object.
+   * @returns {Promise<Transaction>} JSON representation of the deployment transaction.
+   *
+   * @example
+   * import { AleoNetworkClient, DeploymentJSON } from "@provablehq/sdk/testnet.js";
+   *
+   * // Get the transaction ID of the deployment transaction for a program.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * const transaction = networkClient.getDeploymentTransactionForProgram("hello_hello.aleo");
+   *
+   * // Get the verifying keys for each function in the deployment.
+   * const deployment = <DeploymentJSON>transaction.deployment;
+   * const verifyingKeys = deployment.verifying_keys;
    */
   async getDeploymentTransactionForProgram(program: Program | string): Promise<TransactionJSON> {
     if (program instanceof Program) {
@@ -444,8 +518,21 @@ class AleoNetworkClient {
   /**
    * Returns the deployment transaction associated with a specified program as a wasm object.
    *
-   * @param {Program | string} program
-   * @returns {TransactionJSON}
+   * @param {Program | string} program The name of the deployed program OR a wasm Program object.
+   * @returns {Promise<Transaction>} Wasm object representation of the deployment transaction.
+   *
+   * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/testnet.js";
+   *
+   * // Get the transaction ID of the deployment transaction for a program.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * const transactionId = networkClient.getDeploymentTransactionIDForProgram("hello_hello.aleo");
+   *
+   * // Get the transaction data for the deployment transaction.
+   * const transaction = networkClient.getDeploymentTransactionObjectForProgram(transactionId);
+   *
+   * // Get the verifying keys for the functions in the deployed program.
+   * const verifyingKeys = transaction.verifyingKeys();
    */
   async getDeploymentTransactionObjectForProgram(program: Program | string): Promise<Transaction> {
     try {
@@ -457,9 +544,16 @@ class AleoNetworkClient {
   }
 
   /**
-   * Returns the contents of the latest block.
+   * Returns the contents of the latest block as JSON.
    *
+   * @returns {Promise<BlockJSON>} A javascript object containing the latest block
+   * 
    * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/testnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
    * const latestHeight = networkClient.getLatestBlock();
    */
   async getLatestBlock(): Promise<BlockJSON> {
@@ -474,6 +568,16 @@ class AleoNetworkClient {
    * Returns the latest committee.
    *
    * @returns {Promise<object>} A javascript object containing the latest committee
+   * 
+   * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * 
+   * // Create a network client and get the latest committee.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * const latestCommittee = await networkClient.getLatestCommittee();
    */
   async getLatestCommittee(): Promise<object> {
     try {
@@ -484,14 +588,20 @@ class AleoNetworkClient {
   }
 
   /**
-   * Returns the committe at the specified block height.
+   * Returns the committee at the specified block height.
    * 
-   * @param {number} blockHeight
-   * 
+   * @param {number} blockHeight - The height of the block to fetch the committee for
    * @returns {Promise<object>} A javascript object containing the committee
    * 
    * @example
-   * const committee = await networkClient.getCommitteByBlockHeight(1234);
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * 
+   * // Create a network client and get the committee for a specific block.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * const committee = await networkClient.getCommitteeByBlockHeight(1234);
    */
   async getCommitteeByBlockHeight(blockHeight: number): Promise<object> {
     try {
@@ -504,7 +614,14 @@ class AleoNetworkClient {
   /**
    * Returns the latest block height.
    *
+   * @returns {Promise<number>} The latest block height.
+   *
    * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
    * const latestHeight = networkClient.getLatestHeight();
    */
   async getLatestHeight(): Promise<number> {
@@ -517,9 +634,17 @@ class AleoNetworkClient {
 
   /**
    * Returns the latest block hash.
+   *
+   * @returns {Promise<string>} The latest block hash.
    * 
    * @example
-   * const latestHash - newtworkClient.getLatestBlockHash();
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
+   * // Get the latest block hash.
+   * const latestHash = networkClient.getLatestBlockHash();
    */
   async getLatestBlockHash(): Promise<string> {
     try {
@@ -533,9 +658,14 @@ class AleoNetworkClient {
    * Returns the source code of a program given a program ID.
    *
    * @param {string} programId The program ID of a program deployed to the Aleo Network
-   * @return {Promise<string>} Source code of the program
+   * @returns {Promise<string>} Source code of the program
    *
    * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
    * const program = networkClient.getProgram("hello_hello.aleo");
    * const expectedSource = "program hello_hello.aleo;\n\nfunction hello:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n"
    * assert.equal(program, expectedSource);
@@ -552,9 +682,14 @@ class AleoNetworkClient {
    * Returns a program object from a program ID or program source code.
    *
    * @param {string} inputProgram The program ID or program source code of a program deployed to the Aleo Network
-   * @return {Promise<Program>} Source code of the program
+   * @returns {Promise<Program>} Source code of the program
    *
    * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
    * const programID = "hello_hello.aleo";
    * const programSource = "program hello_hello.aleo;\n\nfunction hello:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n"
    *
@@ -563,7 +698,7 @@ class AleoNetworkClient {
    * const programObjectFromSource = await networkClient.getProgramObject(programSource);
    *
    * // Both program objects should be equal
-   * assert.equal(programObjectFromID.to_string(), programObjectFromSource.to_string());
+   * assert(programObjectFromID.to_string() === programObjectFromSource.to_string());
    */
   async getProgramObject(inputProgram: string): Promise<Program> {
     try {
@@ -584,11 +719,16 @@ class AleoNetworkClient {
    * @returns {Promise<ProgramImports>} Object of the form { "program_id": "program_source", .. } containing program id & source code for all program imports
    *
    * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   * 
    * const double_test_source = "import multiply_test.aleo;\n\nprogram double_test.aleo;\n\nfunction double_it:\n    input r0 as u32.private;\n    call multiply_test.aleo/multiply 2u32 r0 into r1;\n    output r1 as u32.private;\n"
    * const double_test = Program.fromString(double_test_source);
    * const expectedImports = {
    *     "multiply_test.aleo": "program multiply_test.aleo;\n\nfunction multiply:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    mul r0 r1 into r2;\n    output r2 as u32.private;\n"
    * }
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
    *
    * // Imports can be fetched using the program ID, source code, or program object
    * let programImports = await networkClient.getProgramImports("double_test.aleo");
@@ -639,8 +779,13 @@ class AleoNetworkClient {
    * @returns {string[]} - The list of program names that the program imports
    *
    * @example
-   * const programImportsNames = networkClient.getProgramImports("double_test.aleo");
-   * const expectedImportsNames = ["multiply_test.aleo"];
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
+   * const programImportsNames = networkClient.getProgramImports("wrapped_credits.aleo");
+   * const expectedImportsNames = ["credits.aleo"];
    * assert.deepStrictEqual(programImportsNames, expectedImportsNames);
    */
   async getProgramImportNames(inputProgram: Program | string): Promise<string[]> {
@@ -656,7 +801,14 @@ class AleoNetworkClient {
    * Returns the names of the mappings of a program.
    *
    * @param {string} programId - The program ID to get the mappings of (e.g. "credits.aleo")
+   * @returns {Promise<Array<string>>} - The names of the mappings of the program.
+   *
    * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
    * const mappings = networkClient.getProgramMappingNames("credits.aleo");
    * const expectedMappings = [
    *   "committee",
@@ -682,14 +834,19 @@ class AleoNetworkClient {
    *
    * @param {string} programId - The program ID to get the mapping value of (e.g. "credits.aleo")
    * @param {string} mappingName - The name of the mapping to get the value of (e.g. "account")
-   * @param {string | Plaintext} key - The key of the mapping to get the value of (e.g. "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px")
-   * @return {Promise<string>} String representation of the value of the mapping
+   * @param {string | Plaintext} key - The key to look up in the mapping (e.g. an address for the "account" mapping)
+   * @returns {Promise<string>} String representation of the value of the mapping
    *
    * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
    * // Get public balance of an account
    * const mappingValue = networkClient.getMappingValue("credits.aleo", "account", "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px");
    * const expectedValue = "0u64";
-   * assert.equal(mappingValue, expectedValue);
+   * assert(mappingValue === expectedValue);
    */
   async getProgramMappingValue(programId: string, mappingName: string, key: string | Plaintext): Promise<string> {
     try {
@@ -702,11 +859,19 @@ class AleoNetworkClient {
 
 
   /**
-   * Returns the value of a mapping as a wasm Plaintext object. Returning an
-   * object in this format allows it to be converted to a Js type and for its
-   * internal members to be inspected if it's a struct or array.
+   * Returns the value of a mapping as a wasm Plaintext object. Returning an object in this format allows it to be converted to a Js type and for its internal members to be inspected if it's a struct or array.
+   *
+   * @param {string} programId - The program ID to get the mapping value of (e.g. "credits.aleo")
+   * @param {string} mappingName - The name of the mapping to get the value of (e.g. "bonded")
+   * @param {string | Plaintext} key - The key to look up in the mapping (e.g. an address for the "bonded" mapping)
+   * @returns {Promise<Plaintext>} String representation of the value of the mapping
    *
    * @example
+   * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
    * // Get the bond state as an account.
    * const unbondedState = networkClient.getMappingPlaintext("credits.aleo", "bonded", "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px");
    *
@@ -723,15 +888,9 @@ class AleoNetworkClient {
    *
    * const expectedState = {
    *     validator: "aleo1u6940v5m0fzud859xx2c9tj2gjg6m5qrd28n636e6fdd2akvfcgqs34mfd",
-   *     microcredits: BigInt("9007199254740991")
+   *     microcredits: BigInt(9007199254740991)
    * };
    * assert.equal(unbondedState, expectedState);
-   *
-   * @param {string} programId - The program ID to get the mapping value of (e.g. "credits.aleo")
-   * @param {string} mappingName - The name of the mapping to get the value of (e.g. "account")
-   * @param {string | Plaintext} key - The key of the mapping to get the value of (e.g. "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px")
-   *
-   * @return {Promise<string>} String representation of the value of the mapping
    */
   async getProgramMappingPlaintext(programId: string, mappingName: string, key: string | Plaintext): Promise<Plaintext> {
     try {
@@ -746,11 +905,20 @@ class AleoNetworkClient {
   /**
    * Returns the public balance of an address from the account mapping in credits.aleo
    * 
-   * @param {string} address
+   * @param {Address | string} address A string or wasm object representing an address.
+   * @returns {Promise<number>} The public balance of the address in microcredits.
    * 
    * @example
-   * const account = new Account();
-   * const publicBalance = networkClient.getPublicBalance(account.address());
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
+   * // Get the balance of an account from either an address object or address string.
+   * const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+   * const publicBalance = await networkClient.getPublicBalance(account.address());
+   * const publicBalanceFromString = await networkClient.getPublicBalance(account.address().to_string());
+   * assert(publicBalance === publicBalanceFromString);
    */
   async getPublicBalance(address: Address | string): Promise<number> {
     try {
@@ -765,7 +933,15 @@ class AleoNetworkClient {
   /**
    * Returns the latest state/merkle root of the Aleo blockchain.
    * 
+   * @returns {Promise<string>} A string representing the latest state root of the Aleo blockchain.
+   * 
    * @example
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
+   * // Get the latest state root.
    * const stateRoot = networkClient.getStateRoot();
    */
   async getStateRoot(): Promise<string> {
@@ -779,8 +955,15 @@ class AleoNetworkClient {
   /**
    * Returns a transaction by its unique identifier.
    *
-   * @param {string} transactionId
+   * @param {string} transactionId The transaction ID to fetch.
+   * @returns {Promise<TransactionJSON>} A json representation of the transaction.
+   * 
    * @example
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
    * const transaction = networkClient.getTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
    */
   async getTransaction(transactionId: string): Promise<TransactionJSON> {
@@ -794,9 +977,17 @@ class AleoNetworkClient {
   /**
    * Returns a confirmed transaction by its unique identifier.
    * 
-   * @param {string} transactionId
+   * @param {string} transactionId The transaction ID to fetch.
+   * @returns {Promise<ConfirmedTransactionJSON>} A json object containing the confirmed transaction.
+   * 
    * @example
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * 
    * const transaction = networkClient.getConfirmedTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
+   * assert.equal(transaction.status, "confirmed");
    */
   async getConfirmedTransaction(transactionId: string): Promise<ConfirmedTransactionJSON> {
     try {
@@ -809,14 +1000,17 @@ class AleoNetworkClient {
   /**
    * Returns a transaction as a wasm object. Getting a transaction of this type will allow the ability for the inputs,
    * outputs, and records to be searched for and displayed.
+   * 
+   * @param {string} transactionId - The unique identifier of the transaction to fetch
+   * @returns {Promise<Transaction>} A wasm object representation of the transaction.
    *
    * @example
    * const transactionObject = networkClient.getTransaction("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
    * // Get the transaction inputs as a JS array.
-   * const transactionOutputs = transactionObject.inputs(true);
+   * const transactionInputs = transactionObject.inputs(true);
    *
    * // Get the transaction outputs as a JS object.
-   * const transactionInputs = transactionObject.outputs(true);
+   * const transactionOutputs = transactionObject.outputs(true);
    *
    * // Get any records generated in transitions in the transaction as a JS object.
    * const records = transactionObject.records();
@@ -827,10 +1021,6 @@ class AleoNetworkClient {
    *
    * // Get a JS representation of all inputs, outputs, and transaction metadata.
    * const transactionSummary = transactionObject.summary();
-   *
-   * @param {string} transactionId
-   * @example
-   * const transaction = networkClient.getTransactionObject("at1handz9xjrqeynjrr0xay4pcsgtnczdksz3e584vfsgaz0dh0lyxq43a4wj");
    */
   async getTransactionObject(transactionId: string): Promise<Transaction> {
     try {
@@ -844,8 +1034,15 @@ class AleoNetworkClient {
   /**
    * Returns the transactions present at the specified block height.
    *
-   * @param {number} blockHeight
+   * @param {number} blockHeight The block height to fetch the confirmed transactions at.
+   * @returns {Promise<Array<ConfirmedTransactionJSON>>} An array of confirmed transactions (in JSON format) for the block height.
+   *
    * @example
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
    * const transactions = networkClient.getTransactions(654);
    */
   async getTransactions(blockHeight: number): Promise<Array<ConfirmedTransactionJSON>> {
@@ -858,10 +1055,17 @@ class AleoNetworkClient {
 
   /**
    * Returns the confirmed transactions present in the block with the specified block hash.
-   * 
-   * @param {string} blockHash
+   *
+   * @param {string} blockHash The block hash to fetch the confirmed transactions at.
+   * @returns {Promise<Array<ConfirmedTransactionJSON>>} An array of confirmed transactions (in JSON format) for the block hash.
+   *
    * @example
-   * const transactions = networkClient.getTransactionsByHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8x0t6dr72py8r87pxupqfne5t9");
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
+   * const transactions = networkClient.getTransactionsByBlockHash("ab19dklwl9vp63zu3hwg57wyhvmqf92fx5g8x0t6dr72py8r87pxupqfne5t9");
    */
   async getTransactionsByBlockHash(blockHash: string): Promise<Array<ConfirmedTransactionJSON>> {
     try {
@@ -876,7 +1080,15 @@ class AleoNetworkClient {
   /**
    * Returns the transactions in the memory pool. This method requires access to a validator's REST API.
    *
+   * @returns {Promise<Array<TransactionJSON>>} An array of transactions (in JSON format) currently in the mempool.
+   *
    * @example
+   * import { AleoNetworkClient, Account } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   *
+   * // Get the current transactions in the mempool.
    * const transactions = networkClient.getTransactionsInMempool();
    */
   async getTransactionsInMempool(): Promise<Array<TransactionJSON>> {
@@ -889,7 +1101,8 @@ class AleoNetworkClient {
 
   /**
    * Returns the transition ID of the transition corresponding to the ID of the input or output.
-   * @param {string} inputOrOutputID - ID of the input or output.
+   * @param {string} inputOrOutputID - The unique identifier of the input or output to find the transition ID for
+   * @returns {Promise<string>} - The transition ID of the input or output ID.
    *
    * @example
    * const transitionId = networkClient.getTransitionId("2429232855236830926144356377868449890830704336664550203176918782554219952323field");
@@ -905,8 +1118,8 @@ class AleoNetworkClient {
   /**
    * Submit an execute or deployment transaction to the Aleo network.
    *
-   * @param {Transaction | string} transaction  - The transaction to submit to the network
-   * @returns {string} - The transaction id of the submitted transaction or the resulting error
+   * @param {Transaction | string} transaction - The transaction to submit, either as a Transaction object or string representation
+   * @returns {Promise<string>} - The transaction id of the submitted transaction or the resulting error
    */
   async submitTransaction(transaction: Transaction | string): Promise<string> {
     const transaction_string = transaction instanceof Transaction ? transaction.toString() : transaction;
@@ -933,7 +1146,8 @@ class AleoNetworkClient {
   /**
    * Submit a solution to the Aleo network.
    *
-   * @param {string} solution The string representation of the solution desired to be submitted to the network.
+   * @param {string} solution - The string representation of the solution to submit
+   * @returns {Promise<string>} The solution id of the submitted solution or the resulting error.
    */
   async submitSolution(solution: string): Promise<string> {
     try {
@@ -957,9 +1171,31 @@ class AleoNetworkClient {
   }
 
   /**
-   * Await a transaction to be confirmed on the Aleo network.
+   * Await a submitted transaction to be confirmed or rejected on the Aleo network.
    *
-   * @param {string} solution The string representation of the solution desired to be submitted to the network.
+   * @param {string} transactionId - The transaction ID to wait for confirmation
+   * @param {number} checkInterval - The interval in milliseconds to check for confirmation (default: 2000)
+   * @param {number} timeout - The maximum time in milliseconds to wait for confirmation (default: 45000)
+   * @returns {Promise<Transaction>} The confirmed transaction object that returns if the transaction is confirmed.
+   *
+   * @example
+   * import { AleoNetworkClient, Account, ProgramManager } from "@provablehq/sdk/mainnet.js";
+   *
+   * // Create a network client and program manager.
+   * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+   * const programManager = new ProgramManager(networkClient);
+   *
+   * // Set the account for the program manager.
+   * programManager.setAccount(Account.fromCiphertext(process.env.ciphertext, process.env.password));
+   *
+   * // Build a transfer transaction.
+   * const tx = await programManager.buildTransferPublicTransaction(100, "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px", 0);
+   *
+   * // Submit the transaction to the network.
+   * const transactionId = await networkClient.submitTransaction(tx);
+   *
+   * // Wait for the transaction to be confirmed.
+   * const transaction = await networkClient.waitForTransactionConfirmation(transactionId);
    */
   async waitForTransactionConfirmation(
       transactionId: string,

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "7e4f181fc1a372e8ceff89612e5c9b13f72bff5b066da9f8d6827ae65af492c4"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Motivation

Some documentation for the `AleoNetworkClient` and `Account` classes were out of date and the new method added to the aleo-wasm have not yet been documented. This PR adds documentation for all 3.

## Changelog
* Annotates `AleoNetworkClient` and `Account` classes with full parameter, return type and example annotations.
* Adds autogenerated documentation on the new `wasm` methods.
