### PR TITLE
[Feature] Add setHeader and removeHeader methods for the AleoNetworkClient

### DIFF
--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -37,7 +37,7 @@ class AleoNetworkClient {
     headers: { [key: string]: string };
     account: Account | undefined;
 
-    constructor(host: string, options?: AleoNetworkClientOptions) {
+    constructor(host: string, options?: AleoNetworkClientOptions | undefined) {
         this.host = host + "/%%NETWORK%%";
 
         if (options && options.headers) {

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -95,6 +95,43 @@ class AleoNetworkClient {
     }
 
     /**
+     * Set a header in the `AleoNetworkClient`s header map
+     * 
+     * @param {string} headerName The name of the header to set
+     * @param {string} value The header value
+     * 
+     * @example
+     * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+     * 
+     * // Create a networkClient
+     * const networkClient = new AleoNetworkClient();
+     * 
+     * // Set the value of the `Accept-Language` header to `en-US`
+     * networkClient.setHeader('Accept-Language', 'en-US');
+     */
+    setHeader(headerName: string, value: string) {
+        this.headers[headerName] = value;
+    }
+
+    /**
+     * Remove a header from the `AleoNetworkClient`s header map
+     * 
+     * @param {string} headerName The name of the header to be removed
+     * 
+     * @example
+     * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+     * 
+     * // Create a networkClient
+     * const networkClient = new AleoNetworkClient();
+     * 
+     * // Remove the default `X-Aleo-SDK-Version` header
+     * networkClient.removeHeader('X-Aleo-SDK-Version');
+     */
+    removeHeader(headerName: string) {
+        delete this.headers[headerName]
+    }
+
+    /**
      * Fetches data from the Aleo network and returns it as a JSON object.
      *
      * @param url The URL to fetch data from.

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -1,5 +1,5 @@
 import { Account } from "./account";
-import { AleoNetworkClient, ProgramImports } from "./network-client";
+import { AleoNetworkClient, AleoNetworkClientOptions, ProgramImports } from "./network-client";
 
 import { RecordProvider, RecordSearchParams } from "./record-provider";
 
@@ -90,9 +90,10 @@ class ProgramManager {
         host?: string | undefined,
         keyProvider?: FunctionKeyProvider | undefined,
         recordProvider?: RecordProvider | undefined,
+        networkClientOptions?: AleoNetworkClientOptions | undefined,
     ) {
         this.host = host ? host : "https://api.explorer.provable.com/v1";
-        this.networkClient = new AleoNetworkClient(this.host);
+        this.networkClient = new AleoNetworkClient(this.host, networkClientOptions);
 
         this.keyProvider = keyProvider ? keyProvider : new AleoKeyProvider();
         this.recordProvider = recordProvider;
@@ -146,6 +147,43 @@ class ProgramManager {
      */
     setRecordProvider(recordProvider: RecordProvider) {
         this.recordProvider = recordProvider;
+    }
+
+    /**
+     * Set a header in the `AleoNetworkClient`s header map
+     * 
+     * @param {string} headerName The name of the header to set
+     * @param {string} value The header value
+     * 
+     * @example
+     * import { ProgramManager } from "@provablehq/sdk/mainnet.js";
+     * 
+     * // Create a ProgramManager
+     * const programManager = new ProgramManager("https://api.explorer.provable.com/v1");
+     * 
+     * // Set the value of the `Accept-Language` header to `en-US`
+     * programManager.setHeader('Accept-Language', 'en-US');
+     */
+    setHeader(headerName: string, value: string) {
+        this.networkClient.headers[headerName] = value;
+    }
+
+    /**
+     * Remove a header from the `AleoNetworkClient`s header map
+     * 
+     * @param {string} headerName The name of the header to be removed
+     * 
+     * @example
+     * import { ProgramManager } from "@provablehq/sdk/mainnet.js";
+     * 
+     * // Create a ProgramManager
+     * const programManager = new ProgramManager("https://api.explorer.provable.com/v1");
+     * 
+     * // Remove the default `X-Aleo-SDK-Version` header
+     * programManager.removeHeader('X-Aleo-SDK-Version');
+     */
+    removeHeader(headerName: string) {
+        delete this.networkClient.headers[headerName]
     }
 
     /**

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -214,6 +214,25 @@ describe("NodeConnection", () => {
         });
     });
 
+    describe("setHeader", () => {
+        it("should correctly update the headers map", async () => {
+            connection.setHeader('X-Test-Header', 'testvalue');
+            expect(connection.headers['X-Test-Header']).equal('testvalue');
+        })
+
+        it("should update existing header in map", async () => {
+            connection.setHeader('X-Test-Header', 'secondtestvalue');
+            expect(connection.headers['X-Test-Header']).equal('secondtestvalue');
+        })
+    })
+
+    describe("removeHeader", () => {
+        it("should remove header from the map", async () => {
+            connection.removeHeader('X-Test-Header');
+            expect(connection.headers['X-Test-Header']).undefined;
+        })
+    })
+
     describe("waitForTransactionConfirmation", () => {
         const mainnetAcceptedTx =
             "at1dl9lze8wscct0dee8x9tjnfmpjvj33hh23jcnp5f0ywjn5552yrsperzl9";

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -10,8 +10,29 @@ import {
 import { Account, ExecutionResponse, OfflineQuery, ProgramManager, RecordPlaintext } from "../src/node";
 
 describe('Program Manager', () => {
-    const programManager = new ProgramManager("https://api.explorer.provable.com/v1", undefined, undefined);
+    const programManager = new ProgramManager("https://api.explorer.provable.com/v1");
     programManager.setAccount(new Account({privateKey: statePathRecordOwnerPrivateKey}));
+
+    describe('Instantiate with AleoNetworkClientOptions', () => {
+        it('should have the specified headers when instantiated', async () => {
+            const newProgramManager = new ProgramManager("https://api.explorer.provable.com/v1", undefined, undefined, { headers: {'X-Test-Header': 'programManager'} });
+            expect(Object.keys(newProgramManager.networkClient.headers).length).equal(1);
+            expect(newProgramManager.networkClient.headers['X-Test-Header']).equal('programManager');
+            expect(newProgramManager.networkClient.headers['X-Aleo-SDK-Version']).undefined;
+        })
+    });
+
+    describe('networkClient header methods', () => {
+        it('should correctly udpdate the networkClient headers map', async () => {
+            programManager.setHeader('X-Added-Header', 'programManager');
+            expect(programManager.networkClient.headers['X-Added-Header']).equal('programManager');
+        })
+
+        it('should remove header from the networkClient headers map', async () => {
+            programManager.removeHeader('X-Added-Header');
+            expect(programManager.networkClient.headers['X-Added-Header']).undefined;
+        })
+    })
 
     describe('Execute offline', () => {
         it.skip('Program manager should execute offline and verify the resulting proof correctly', async () => {


### PR DESCRIPTION
## Motivation

Presently the network client headers may only be set on initialization. If not specified, then a default header `X-Aleo-SDK-Version` is added. When a `ProgramManager` is constructed, it constructs the `AleoNetworkClient` with the default header. This can lead to [CORS issues](https://github.com/ProvableHQ/sdk/issues/1023).

## Changes

`setHeader` and `removeHeader` methods were created for the `AleoNetworkClient`. These methods were also added for `ProgramManager` and they act on the network client in the program manager. An optional parameter was also added to the `ProgramManager` constructor to allow initialization with desired headers.

## Test Plan

Tests for these new methods are added in `sdk/tests/network-client.test.ts` and `sdk/tests/program-manager.test.ts`
