### PR TITLE
chore(ci): upgrade checkout to v4

### DIFF
--- a/.github/workflows/staging-website.yml
+++ b/.github/workflows/staging-website.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       #        with:
       #          persist-credentials: false
 

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       #        with:
       #          persist-credentials: false
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 #        with:
 #          persist-credentials: false
 


### PR DESCRIPTION
Node 20 compatibility: switch all jobs to actions/checkout@v4. Pure maintenance, behavior unchanged.