### PR TITLE
Update snarkVM rev which fixes snarkOS compilation

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -23,16 +23,16 @@ doctest = false
 
 [dependencies.snarkvm-algorithms]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 
 [dependencies.snarkvm-circuit-network]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 default-features = false
 features = [
     "account",
@@ -46,37 +46,37 @@ features = [
 
 [dependencies.snarkvm-ledger-block]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 
 [dependencies.snarkvm-parameters]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
 git = "https://github.com/ProvableHQ/snarkVM"
-rev = "3e94245569ab77724ebde670d7d2685f040e42b8"
+rev = "831e342cc49cef86b8947dd8492f784eefa5af76"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]


### PR DESCRIPTION
## Motivation

Opening this PR to an [updated snarkVM rev](https://github.com/ProvableHQ/snarkVM/pull/2907) which fixes snarkOS compilation. Let's see if CI is happy.

At the first run, sdk-test was the only one which failed on the following tests:
- programs::manager::authorize::tests::test_authorization
- programs::manager::proving_request::tests::test_nested_proving_request

However, the errors are a mysterious "Invalid private key", which seems a remnant from not setting `PUZZLE_PK` appropriately, not some inscrutible panic due to filesystem access. Previously failing CI was because of `RuntimeError: unreachable`.