### PR TITLE
Add Boolean type

### DIFF
--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -60,6 +60,7 @@ export { logAndThrow } from "./utils.js";
 export {
     Address,
     Authorization,
+    Boolean,
     BHP256,
     BHP512,
     BHP768,

--- a/sdk/src/wasm.ts
+++ b/sdk/src/wasm.ts
@@ -1,6 +1,7 @@
 export {
     Address,
     Authorization,
+    Boolean,
     BHP256,
     BHP512,
     BHP768,

--- a/sdk/tests/arithmetic.test.ts
+++ b/sdk/tests/arithmetic.test.ts
@@ -44,6 +44,58 @@ describe('Field and Group Arithmetic Tests', () => {
             expect(two_power_four.equals(two_times_eight)).equal(true);
         });
 
+        it('Check boolean creation and serialization', () => {
+            const t = Boolean.one();
+            const f = Boolean.zero();
+
+            expect(t.toString()).equals("true");
+            expect(f.toString()).equals("false");
+
+            const tBytes = t.toBytesLe();
+            const fBytes = f.toBytesLe();
+
+            const tFromBytes = Boolean.fromBytesLe(tBytes);
+            const fFromBytes = Boolean.fromBytesLe(fBytes);
+
+            expect(t.equals(tFromBytes)).equals(true);
+            expect(f.equals(fFromBytes)).equals(true);
+
+            const tBits = t.toBitsLe();
+            const fBits = f.toBitsLe();
+
+            const tFromBits = Boolean.fromBitsLe(tBits);
+            const fFromBits = Boolean.fromBitsLe(fBits);
+
+            expect(t.equals(tFromBits)).equals(true);
+            expect(f.equals(fFromBits)).equals(true);
+        });
+
+        it('Check boolean logical operations', () => {
+            const t = Boolean.one();
+            const f = Boolean.zero();
+
+            expect(t.not().toString()).equals("false");
+            expect(f.not().toString()).equals("true");
+
+            expect(t.and(t).toString()).equals("true");
+            expect(t.and(f).toString()).equals("false");
+            expect(f.and(f).toString()).equals("false");
+
+            expect(t.or(t).toString()).equals("true");
+            expect(t.or(f).toString()).equals("true");
+            expect(f.or(f).toString()).equals("false");
+
+            expect(t.xor(t).toString()).equals("false");
+            expect(t.xor(f).toString()).equals("true");
+            expect(f.xor(f).toString()).equals("false");
+
+            expect(t.nand(t).toString()).equals("false");
+            expect(t.nand(f).toString()).equals("true");
+
+            expect(f.nor(f).toString()).equals("true");
+            expect(t.nor(f).toString()).equals("false");
+        });
+
         it('Check scalar field arithmetic', () => {
             // Create the 2 scalar element.
             const a = Scalar.fromString("2scalar");

--- a/sdk/tests/arithmetic.test.ts
+++ b/sdk/tests/arithmetic.test.ts
@@ -45,8 +45,8 @@ describe('Field and Group Arithmetic Tests', () => {
         });
 
         it('Check boolean creation and serialization', () => {
-            const t = Boolean.one();
-            const f = Boolean.zero();
+            const t = Boolean.fromString("true");
+            const f = Boolean.fromString("false");
 
             expect(t.toString()).equals("true");
             expect(f.toString()).equals("false");
@@ -71,8 +71,8 @@ describe('Field and Group Arithmetic Tests', () => {
         });
 
         it('Check boolean logical operations', () => {
-            const t = Boolean.one();
-            const f = Boolean.zero();
+            const t = new Boolean(true);
+            const f = new Boolean(false);
 
             expect(t.not().toString()).equals("false");
             expect(f.not().toString()).equals("true");

--- a/sdk/tests/arithmetic.test.ts
+++ b/sdk/tests/arithmetic.test.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { Field, Scalar, Group} from "../src/node.js";
+import { Field, Scalar, Group, Boolean} from "../src/node.js";
 import { FieldGenerator, GroupGenerator, ScalarGenerator } from "./data/algebra.js";
 
 describe('Field and Group Arithmetic Tests', () => {

--- a/wasm/src/types/boolean.rs
+++ b/wasm/src/types/boolean.rs
@@ -20,7 +20,7 @@ use crate::{
     to_bits_array_le,
     types::native::{BooleanNative, LiteralNative, PlaintextNative},
 };
-use snarkvm_console::prelude::{Double, FromBits, FromBytes, One, Pow, ToBits, ToBytes, Zero};
+use snarkvm_console::prelude::{FromBits, FromBytes, ToBits, ToBytes, Zero};
 use snarkvm_wasm::utilities::Uniform;
 
 use js_sys::{Array, Uint8Array};
@@ -36,6 +36,12 @@ pub struct Boolean(BooleanNative);
 
 #[wasm_bindgen]
 impl Boolean {
+    /// Creates a Boolean from a native JS bool.
+    #[wasm_bindgen(constructor)]
+    pub fn new(value: bool) -> Boolean {
+        Boolean(BooleanNative::new(value))
+    }
+
     /// Creates a boolean object from a string representation ("true"/"false").
     #[wasm_bindgen(js_name = "fromString")]
     #[allow(clippy::should_implement_trait)]
@@ -135,15 +141,6 @@ impl Boolean {
         self.0 == BooleanNative::from(other)
     }
 
-    /// `false`
-    pub fn zero() -> Boolean {
-        Boolean(BooleanNative::zero())
-    }
-
-    /// `true`
-    pub fn one() -> Boolean {
-        Boolean(BooleanNative::one())
-    }
 }
 
 impl Deref for Boolean {

--- a/wasm/src/types/boolean.rs
+++ b/wasm/src/types/boolean.rs
@@ -1,0 +1,187 @@
+// Copyright (C) 2019-2025 Provable Inc.
+// This file is part of the Provable SDK library.
+
+// The Provable SDK library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Provable SDK library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    Plaintext,
+    from_js_typed_array,
+    to_bits_array_le,
+    types::native::{BooleanNative, LiteralNative, PlaintextNative},
+};
+use snarkvm_console::prelude::{Double, FromBits, FromBytes, One, Pow, ToBits, ToBytes, Zero};
+use snarkvm_wasm::utilities::Uniform;
+
+use js_sys::{Array, Uint8Array};
+use once_cell::sync::OnceCell;
+use std::{ops::Deref, str::FromStr};
+use wasm_bindgen::prelude::*;
+
+/// Boolean element.
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Boolean(BooleanNative);
+
+
+#[wasm_bindgen]
+impl Boolean {
+    /// Creates a boolean object from a string representation ("true"/"false").
+    #[wasm_bindgen(js_name = "fromString")]
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_string(boolean: &str) -> Result<Boolean, String> {
+        Ok(Self(BooleanNative::from_str(boolean).map_err(|e| e.to_string())?))
+    }
+
+    /// Returns the string representation of the boolean element.
+    #[wasm_bindgen(js_name = "toString")]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Create a boolean element from a Uint8Array of left endian bytes.
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: &Uint8Array) -> Result<Boolean, String> {
+        let bytes = bytes.to_vec();
+        let boolean = BooleanNative::from_bytes_le(&bytes).map_err(|e| e.to_string())?;
+        Ok(Boolean(boolean))
+    }
+
+    /// Encode the boolean element as a Uint8Array of left endian bytes.
+    #[wasm_bindgen(js_name = "toBytesLe")]
+    pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
+        let bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
+        Ok(Uint8Array::from(bytes.as_slice()))
+    }
+
+    /// Reconstruct a boolean element from a boolean array representation.
+    #[wasm_bindgen(js_name = "fromBitsLe")]
+    pub fn from_bits_le(bits: &Array) -> Result<Boolean, String> {
+        let bit_vec = from_js_typed_array!(bits, as_bool, "boolean")?;
+        if bit_vec.len() != 1 {
+            return Err("Boolean expects exactly 1 bit".to_string());
+        }
+        let boolean = BooleanNative::from_bits_le(&bit_vec).map_err(|e| e.to_string())?;
+        Ok(Boolean(boolean))
+    }
+
+    /// Get the left endian boolean array representation of the boolean element.
+    #[wasm_bindgen(js_name = "toBitsLe")]
+    pub fn to_bits_le(&self) -> Array {
+        to_bits_array_le!(self)
+    }
+
+    /// Create a plaintext from the boolean element.
+    #[wasm_bindgen(js_name = "toPlaintext")]
+    pub fn to_plaintext(&self) -> Plaintext {
+        Plaintext::from(PlaintextNative::Literal(LiteralNative::Boolean(self.0), OnceCell::new()))
+    }
+
+    /// Clone the boolean element.
+    #[allow(clippy::should_implement_trait)]
+    pub fn clone(&self) -> Boolean {
+        Boolean(self.0)
+    }
+
+    /// Generate a random boolean element.
+    pub fn random() -> Boolean {
+        let rng = &mut rand::thread_rng();
+        Boolean(BooleanNative::rand(rng))
+    }
+
+    /// Logical NOT.
+    pub fn not(&self) -> Boolean {
+        Boolean(!self.0)
+    }
+
+    /// Logical AND.
+    pub fn and(&self, other: &Boolean) -> Boolean {
+        Boolean(self.0 & other.0)
+    }
+
+    /// Logical OR.
+    pub fn or(&self, other: &Boolean) -> Boolean {
+        Boolean(self.0 | other.0)
+    }
+
+    /// Logical XOR.
+    pub fn xor(&self, other: &Boolean) -> Boolean {
+        Boolean(self.0 ^ other.0)
+    }
+
+    /// Logical NAND.
+    pub fn nand(&self, other: &Boolean) -> Boolean {
+        Boolean(!(self.0 & other.0))
+    }
+
+    /// Logical NOR.
+    pub fn nor(&self, other: &Boolean) -> Boolean {
+        Boolean(!(self.0 | other.0))
+    }
+
+    /// Check if one boolean element equals another.
+    pub fn equals(&self, other: &Boolean) -> bool {
+        self.0 == BooleanNative::from(other)
+    }
+
+    /// `false`
+    pub fn zero() -> Boolean {
+        Boolean(BooleanNative::zero())
+    }
+
+    /// `true`
+    pub fn one() -> Boolean {
+        Boolean(BooleanNative::one())
+    }
+}
+
+impl Deref for Boolean {
+    type Target = BooleanNative;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<BooleanNative> for Boolean {
+    fn from(native: BooleanNative) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Boolean> for BooleanNative {
+    fn from(boolean: Boolean) -> Self {
+        boolean.0
+    }
+}
+
+impl From<&BooleanNative> for Boolean {
+    fn from(native: &BooleanNative) -> Self {
+        Self(*native)
+    }
+}
+
+impl From<&Boolean> for BooleanNative {
+    fn from(boolean: &Boolean) -> Self {
+        boolean.0
+    }
+}
+
+impl FromStr for Boolean {
+    type Err = anyhow::Error;
+
+    fn from_str(boolean: &str) -> Result<Self, Self::Err> {
+        Ok(Self(BooleanNative::from_str(boolean)?))
+    }
+}

--- a/wasm/src/types/boolean.rs
+++ b/wasm/src/types/boolean.rs
@@ -20,7 +20,7 @@ use crate::{
     to_bits_array_le,
     types::native::{BooleanNative, LiteralNative, PlaintextNative},
 };
-use snarkvm_console::prelude::{FromBits, FromBytes, ToBits, ToBytes, Zero};
+use snarkvm_console::prelude::{FromBits, FromBytes, ToBits, ToBytes};
 use snarkvm_wasm::utilities::Uniform;
 
 use js_sys::{Array, Uint8Array};
@@ -32,7 +32,6 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Boolean(BooleanNative);
-
 
 #[wasm_bindgen]
 impl Boolean {
@@ -140,7 +139,6 @@ impl Boolean {
     pub fn equals(&self, other: &Boolean) -> bool {
         self.0 == BooleanNative::from(other)
     }
-
 }
 
 impl Deref for Boolean {

--- a/wasm/src/types/mod.rs
+++ b/wasm/src/types/mod.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod boolean;
+pub use boolean::Boolean;
+
 pub mod field;
 pub use field::Field;
 

--- a/wasm/src/types/native/mod.rs
+++ b/wasm/src/types/native/mod.rs
@@ -34,7 +34,7 @@ use snarkvm_console::{
         Value,
         ValueType,
     },
-    types::{Field, Group, Scalar, U16, U64},
+    types::{Boolean, Field, Group, Scalar, U16, U64},
 };
 use snarkvm_ledger_block::{Execution, Input, Output, Transaction, Transition};
 use snarkvm_ledger_query::Query;
@@ -55,6 +55,7 @@ pub type SignatureNative = Signature<CurrentNetwork>;
 pub type ViewKeyNative = ViewKey<CurrentNetwork>;
 
 // Algebraic & Primitive Data Types
+pub type BooleanNative = Boolean<CurrentNetwork>;
 pub type FieldNative = Field<CurrentNetwork>;
 pub type GroupNative = Group<CurrentNetwork>;
 pub type ScalarNative = Scalar<CurrentNetwork>;


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Adds Boolean type to the wasm SDK with methods for serialization (to_string, to_bytes_le, to_bits_le, to_plaintext), logical operations (not, and, or, xor, nand, nor, equals), and helpers (random, zero, one, clone), along with from_* constructors.
