### PR TITLE
Fix docstring for DelegatedProvingParams interface

### DIFF
--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -22,7 +22,7 @@ interface AleoNetworkClientOptions {
 }
 
 /**
- * Options for executing a fee authorization.
+ * Options for submitting a proving request.
  *
  * @property provingRequest {ProvingRequest | string} The proving request being submitted to the network.
  * @property url {string} The URL of the delegated proving service.


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR fixes a typo in the docstring for the `DelegatedProvingparams` interface.
