### PR TITLE
fix: update broken concepts link in wasm/README.md

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -22,7 +22,7 @@ Functionality exposed by this crate includes:
 * Aleo primitives such as `Records`, `Programs`, and `Transactions` and their associated helper methods
 * A `ProgramManager` object that contains methods for authoring, deploying, and interacting with Aleo programs
 
-More information on these concepts can be found at the [Aleo Developer Hub](https://docs.leo-lang.org/concepts).
+More information on these concepts can be found at the [Aleo Developer Hub](https://developer.aleo.org/concepts/network/overview/core_architecture/).
 
 ## Usage
 


### PR DESCRIPTION
Replaced the outdated and broken link to the Aleo concepts section with the current, working URL for the "Core Architecture" page in the Aleo Developer Hub https://developer.aleo.org/concepts/network/overview/core_architecture/ . This ensures users are directed to the correct documentation for understanding Aleo's core concepts and architecture.