### PR TITLE
[Feature] Adding saving and loading methods for proving and verifying keys

### DIFF
--- a/docs/examples/05_offline_transfer_public.md
+++ b/docs/examples/05_offline_transfer_public.md
@@ -1,4 +1,4 @@
-// This example will demonstrate how to build an offline public transfer transaction using proving keys from local storage
+// This example demonstrates how to build an offline public transfer transaction using proving keys from local storage
 ```typescript
 import { Account, AleoKeyProvider, CREDITS_PROGRAM_KEYS, initThreadPool, OfflineKeyProvider, OfflineSearchParams, ProgramManager, ProvingKey, VerifyingKey } from '@provable.sdk';
 

--- a/docs/examples/05_offline_transfer_public.md
+++ b/docs/examples/05_offline_transfer_public.md
@@ -1,0 +1,55 @@
+// This example will demonstrate how to build an offline public transfer transaction using proving keys from local storage
+```typescript
+import { Account, AleoKeyProvider, CREDITS_PROGRAM_KEYS, initThreadPool, OfflineKeyProvider, OfflineSearchParams, ProgramManager, ProvingKey, VerifyingKey } from '@provable.sdk';
+
+// Initialize multi-threading to allow WASM execution.
+await initThreadPoool();
+
+// Create an account.
+const account = new Account();
+
+// Create an Aleo Key Provider to fetch the proving and verifying keys for transfer public and fee public methods.
+const keyProvider = new AleoKeyProvider();
+
+// Obtain the Proving and Verifying keys for credits.aleo/transfer_public and credits.aleo/fee_public.
+const feeKeyPair = await keyProvider.fetchCreditsKeys(CREDITS_PROGRAM_KEYS.fee_public);
+const transferPublicKeyPair = await keyProvider.fetchCreditsKeys(CREDITS_PROGRAM_KEYS.transfer_public);
+
+// Save the keys to storage
+const feeKeyBuffer = keyProvider.convertKeysToBuffer(feeKeyPair);
+const transferPublicKeyBuffer = keyProvider.convertToBuffer(transferPublicKeyPair);
+await keyProvider.saveKeysToLocalDisk("/KEY_DIR", "fee_public", feeKeyBuffer);
+await keyProvider.saveKeysToLocalDisk("/KEY_DIR", "transfer_public", transferPublicKeyBuffer);
+
+// Load keys from storage using the Offline Key Provider
+const offlineKeyProvider = new OfflineKeyProvider();
+const feeKeys = offlineKeyProvider.loadKeysFromDisk("./KEY_DIR/fee_public.prover", "./KEY_DIR/fee_public.verifier");
+const transferPublicKeys = offlineKeyProvider.loadKeysFromDisk("./KEY_DIR/transfer_public.prover", "./KEY_DIR/transfer_public.verifier")
+
+// Store the keys in cache
+offlineKeyProvider.insertFeePublicKeys(transferPublicKeys);
+offlineKeyProvider.insertTransferPublicKeys(transferPublicKeys);
+
+// Create an account.
+const account = new Account();
+
+// Create program manager using the KeyProvider and NetworkProvider.
+const programManager = new ProgramManager("https://api.explorer.provable.com/v2", keyProvider);
+// Set the account as the program caller.
+programManager.setAccount(account);
+
+// Create recipient account.
+const recipient = new Account();
+
+// Build a transfer_public transaction.
+// Publicly send 5 microcredits to the recipient
+const transaction = await programManager
+  .buildExecutionTransaction(
+    progranName: "credits.aleo",
+    functionName: "transfer_public",
+    priorityFee: 0.0,
+    privateFee: false,
+    inputs: [$"{RECEIVER_ALEO_ADDRESS}", "5"],
+    keySearchParams: OfflineSearchParams.transferPublicKeyParams(),
+  );
+```

--- a/docs/examples/05_offline_transfer_public.md
+++ b/docs/examples/05_offline_transfer_public.md
@@ -1,6 +1,6 @@
 // This example demonstrates how to build an offline public transfer transaction using proving keys from local storage
 ```typescript
-import { Account, AleoKeyProvider, CREDITS_PROGRAM_KEYS, initThreadPool, OfflineKeyProvider, OfflineSearchParams, ProgramManager, ProvingKey, VerifyingKey } from '@provable.sdk';
+import { Account, AleoKeyProvider, CREDITS_PROGRAM_KEYS, initThreadPool, KeyStorageManager, OfflineKeyProvider, OfflineSearchParams, ProgramManager, ProvingKey, VerifyingKey } from '@provable.sdk';
 
 // Initialize multi-threading to allow WASM execution.
 await initThreadPoool();
