### PR TITLE
[Fix] Add `network` property to AleoNetworkClient. Change Object::entries to Object::keys

### DIFF
--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -36,9 +36,11 @@ class AleoNetworkClient {
   host: string;
   headers: { [key: string]: string };
   account: Account | undefined;
+  readonly network: string;
 
   constructor(host: string, options?: AleoNetworkClientOptions) {
     this.host = host + "/%%NETWORK%%";
+    this.network = "%%NETWORK%%";
 
     if (options && options.headers) {
       this.headers = options.headers;

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -36,16 +36,10 @@ async function expectThrows(f: () => Promise<any>): Promise<void> {
 
 describe('NodeConnection', () => {
     let connection: AleoNetworkClient;
-    let network: string;
     let windowFetchSpy: sinon.SinonSpy;
 
     beforeEach(() => {
         connection = new AleoNetworkClient("https://api.explorer.provable.com/v1");
-        if (connection.host === "https://api.explorer.provable.com/v1/testnet") {
-            network = "testnet";
-        } else {
-            network = "mainnet";
-        }
         windowFetchSpy = sinon.spy(globalThis, 'fetch');
     });
 
@@ -237,7 +231,7 @@ describe('NodeConnection', () => {
 
     describe('Test API methods that return wasm objects', () => {
         it('Plaintext returned from the API should have expected properties', async () => {
-            if (network === "testnet") {
+            if (connection.network === "testnet") {
                 // Check a struct variant of a plaintext object.
                 let plaintext = await connection.getProgramMappingPlaintext("credits.aleo", "committee", "aleo17m3l8a4hmf3wypzkf5lsausfdwq9etzyujd0vmqh35ledn2sgvqqzqkqal");
                 expect(plaintext.plaintextType()).equal("struct");
@@ -258,7 +252,7 @@ describe('NodeConnection', () => {
 
         it('should have correct data within the wasm object and summary object for an execution transaction', async () => {
             // Get the first transaction at block 24700 on testnet.
-            if (network === "testnet") {
+            if (connection.network === "testnet") {
                 const transaction = await connection.getTransactionObject("at1fjy6s9md2v4rgcn3j3q4qndtfaa2zvg58a4uha0rujvrn4cumu9qfazxdd");
                 const transition = <Transition>transaction.transitions()[0];
                 const summary = <TransactionObject>transaction.summary(true);
@@ -323,7 +317,7 @@ describe('NodeConnection', () => {
 
         it('should have correct data within the wasm object and summary object for a deployment transaction', async () => {
             // Get the deployment transaction for token_registry.aleo
-            if (network === "mainnet") {
+            if (connection.network === "mainnet") {
                 const transaction = await connection.getTransactionObject("at15mwg0jyhvpjjrfxwrlwzn8puusnmy7r3xzvpjht4e5gzgnp68q9qd0qqec");
                 const summary = <TransactionObject>transaction.summary(true);
                 const deployment = <DeploymentObject>summary.deployment;
@@ -349,7 +343,7 @@ describe('NodeConnection', () => {
         });
 
         it('Should give the correct JSON response when requesting multiple transactions', async () => {
-            if (network === "testnet") {
+            if (connection.network === "testnet") {
                 const transactions = await connection.getTransactions(27400);
                 expect(transactions.length).equal(4);
                 expect(transactions[0].status).equal("accepted");

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -14,7 +14,7 @@ import { expect } from "chai";
 describe('Program Manager', () => {
     const programManager = new ProgramManager("https://api.explorer.provable.com/v1", undefined, undefined);
     programManager.setAccount(new Account({privateKey: statePathRecordOwnerPrivateKey}));
-    const network = (<AleoNetworkClient>programManager.networkClient).host  === "https://api.explorer.provable.com/v1/testnet" ? "testnet" : "mainnet";
+    const network = programManager.networkClient.network;
 
     describe('Execute offline', () => {
         it.skip('Program manager should execute offline and verify the resulting proof correctly', async () => {

--- a/wasm/src/programs/execution.rs
+++ b/wasm/src/programs/execution.rs
@@ -131,14 +131,14 @@ pub fn verify_function_execution(
     // Secondly, get the verifying keys and insert them into the process object.
     if let Some(imported_verifying_keys) = imported_verifying_keys {
         // Go through the imports and get the program IDs.
-        let program_ids = Object::entries(&imported_verifying_keys)
+        let program_ids = Object::keys(&imported_verifying_keys)
             .iter()
-            .filter_map(|entries| Array::try_from(entries).unwrap().get(0).as_string()) // Safe unwraps because `entries` returns arrays with string keys.
             .map(|entry| {
+                let entry = entry.as_string().unwrap(); // Safe unwraps because `keys` returns array of string keys.
                 ProgramIDNative::from_str(&entry)
                     .map_err(|_| format!("Program ID not found in imports provided: {entry}"))
             })
-            .collect::<Result<Vec<_>,_>>()?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         // Go through the imports and insert the verifying keys for each function.
         for imported_program_id in &program_ids {
@@ -149,8 +149,8 @@ pub fn verify_function_execution(
             )
             .map_err(|_| format!("Verifying key not found for imported program {}", imported_program_id))?;
             // Get the verifying key for each function.
-            for i in 0..vk_list.length() {
-                let vk = Array::try_from(vk_list.get(i)).map_err(|_| format!("Verifying key and function not found for {}, for each function provide an array of the form ['function_name', 'vk']", imported_program_id))?;
+            for vk in vk_list.iter() {
+                let vk = Array::try_from(vk).map_err(|_| format!("Verifying key and function not found for {}, for each function provide an array of the form ['function_name', 'vk']", imported_program_id))?;
                 {
                     // Insert the verifying key into the temporary process.
                     let imported_function = IdentifierNative::from_str(


### PR DESCRIPTION
## Motivation

Cleanup PR [1019](https://github.com/ProvableHQ/sdk/pull/1019) per comments by @Pauan

## Test Plan

No new functionality was added, all existing tests pass. All checks on an AleoNetworkClient's network in tests now use the `network` property.

## Related PRs

https://github.com/ProvableHQ/sdk/pull/1019
