### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -65,5 +65,5 @@ for all the SDK's classes, methods, and interfaces. The documentation is generat
 
 ### [Leo Language Documentation](https://docs.leo-lang.org)
 For developers who want to build their own zero-knowledge programs, the Leo Language provides an easy-to-use imperative
-programming language for writing zero-knowledge programs on Aleo. In conjuction with the SDK, private programs built 
+programming language for writing zero-knowledge programs on Aleo. In conjunction with the SDK, private programs built 
 using Leo can be turned into fully functional private web applications.

--- a/docs/api_reference/sdk-src_wasm.md
+++ b/docs/api_reference/sdk-src_wasm.md
@@ -2254,7 +2254,7 @@ __*return*__ | [RecordCiphertext](sdk-src_wasm.md) | *Record ciphertext*
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Return the string reprensentation of the record ciphertext
+Return the string representation of the record ciphertext
 
 Parameters | Type | Description
 --- | --- | ---

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -61,5 +61,5 @@ for all the SDK's classes, methods, and interfaces. The documentation is generat
 
 ### [Leo Language Documentation](https://docs.leo-lang.org)
 For developers who want to build their own zero-knowledge programs, the Leo Language provides an easy-to-use imperative
-programming language for writing zero-knowledge programs on Aleo. In conjuction with the SDK, private programs built
+programming language for writing zero-knowledge programs on Aleo. In conjunction with the SDK, private programs built
 using Leo can be turned into fully functional private web applications.


### PR DESCRIPTION
This PR fixes a typo in multiple documentation files where "conjuction" was incorrectly spelled. Changed to the correct spelling "conjunction" in:

- docs/00_overview.md
- docs/api_reference/sdk-src_wasm.md 
- sdk/README.md

Also fixed a typo "reprensentaton" to "representation" in the API reference documentation.