@@ -16,19 +16,22 @@ const feeKeyPair = await keyProvider.fetchCreditsKeys(CREDITS_PROGRAM_KEYS.fee_p
 const transferPublicKeyPair = await keyProvider.fetchCreditsKeys(CREDITS_PROGRAM_KEYS.transfer_public);
 
 // Save the keys to storage
-const feeKeyBuffer = keyProvider.convertKeysToBuffer(feeKeyPair);
-const transferPublicKeyBuffer = keyProvider.convertToBuffer(transferPublicKeyPair);
-await keyProvider.saveKeysToLocalDisk("/KEY_DIR", "fee_public", feeKeyBuffer);
-await keyProvider.saveKeysToLocalDisk("/KEY_DIR", "transfer_public", transferPublicKeyBuffer);
+const feeKeyBuffer = keyProvider.convertKeysToBytes(feeKeyPair);
+const transferPublicKeyBuffer = keyProvider.convertKeysToBytes(transferPublicKeyPair);
+await KeyStorageManager.saveKeyBytesToDisk("/KEY_DIR", "fee_public", feeKeyBuffer);
+await keyProvider.saveKeyBytesToDisk("/KEY_DIR", "transfer_public", transferPublicKeyBuffer);
 
 // Load keys from storage using the Offline Key Provider
 const offlineKeyProvider = new OfflineKeyProvider();
-const feeKeys = offlineKeyProvider.loadKeysFromDisk("./KEY_DIR/fee_public.prover", "./KEY_DIR/fee_public.verifier");
-const transferPublicKeys = offlineKeyProvider.loadKeysFromDisk("./KEY_DIR/transfer_public.prover", "./KEY_DIR/transfer_public.verifier")
+const localFeeKeyBytes = await KeyStorageManager.loadKeyBytesFromDisk("./KEY_DIR", "fee_public");
+const feeProvingKey = ProvingKey.fromBytes(localFeeKeyBytes.provingKeyBytes);
+
+const localTransferPublicKeyBytes = await KeyStorageManager.loadKeyBytesFromDisk("./KEY_DIR", "transfer_public");
+const transferPublicProvingKey = ProvingKey.fromBytes(localTransferPublicKeyBytes.provingKeyBytes);
 
 // Store the keys in cache
-offlineKeyProvider.insertFeePublicKeys(transferPublicKeys);
-offlineKeyProvider.insertTransferPublicKeys(transferPublicKeys);
+offlineKeyProvider.insertFeePublicKeys(feeProvingKey);
+offlineKeyProvider.insertTransferPublicKeys(transferPublicProvingKey);
 
 // Create an account.
 const account = new Account();

--- a/docs/examples/06_offline_transaction.md
+++ b/docs/examples/06_offline_transaction.md
@@ -1,0 +1,63 @@
+This example demonstrates how to create an offline transaction for a non-credits Aleo program.
+This example presumes that a program called `demo_program.aleo` has been deployed to a testnet (local or production testnet).
+
+Aleo Program
+```leo
+program demo_program.aleo {
+    @noupgrade
+    async constructor() {}
+
+    record BasicRecord {
+        owner: address,
+        sum: u32,
+    }
+
+    transition basic_mint(public a: u32, b: u32) -> BasicRecord {
+        let c: u32 = a + b;
+        return BasicRecord { owner: self.caller, sum: c};
+    }
+}
+```
+
+
+```typescript
+import { Account, AleoKeyProvider, CREDITS_PROGRAM_KEYS, initThreadPool, OfflineKeyProvider, OfflineSearchParams, ProgramManager, ProvingKey, VerifyingKey } from '@provable.sdk';
+
+// Initialize multi-threading to allow WASM execution.
+await initThreadPoool();
+
+// Create an account.
+const account = new Account();
+
+// Create an Aleo Key Provider to fetch the proving and verifying keys for transfer public and fee public methods.
+const keyProvider = new OfflineKeyProvider();
+
+// Load keys from storage using the Offline Key Provider
+const basicMintKeys = keyProvider.loadKeysFromDisk("./KEY_DIR/basic_mint.prover", "./KEY_DIR/basic_mint.verifier");
+
+// Store the keys in cache
+keyProvider.cacheKeys("demo_program.aleo/basic_mint", basicMintKeys);
+
+// Create an account.
+const account = new Account();
+
+// Create program manager using the KeyProvider and NetworkProvider.
+const programManager = new ProgramManager("https://api.explorer.provable.com/v1", keyProvider);
+// Set the account as the program caller.
+programManager.setAccount(account);
+
+// Create recipient account.
+const recipient = new Account();
+
+// Build a transfer_public transaction.
+// Publicly send 5 microcredits to the recipient
+const transaction = await programManager
+  .buildExecutionTransaction(
+    progranName: "demo_program.aleo",
+    functionName: "basic_mint",
+    priorityFee: 0.0,
+    privateFee: false,
+    inputs: ["5u32", "5u32"],
+    keySearchParams: {"cacheKey": "demo_program:basic_mint"},
+  );
+```

--- a/docs/examples/06_offline_transaction.md
+++ b/docs/examples/06_offline_transaction.md
@@ -21,7 +21,7 @@ program demo_program.aleo {
 
 
 ```typescript
-import { Account, AleoKeyProvider, CREDITS_PROGRAM_KEYS, initThreadPool, OfflineKeyProvider, OfflineSearchParams, ProgramManager, ProvingKey, VerifyingKey } from '@provable.sdk';
+import { Account, AleoKeyProvider, CREDITS_PROGRAM_KEYS, initThreadPool, KeyStorageManager, OfflineKeyProvider, OfflineSearchParams, ProgramManager, ProvingKey, VerifyingKey } from '@provable.sdk';
 
 // Initialize multi-threading to allow WASM execution.
 await initThreadPoool();
@@ -33,7 +33,9 @@ const account = new Account();
 const keyProvider = new OfflineKeyProvider();
 
 // Load keys from storage using the Offline Key Provider
-const basicMintKeys = keyProvider.loadKeysFromDisk("./KEY_DIR/basic_mint.prover", "./KEY_DIR/basic_mint.verifier");
+const basicMintKeyBytes = KeyStorageManager.loadKeysFromDisk("./KEY_DIR/basic_mint.prover", "./KEY_DIR/basic_mint.verifier");
+
+const basicMintKeys = [Prover.fromBytes(basicMintKeyBytes[0]), Verifier.fromBytes(basicMintKeyBytes[1])];
 
 // Store the keys in cache
 keyProvider.cacheKeys("demo_program.aleo/basic_mint", basicMintKeys);

--- a/docs/examples/07_synthesize_keys.md
+++ b/docs/examples/07_synthesize_keys.md
@@ -1,0 +1,36 @@
+// This example demonstrates how to synthesize proving and verifying keys offline.  A copy of the program and its imports must be available locally in order to proceed with offline key synthesis.
+
+// Aleo Program
+```Leo
+program demo_program.aleo {
+    @noupgrade
+    async constructor() {}
+
+    record BasicRecord {
+        owner: address,
+        sum: u32,
+    }
+
+    transition basic_mint(public a: u32, b: u32) -> BasicRecord {
+        let c: u32 = a + b;
+        return BasicRecord { owner: self.caller, sum: c};
+    }
+}
+```
+
+```typescript
+import {Account, ProgramManager, initThreadPool} from `provable.sdk`;
+
+await initThreadPool();
+
+const programManager = new ProgramManager();
+
+keyPair = programManager
+    .synthesizeKeys(
+        "demo_program",
+        "basic_mint",
+        ["5u32", "3u32"],
+    );
+
+//Save the keys to local storage
+```

--- a/sdk/src/function-key-provider.ts
+++ b/sdk/src/function-key-provider.ts
@@ -16,7 +16,7 @@ import {
 
 import { get } from "./utils.js";
 
-import fs from "node:fs/promises";
+import { KeyBytes } from "./key-manager.js";
 
 type FunctionKeyPair = [ProvingKey, VerifyingKey];
 type CachedKeyPair = [Uint8Array, Uint8Array];
@@ -24,10 +24,6 @@ type AleoKeyProviderInitParams = {
     proverUri?: string;
     verifierUri?: string;
     cacheKey?: string;
-};
-type KeyBuffers = {
-  provingKey: Buffer;
-  verifyingKey: Buffer;
 };
 
 /**
@@ -622,30 +618,15 @@ class AleoKeyProvider implements FunctionKeyProvider {
      * 
      * @returns {Promise<KeyBuffers>} The buffers containing the proving and verifying keys.
      */
-    async convertKeysToBuffer(keyPair: FunctionKeyPair): Promise<KeyBuffers> {
+    async convertKeysToBytes(keyPair: FunctionKeyPair): Promise<KeyBytes> {
         const [provingKey, verifyingKey] = keyPair;
         const proverBytes = provingKey.toBytes();
         const verifierBytes = verifyingKey.toBytes();
         return {
-            provingKey: Buffer.from(proverBytes), 
-            verifyingKey: Buffer.from(verifierBytes)
+            provingKey: proverBytes,
+            verifyingKey: verifierBytes
         };
-    }
-
-    /**
-     * Saves the keys in a FunctionKeyPair to the local disk.
-     * @param {string} path The path to save the keys to.
-     * @param {string} keyId The keyId to use for the file names.
-     * @param {KeyBuffers} keyPairBuffers The buffers containing the proving and verifying keys.
-     * 
-     * @returns {Promise<void>} A promise that resolves when the keys have been saved.
-     */
-    async saveKeysToLocalDisk(path: string, keyId: string, keyPairBuffers: KeyBuffers): Promise<void> {
-        const proverPath = `${path}/${keyId}_proving.key`;
-        const verifierPath = `${path}/${keyId}_verifying.key`;
-        await fs.writeFile(proverPath, keyPairBuffers.provingKey);
-        await fs.writeFile(verifierPath, keyPairBuffers.verifyingKey);
     }
 }
 
-export {AleoKeyProvider, AleoKeyProviderParams, AleoKeyProviderInitParams, CachedKeyPair, FunctionKeyPair, FunctionKeyProvider, KeyBuffers, KeySearchParams}
+export {AleoKeyProvider, AleoKeyProviderParams, AleoKeyProviderInitParams, CachedKeyPair, FunctionKeyPair, FunctionKeyProvider, KeyBytes, KeySearchParams}

--- a/sdk/src/function-key-provider.ts
+++ b/sdk/src/function-key-provider.ts
@@ -616,15 +616,15 @@ class AleoKeyProvider implements FunctionKeyProvider {
      * Converts the keys in a FunctionKeyPair to buffers.
      * @param {FunctionKeyPair} The proving and verifying keys to convert.
      * 
-     * @returns {Promise<KeyBuffers>} The buffers containing the proving and verifying keys.
+     * @returns {Promise<KeyBytes>} The buffers containing the proving and verifying keys.
      */
-    async convertKeysToBytes(keyPair: FunctionKeyPair): Promise<KeyBytes> {
+    convertKeysToBytes(keyPair: FunctionKeyPair): KeyBytes {
         const [provingKey, verifyingKey] = keyPair;
         const proverBytes = provingKey.toBytes();
         const verifierBytes = verifyingKey.toBytes();
         return {
-            provingKey: proverBytes,
-            verifyingKey: verifierBytes
+            provingKeyBytes: proverBytes,
+            verifyingKeyBytes: verifierBytes
         };
     }
 }

--- a/sdk/src/function-key-provider.ts
+++ b/sdk/src/function-key-provider.ts
@@ -16,12 +16,18 @@ import {
 
 import { get } from "./utils.js";
 
+import fs from "node:fs/promises";
+
 type FunctionKeyPair = [ProvingKey, VerifyingKey];
 type CachedKeyPair = [Uint8Array, Uint8Array];
 type AleoKeyProviderInitParams = {
     proverUri?: string;
     verifierUri?: string;
     cacheKey?: string;
+};
+type KeyBuffers = {
+  provingKey: Buffer;
+  verifyingKey: Buffer;
 };
 
 /**
@@ -608,6 +614,37 @@ class AleoKeyProvider implements FunctionKeyProvider {
 
     unBondPublicKeys(): Promise<FunctionKeyPair> {
         return this.fetchCreditsKeys(CREDITS_PROGRAM_KEYS.unbond_public);
+    }
+
+    /**
+     * Converts the keys in a FunctionKeyPair to buffers.
+     * @param {FunctionKeyPair} The proving and verifying keys to convert.
+     * 
+     * @returns {Promise<KeyBuffers>} The buffers containing the proving and verifying keys.
+     */
+    async saveKeysToFile(keyPair: FunctionKeyPair): Promise<KeyBuffers> {
+        const [provingKey, verifyingKey] = keyPair;
+        const proverBytes = provingKey.toBytes();
+        const verifierBytes = verifyingKey.toBytes();
+        return {
+            provingKey: Buffer.from(proverBytes), 
+            verifyingKey: Buffer.from(verifierBytes)
+        };
+    }
+
+    /**
+     * Saves the keys in a FunctionKeyPair to the local disk.
+     * @param {string} path The path to save the keys to.
+     * @param {string} keyId The keyId to use for the file names.
+     * @param {KeyBuffers} keyPairBuffers The buffers containing the proving and verifying keys.
+     * 
+     * @returns {Promise<void>} A promise that resolves when the keys have been saved.
+     */
+    async saveKeysToLocalDisk(path: string, keyId: string, keyPairBuffers: KeyBuffers): Promise<void> {
+        const proverPath = `${path}/${keyId}_proving.key`;
+        const verifierPath = `${path}/${keyId}_verifying.key`;
+        await fs.writeFile(proverPath, keyPairBuffers.provingKey);
+        await fs.writeFile(verifierPath, keyPairBuffers.verifyingKey);
     }
 }
 

--- a/sdk/src/function-key-provider.ts
+++ b/sdk/src/function-key-provider.ts
@@ -648,4 +648,4 @@ class AleoKeyProvider implements FunctionKeyProvider {
     }
 }
 
-export {AleoKeyProvider, AleoKeyProviderParams, AleoKeyProviderInitParams, CachedKeyPair, FunctionKeyPair, FunctionKeyProvider, KeySearchParams}
+export {AleoKeyProvider, AleoKeyProviderParams, AleoKeyProviderInitParams, CachedKeyPair, FunctionKeyPair, FunctionKeyProvider, KeyBuffers, KeySearchParams}

--- a/sdk/src/function-key-provider.ts
+++ b/sdk/src/function-key-provider.ts
@@ -622,7 +622,7 @@ class AleoKeyProvider implements FunctionKeyProvider {
      * 
      * @returns {Promise<KeyBuffers>} The buffers containing the proving and verifying keys.
      */
-    async saveKeysToFile(keyPair: FunctionKeyPair): Promise<KeyBuffers> {
+    async convertKeysToBuffer(keyPair: FunctionKeyPair): Promise<KeyBuffers> {
         const [provingKey, verifyingKey] = keyPair;
         const proverBytes = provingKey.toBytes();
         const verifierBytes = verifyingKey.toBytes();

--- a/sdk/src/key-manager.ts
+++ b/sdk/src/key-manager.ts
@@ -1,42 +1,45 @@
 import fs from "node:fs/promises";
 
 type KeyBytes = {
-  provingKey: Uint8Array;
-  verifyingKey: Uint8Array;
+  provingKeyBytes: Uint8Array;
+  verifyingKeyBytes: Uint8Array;
 };
 
 interface KeyStorage {
-    saveKeyToDisk(path: string, filename: string, keyBytes: KeyBytes): Promise<void>;
-    loadKeyFromDisk(provingKeyPath: string): Promise<Uint8Array>;
+    saveKeyBytesToDisk(path: string, keyID: string, keyBytes: KeyBytes): Promise<void>;
+    loadKeyBytesFromDisk(provingKeyPath: string): Promise<Uint8Array>;
 }
 
 
-class KeyStorageManager implements KeyStorage {
+class KeyStorageManager {
     /**
-    * Saves the keys in a FunctionKeyPair to the local disk.
+    * Saves the key bytes to the local disk.
     * @param {string} path The path to save the keys to.
     * @param {string} keyID The keyId to use for the file names.
-    * @param {KeyBytes} keyPairBuffers The buffers containing the proving and verifying keys.
-    * 
+    * @param {KeyBytes} keyPairBytes The bytes containing the proving and verifying keys.
+    *
     * @returns {Promise<void>} A promise that resolves when the keys have been saved.
     */
-    async saveKeyToDisk(path: string, keyID: string, keyPairBytes: KeyBytes): Promise<void> {
+    static async saveKeyBytesToDisk(path: string, keyID: string, keyPairBytes: KeyBytes): Promise<void> {
         await fs.mkdir(path, { recursive: true });
-        await fs.writeFile(`${path}/${keyID}_proving`, keyPairBytes.provingKey);
-        await fs.writeFile(`${path}/${keyID}_verifying`, keyPairBytes.verifyingKey);
+        await fs.writeFile(`${path}/${keyID}.prover`, keyPairBytes.provingKeyBytes);
+        await fs.writeFile(`${path}/${keyID}.verifier`, keyPairBytes.verifyingKeyBytes);
     }
 
     /**
     * Load keys from disk.
     * @param {string} keyPath The file path for the proving or verifying key.
     *
-    * @returns {Promise<FunctionKeyPair>}
+    * @returns {Promise<Uint8Array>}
     */
-    async loadKeyFromDisk(keyPath: string): Promise<Uint8Array> {
-        const key = await fs.readFile(keyPath);
-
-        return key;
+    static async loadKeyBytesFromDisk(path: string, keyID: string): Promise<KeyBytes> {
+        const provingKey = await fs.readFile(`${path}/${keyID}.prover`);
+        const verifyingKey = await fs.readFile(`${path}/${keyID}.verifier`);
+        return {
+          provingKeyBytes: new Uint8Array(provingKey),
+          verifyingKeyBytes: new Uint8Array(verifyingKey)
+        };
     }
 }
 
-export { KeyBytes, KeyStorageManager };
+export { KeyBytes, KeyStorage, KeyStorageManager };

--- a/sdk/src/key-manager.ts
+++ b/sdk/src/key-manager.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+
+type KeyBytes = {
+  provingKey: Uint8Array;
+  verifyingKey: Uint8Array;
+};
+
+interface KeyStorage {
+    saveKeyToDisk(path: string, filename: string, keyBytes: KeyBytes): Promise<void>;
+    loadKeyFromDisk(provingKeyPath: string): Promise<Uint8Array>;
+}
+
+
+class KeyStorageManager implements KeyStorage {
+    /**
+    * Saves the keys in a FunctionKeyPair to the local disk.
+    * @param {string} path The path to save the keys to.
+    * @param {string} keyID The keyId to use for the file names.
+    * @param {KeyBytes} keyPairBuffers The buffers containing the proving and verifying keys.
+    * 
+    * @returns {Promise<void>} A promise that resolves when the keys have been saved.
+    */
+    async saveKeyToDisk(path: string, keyID: string, keyPairBytes: KeyBytes): Promise<void> {
+        await fs.mkdir(path, { recursive: true });
+        await fs.writeFile(`${path}/${keyID}_proving`, keyPairBytes.provingKey);
+        await fs.writeFile(`${path}/${keyID}_verifying`, keyPairBytes.verifyingKey);
+    }
+
+    /**
+    * Load keys from disk.
+    * @param {string} keyPath The file path for the proving or verifying key.
+    *
+    * @returns {Promise<FunctionKeyPair>}
+    */
+    async loadKeyFromDisk(keyPath: string): Promise<Uint8Array> {
+        const key = await fs.readFile(keyPath);
+
+        return key;
+    }
+}
+
+export { KeyBytes, KeyStorageManager };

--- a/sdk/src/node.ts
+++ b/sdk/src/node.ts
@@ -1,2 +1,4 @@
 import "./node-polyfill.js";
 export * from "./browser.js";
+
+export * from "./key-manager.js";

--- a/sdk/src/offline-key-provider.ts
+++ b/sdk/src/offline-key-provider.ts
@@ -2,7 +2,6 @@ import {
     CachedKeyPair,
     FunctionKeyPair,
     FunctionKeyProvider,
-    KeyBuffers,
     KeySearchParams,
 } from "./function-key-provider.js";
 
@@ -19,8 +18,6 @@ import {
     PUBLIC_TO_PRIVATE_TRANSFER,
     PUBLIC_TRANSFER_AS_SIGNER,
 } from "./constants.js";
-
-import fs from "node:fs/promises";
 
 /**
  * Search parameters for the offline key provider. This class implements the KeySearchParams interface and includes
@@ -605,46 +602,12 @@ class OfflineKeyProvider implements FunctionKeyProvider {
     }
 
     /**
-     * Convert key buffers to a FunctionKeyPair.
-     * @param {KeyBuffers} keyBuffers The key buffers loaded from storage.
-     * @returns {FunctionKeyPair}
-     */
-    convertKeyBuffersToFunctionKeyPair(keyBuffers: KeyBuffers): FunctionKeyPair {
-        const provingKey = ProvingKey.fromBytes(new Uint8Array(keyBuffers.provingKey));
-        const verifyingKey = VerifyingKey.fromBytes(new Uint8Array(keyBuffers.verifyingKey));
-        return [provingKey, verifyingKey];
-    }
-
-    /**
      * Convert key buffer to ProvingKey.
      * @param {Buffer} buffer The key buffer for the proving key loaded from storage.
      * @returns {ProvingKey}
      */
-    convertKeyBufferToProvingKey(buffer: Buffer): ProvingKey {
-        return ProvingKey.fromBytes(new Uint8Array(buffer));
-    }
-
-    /**
-     * Load keys from disk.
-     * @param {string} provingKeyPath The file path for the proving key.
-     * @param {string} verifyingKeyPath The file path for the verifying key.
-     * @returns {Promise<FunctionKeyPair>}
-     */
-    loadKeysFromDisk(provingKeyPath: string, verifyingKeyPath: string): Promise<FunctionKeyPair> {
-        return new Promise(async (resolve, reject) => {
-            try {
-                const provingKeyBuffer = await fs.readFile(provingKeyPath);
-                const verifyingKeyBuffer = await fs.readFile(verifyingKeyPath);
-                const keyBuffers: KeyBuffers = {
-                    provingKey: provingKeyBuffer,
-                    verifyingKey: verifyingKeyBuffer,
-                };
-                const functionKeyPair = this.convertKeyBuffersToFunctionKeyPair(keyBuffers);
-                resolve(functionKeyPair);
-            } catch (error) {
-                reject(new Error(`Failed to load keys from disk: ${error}`));
-            }
-        });
+    convertKeyBytesToProvingKey(bytes: Uint8Array): ProvingKey {
+        return ProvingKey.fromBytes(bytes);
     }
 }
 

--- a/sdk/src/offline-key-provider.ts
+++ b/sdk/src/offline-key-provider.ts
@@ -2,6 +2,7 @@ import {
     CachedKeyPair,
     FunctionKeyPair,
     FunctionKeyProvider,
+    KeyBuffers,
     KeySearchParams,
 } from "./function-key-provider.js";
 
@@ -18,6 +19,8 @@ import {
     PUBLIC_TO_PRIVATE_TRANSFER,
     PUBLIC_TRANSFER_AS_SIGNER,
 } from "./constants.js";
+
+import fs from "node:fs/promises";
 
 /**
  * Search parameters for the offline key provider. This class implements the KeySearchParams interface and includes
@@ -599,6 +602,49 @@ class OfflineKeyProvider implements FunctionKeyProvider {
         } else {
             throw new Error("Attempted to insert invalid proving keys for unbond_public");
         }
+    }
+
+    /**
+     * Convert key buffers to a FunctionKeyPair.
+     * @param {KeyBuffers} keyBuffers The key buffers loaded from storage.
+     * @returns {FunctionKeyPair}
+     */
+    convertKeyBuffersToFunctionKeyPair(keyBuffers: KeyBuffers): FunctionKeyPair {
+        const provingKey = ProvingKey.fromBytes(new Uint8Array(keyBuffers.provingKey));
+        const verifyingKey = VerifyingKey.fromBytes(new Uint8Array(keyBuffers.verifyingKey));
+        return [provingKey, verifyingKey];
+    }
+
+    /**
+     * Convert key buffer to ProvingKey.
+     * @param {Buffer} buffer The key buffer for the proving key loaded from storage.
+     * @returns {ProvingKey}
+     */
+    convertKeyBufferToProvingKey(buffer: Buffer): ProvingKey {
+        return ProvingKey.fromBytes(new Uint8Array(buffer));
+    }
+
+    /**
+     * Load keys from disk.
+     * @param {string} provingKeyPath The file path for the proving key.
+     * @param {string} verifyingKeyPath The file path for the verifying key.
+     * @returns {Promise<FunctionKeyPair>}
+     */
+    loadKeysFromDisk(provingKeyPath: string, verifyingKeyPath: string): Promise<FunctionKeyPair> {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const provingKeyBuffer = await fs.readFile(provingKeyPath);
+                const verifyingKeyBuffer = await fs.readFile(verifyingKeyPath);
+                const keyBuffers: KeyBuffers = {
+                    provingKey: provingKeyBuffer,
+                    verifyingKey: verifyingKeyBuffer,
+                };
+                const functionKeyPair = this.convertKeyBuffersToFunctionKeyPair(keyBuffers);
+                resolve(functionKeyPair);
+            } catch (error) {
+                reject(new Error(`Failed to load keys from disk: ${error}`));
+            }
+        });
     }
 }
 

--- a/sdk/src/offline-key-provider.ts
+++ b/sdk/src/offline-key-provider.ts
@@ -600,15 +600,6 @@ class OfflineKeyProvider implements FunctionKeyProvider {
             throw new Error("Attempted to insert invalid proving keys for unbond_public");
         }
     }
-
-    /**
-     * Convert key buffer to ProvingKey.
-     * @param {Buffer} buffer The key buffer for the proving key loaded from storage.
-     * @returns {ProvingKey}
-     */
-    convertKeyBytesToProvingKey(bytes: Uint8Array): ProvingKey {
-        return ProvingKey.fromBytes(bytes);
-    }
 }
 
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The offline key manager offers a user the option to cache proving and verifying keys to enable offline transactions.  This PR introduces helper methods to save and retrieve proving and verifying keys from either local storage or to a storage location selected by the user.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Install the version of the SDK from this branch.  From the root of the SDK directory run:
```bash
yarn build:all && yarn install`
```

Then navigate to `/create-leo-app/template-node` and replace the code in the `index.js` file with:
```typescript
import { Account, AleoKeyProvider, CREDITS_PROGRAM_KEYS, initThreadPool, OfflineKeyProvider, OfflineSearchParams, ProgramManager, ProvingKey, VerifyingKey, KeyStorageManager } from '@provablehq/sdk/testnet.js';
import { expect } from 'chai';

await initThreadPool();

async function localProgramExecution() {
	const programManager = new ProgramManager();

	// Create a temporary account for the execution of the program
	const account = new Account();
	programManager.setAccount(account);

	// Create a key provider in order to re-use the same key for each execution
	const keyProvider = new AleoKeyProvider();
	
	// Obtain the Proving and Verifying keys for credits.aleo/transfer_public and credits.aleo/fee_public.
	const feeKeyPair = await keyProvider.fetchCreditsKeys(CREDITS_PROGRAM_KEYS.fee_public);
	const transferPublicKeyPair = await keyProvider.fetchCreditsKeys(CREDITS_PROGRAM_KEYS.transfer_public);

	// Save the key bytes to storage
	const feeKeyBytes = keyProvider.convertKeysToBytes(feeKeyPair);
	const transferPublicKeyBytes = keyProvider.convertKeysToBytes(transferPublicKeyPair);

	await KeyStorageManager.saveKeyBytesToDisk("./KEY_DIR", "fee_public", feeKeyBytes);
	await KeyStorageManager.saveKeyBytesToDisk("./KEY_DIR", "transfer_public", transferPublicKeyBytes);

	// Load keys from storage using the Offline Key Provider
	const offlineKeyProvider = new OfflineKeyProvider();
	const localFeeKeyBytes = await KeyStorageManager.loadKeyBytesFromDisk("./KEY_DIR", "fee_public");
	const feeProvingKey = ProvingKey.fromBytes(localFeeKeyBytes.provingKeyBytes);
	const feeVerifyingKey = VerifyingKey.fromBytes(localFeeKeyBytes.verifyingKeyBytes);

	const localTransferPublicKeyBytes = await KeyStorageManager.loadKeyBytesFromDisk("./KEY_DIR", "transfer_public");
	const transferPublicProvingKey = ProvingKey.fromBytes(localTransferPublicKeyBytes.provingKeyBytes);
	const transferPublicVerifyingKey = VerifyingKey.fromBytes(localTransferPublicKeyBytes.verifyingKeyBytes);

	expect(feeProvingKey.toString()).to.equal(feeKeyPair[0].toString());
	expect(feeVerifyingKey.toString()).to.equal(feeKeyPair[1].toString());
	expect(transferPublicProvingKey.toString()).to.equal(transferPublicKeyPair[0].toString());
	expect(transferPublicVerifyingKey.toString()).to.equal(transferPublicKeyPair[1].toString());
};

await localProgramExecution();
```

Create a `./KEYS_DIR` folder and then run:

```bash
yarn install && yarn dev
```