### PR TITLE
[Feature] Decrypt Sender Ciphertext

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,6 @@ jobs:
 
   template-node-ts:
     executor: rust-node
-    resource_class: xlarge
     steps:
       - setup-sdk
       - run:

--- a/create-leo-app/template-node/index.js
+++ b/create-leo-app/template-node/index.js
@@ -2,7 +2,7 @@ import {Account, AleoKeyProvider, AleoKeyProviderParams, initThreadPool, Program
 
 import * as process from "node:process";
 
-await initThreadPool();
+// await initThreadPool();
 
 const programName = "hello_hello.aleo"
 
@@ -78,12 +78,12 @@ async function remoteProgramExecution(programName, functionName, inputs) {
     console.log("Resulting transaction")
 }
 
-const start = Date.now();
-console.log("Starting local execute!");
-await localProgramExecution(hello_hello_program, programName, "hello", ["5u32", "5u32"]);
-console.log("Local execute finished!", Date.now() - start);
-
-console.log("Starting remote execute");
-const auctionTicket = "{\n  owner: aleo12a4wll9ax6w5355jph0dr5wt2vla5sss2t4cnch0tc3vzh643v8qcfvc7a.private,\n  auction: {\n    starting_bid: 1000u64.private,\n    name: 35399035103896773146887283777field.private,\n    item: {\n      id: 2711777270856651361584090827715149911900945757872672230578290769243507539617field.private,\n      offchain_data: [\n        988474637487226873250021955104421895943605632761729320744454284792013483886field.private,\n        1018595503607749325560812785092303652308909717269501712857428145700763090203field.private,\n        1866354748676879328546224733327549476838379876255164483333908854380501015560field.private,\n        17649382157field.private\n      ]\n    }\n  },\n  auction_id: 4494702806735512695876583707511065751304542460719196393147692059573188109243field.private,\n  settings: {\n    auction_privacy: 1field.private,\n    bid_types_accepted: 2field.private\n  },\n  _nonce: 3369967065799891136255379173673996324404175734426175774361522329924029135340group.public,\n  _version: 0u8.public\n}";
-const privateBid = "{\n  owner: aleo12a4wll9ax6w5355jph0dr5wt2vla5sss2t4cnch0tc3vzh643v8qcfvc7a.private,\n  bid: {\n    amount: 50000u64.private,\n    auction_id: 4494702806735512695876583707511065751304542460719196393147692059573188109243field.private,\n    bid_public_key: 7957235921075215080384898776027711008106448988910535634014947882222019778701group.private\n  },\n  bid_id: 7560059211950188901208146469854635725646381155467709838136796808753178551929field.private,\n  _nonce: 6603986437928263590097393830337419611438422585243442121397081002092267314422group.public,\n  _version: 0u8.public\n}";
-await remoteProgramExecution("private_auction_test_3.aleo", "select_winner_private", [auctionTicket, privateBid]);
+// const start = Date.now();
+// console.log("Starting local execute!");
+// await localProgramExecution(hello_hello_program, programName, "hello", ["5u32", "5u32"]);
+// console.log("Local execute finished!", Date.now() - start);
+//
+// console.log("Starting remote execute");
+// const auctionTicket = "{\n  owner: aleo12a4wll9ax6w5355jph0dr5wt2vla5sss2t4cnch0tc3vzh643v8qcfvc7a.private,\n  auction: {\n    starting_bid: 1000u64.private,\n    name: 35399035103896773146887283777field.private,\n    item: {\n      id: 2711777270856651361584090827715149911900945757872672230578290769243507539617field.private,\n      offchain_data: [\n        988474637487226873250021955104421895943605632761729320744454284792013483886field.private,\n        1018595503607749325560812785092303652308909717269501712857428145700763090203field.private,\n        1866354748676879328546224733327549476838379876255164483333908854380501015560field.private,\n        17649382157field.private\n      ]\n    }\n  },\n  auction_id: 4494702806735512695876583707511065751304542460719196393147692059573188109243field.private,\n  settings: {\n    auction_privacy: 1field.private,\n    bid_types_accepted: 2field.private\n  },\n  _nonce: 3369967065799891136255379173673996324404175734426175774361522329924029135340group.public,\n  _version: 0u8.public\n}";
+// const privateBid = "{\n  owner: aleo12a4wll9ax6w5355jph0dr5wt2vla5sss2t4cnch0tc3vzh643v8qcfvc7a.private,\n  bid: {\n    amount: 50000u64.private,\n    auction_id: 4494702806735512695876583707511065751304542460719196393147692059573188109243field.private,\n    bid_public_key: 7957235921075215080384898776027711008106448988910535634014947882222019778701group.private\n  },\n  bid_id: 7560059211950188901208146469854635725646381155467709838136796808753178551929field.private,\n  _nonce: 6603986437928263590097393830337419611438422585243442121397081002092267314422group.public,\n  _version: 0u8.public\n}";
+// await remoteProgramExecution("private_auction_test_3.aleo", "select_winner_private", [auctionTicket, privateBid]);

--- a/sdk/tests/data/records.ts
+++ b/sdk/tests/data/records.ts
@@ -1,3 +1,15 @@
+/// V1 credits.aleo record.
+const CREDITS_RECORD_V1 = "{ owner: aleo12a4wll9ax6w5355jph0dr5wt2vla5sss2t4cnch0tc3vzh643v8qcfvc7a.private, microcredits: 1000000u64.private, _nonce: 3634848344765318974603121890869676775499130077229666060613233255327643175219group.public, _version: 1u8.public }";
+
+/// Record view key for the V1 credits.aleo record.
+const CREDITS_RECORD_VIEW_KEY = "5237002936265850807349726649400053591020997883662246784632368923777787639801field";
+
+/// Sender ciphertext of the credits.aleo record.
+const CREDITS_SENDER_CIPHERTEXT = "1182590395568997043375432557467567048762179115999922880321493200728848194550field";
+
+/// Sender plaintext of the credits.aleo record.
+const CREDITS_SENDER_PLAINTEXT = "aleo1j92w9mhqznj2hvufad796y8suykjppk7f6n6xmncmktfm95vggzqx4sjlh";
+
 // Ciphertext records
 const RECORD_CIPHERTEXT_STRING = "record1qyqsqpe2szk2wwwq56akkwx586hkndl3r8vzdwve32lm7elvphh37rsyqyxx66trwfhkxun9v35hguerqqpqzqrtjzeu6vah9x2me2exkgege824sd8x2379scspmrmtvczs0d93qttl7y92ga0k0rsexu409hu3vlehe3yxjhmey3frh2z5pxm5cmxsv4un97q";
 const RECORD_CIPHERTEXT_STRING_COPY = "record1qyqsqpe2szk2wwwq56akkwx586hkndl3r8vzdwve32lm7elvphh37rsyqyxx66trwfhkxun9v35hguerqqpqzqrtjzeu6vah9x2me2exkgege824sd8x2379scspmrmtvczs0d93qttl7y92ga0k0rsexu409hu3vlehe3yxjhmey3frh2z5pxm5cmxsv4un97q";
@@ -16,6 +28,10 @@ const VIEW_KEY_STRING = "AViewKey1ccEt8A2Ryva5rxnKcAbn7wgTaTsb79tzkKHFpeKsm9NX";
 const RECORD_VIEW_KEY_STRING = "4445718830394614891114647247073357094867447866913203502139893824059966201724field";
 
 export {
+    CREDITS_RECORD_V1,
+    CREDITS_RECORD_VIEW_KEY,
+    CREDITS_SENDER_CIPHERTEXT,
+    CREDITS_SENDER_PLAINTEXT,
     RECORD_CIPHERTEXT_STRING,
     RECORD_CIPHERTEXT_STRING_COPY,
     RECORD_CIPHERTEXT_STRING_NOT_OWNED,

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -368,7 +368,7 @@ describe("NodeConnection", () => {
             }
         });
 
-        it.only("should throw for a malformed tx ID", async () => {
+        it("should throw for a malformed tx ID", async () => {
             const connection = new AleoNetworkClient(host);
             try {
                 await connection.waitForTransactionConfirmation(invalidTx);

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -12,6 +12,10 @@ import {
     beaconPrivateKeyString
 } from "./data/account-data.js";
 import {
+    CREDITS_RECORD_V1,
+    CREDITS_RECORD_VIEW_KEY,
+    CREDITS_SENDER_CIPHERTEXT,
+    CREDITS_SENDER_PLAINTEXT,
     RECORD_CIPHERTEXT_STRING,
     RECORD_CIPHERTEXT_STRING_COPY,
     RECORD_CIPHERTEXT_STRING_NOT_OWNED,
@@ -20,6 +24,7 @@ import {
     RECORD_VIEW_KEY_STRING,
     VIEW_KEY_STRING,
 } from "./data/records.js";
+import process from "node:process";
 
 describe('WASM Objects', () => {
     describe('Address', () => {
@@ -483,6 +488,29 @@ describe('WASM Objects', () => {
             // Ensure the decrypted record is the same as the plaintext
             expect(decryptedRecords[0].toString()).equal(recordPlaintextCopy.toString());
         });
+        it('can decrypt sender ciphertexts', () => {
+            // Get the private key corresponding to the record.
+            const private_key = PrivateKey.from_string(<string>process.env["PUZZLE_PK"]);
+            const view_key = ViewKey.from_private_key(private_key);
+
+            // Construct the record and the sender ciphertext.
+            const record = RecordPlaintext.fromString(CREDITS_RECORD_V1);
+            const record_view_key = Field.fromString(CREDITS_RECORD_VIEW_KEY);
+            const sender_ciphertext = Field.fromString(CREDITS_SENDER_CIPHERTEXT);
+
+            // Decrypt the sender ciphertext using the record object and ensure it's from the expected address.
+            let sender = record.decryptSender(view_key, sender_ciphertext);
+            expect(sender.to_string()).to.equal(CREDITS_SENDER_PLAINTEXT);
+
+            // Decrypt the sender ciphertext using the EncryptionToolkit function and ensure it's from the expected address.
+            sender = EncryptionToolkit.decryptSender(view_key, record, sender_ciphertext);
+            expect(sender.to_string()).to.equal(CREDITS_SENDER_PLAINTEXT);
+
+            // Decrypt the sender ciphertext using only the record view key and ensure it's from the expected address.
+            sender = EncryptionToolkit.decryptSenderWithRvk(record_view_key, sender_ciphertext);
+            expect(sender.to_string()).to.equal(CREDITS_SENDER_PLAINTEXT);
+        })
+        it('can decryption')
     });
     describe('VerifyingKey', () => {
         it('can get the number of constraints', async () => {

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -295,7 +295,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2018,8 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff92927dbd501b3975f3a35be4514f154c7bfde0db3dae2c89a4ebd0a6c2a31"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2045,8 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfedf2ae76fbb1b50228619777e403091d86afa68431977e3254047621d631eb"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2059,8 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9ada6b1454609b36c1f3b7bc267730e2f0cd0417b0757d8418202b7fa10023"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2069,8 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f7d5a0455572948306431129ac86f66e5a826c4d6483003f63c1aa06d66dcb"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2079,8 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279271263ba9c9643e791fa7b8a445761a02ac56fbb530faac6c7c350b85f10b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2089,8 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1024c91b9bf4cb14268fafd7945b9a68e462132cd5c834bcec8e04def98cd207"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2107,13 +2113,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433b0c2fc969a514ac01f6e05756be6d928142eaae3f0ef6805aa6396159dd83"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220bee6126a7290a2697f44ba9dea9d46e586303827306637bd93a63ce505fe9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2123,8 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf624e44496a2db2d28917acf62a3da026298909f60d051aae8ff022cb5e2f30"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2137,8 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e86fd576228776bcd748aca18926d17851120cfc8746bbf186481b9d7acdab"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2152,8 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fada6e6937fb8ae7d25ad0e84110f89492c30e079d71b25c4b952abb8ba5e0ee"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2165,8 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0dfd0497a5b5bede8cabbb79e5b95b9f2c0de6ff896e6f89295509243ef9d0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2174,8 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9406f29259e02fc2a110022619cec95f8a7db420542c6daae6b8258ff7501205"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2184,8 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9978e0b3331faec1244931a62bae48d79b5b8d2b0d247aa8bc6f945b650d95a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2196,8 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c68dd8c19158cf4734377ef906c3dab5c756465b05f7d5a838f4ee4adbca549"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2208,8 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbea45346dc6247f31d294c84ef4595c784d16766939dceb8ddfe3b18ea9feb9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2219,8 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9467bba1edd47c201dfd863b8e5e67be6ea3c268bb705f084d98bbf72ff25385"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2231,8 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8819ed1e129aa99dc5636017a9397e18d356dfbd13b1141e4275816a0d817968"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2244,8 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eaeb0b8c5402d1e9ec0e22466d87e621a72b5c4d191e9e4282a2b4aec21707b"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2255,8 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09b9d82502ae99c20f335baa431977513e2676092970ff5deb9b8ef997b295"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2268,8 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e5d68b4a24c928ef579de5d46e882b0cf85d48206e29fd6f0413216204a249"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2279,8 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1220d41581ac064d916e953d78fcca4ce13c28648bef3df71eadd1359d61f594"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2299,8 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2cff4c435e430b62ee09304da850f26aa9839e5ccf0603618b62c2db745a2db"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2317,8 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86af968fb1d5777b235aca1a6819a291c2d89cdb971e939f60e0c8bebef169fb"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2337,8 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdfc69ed664199bf8ec712dbba4174437f5b4e326b673c204d5070afcfd90d58"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2352,8 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3c338adfab1d4171c1333ea971cf4506165cf6cd4be5128f044cd50cb926f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2363,16 +2389,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5306794f9ec3e380f8de5d8e3f1674182a6f758892604861b85d7292bd8496"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053872b00170acc87bbd010b6ec953e950cd80fd504aa9e789754358090bf2fc"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2381,8 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ccf05eb7691e7616fd5c8864d0be6b9c92664d9b360b14e41fe5b0c55f4c613"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2392,8 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafa8e38818b6886411204f6263c081f9119f0b8173eb1d824ff1fb0446f6f60"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2403,8 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14823c16c5a3e5bf70e2346994f43386967d327835b7a622dc2ed086266e790"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2414,8 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c253940e1e7754a14b2cf4e72f56db50b8c34bb28a5b896b76e35f29b250d92a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2425,8 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f4cae48b8f560acbf178616b781877b4fe752e44ec6925f53b5d4805d1b6fe"
 dependencies = [
  "rand",
  "rayon",
@@ -2439,8 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b58192c2da361f2b77b088d6da1c0e73d9f29cc6375cb3c03965a055bf0990"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2456,8 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bda7ffa0ed7626b39b11a992ccfb41a1a977737194699c2804069900f6d28c"
 dependencies = [
  "anyhow",
  "rand",
@@ -2468,8 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18338abd3ea59b4447c5e02681dfe2bccc5dbd5b7f62a2be3bfd4be2c6318e18"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2488,8 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54083bd33e3e8401672cab534e484362ff54a947f234e566a64a07e13ee6f818"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2500,8 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3bef13150d91e07d57109520b27d99731520386d529500b874e7378ff727d4"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2513,8 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bd7ad7a309542acb0d640fefafb195d80b894c494a2c2c9c103017347ed87f"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2525,8 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae4b94d1c2899fac3ebc620f48c60ecd7ab9e27ced13efe1cf272cf4472a62"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2535,8 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7123458b2e723fbe1f12f04fc145d77eaebf37dac4e4aff06c45e10b27ab0928"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2550,8 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834e57f5d2f062aa27ecaca5e2a871e70014069030ec333bb263264899e8ecbd"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2559,8 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa5d53b35ea5961ad0373a333a4804c0c98717b89788c0e10fb5431c4fb1b2b4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2578,8 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c64b9c837315b38c736c4c7094e43b91f061404c526c81c7ffda7dcc5a4486"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2600,8 +2644,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8919e7e17484d214a717960036496459a3c39862cc0a3ec685b808e6f73c2ba"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2617,8 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d63c2459f69ed66343c4f8258cb997b29be201b59ae6d32d4bb8f973c9dea8"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2640,8 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dccae4ccd30d936f69a8470c1c06fdd53172ab25b6f0352c409205e6f0526213"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2665,8 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3f1b6a76f83dea1d10a36f51022507e38e04ea6420184522a12435e4e5bfb4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2696,8 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202f8993b1d84e4b435e6f06655e5faf8611318b49a724db3bcc6521061b846c"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2720,8 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf311b775983ceeacd94a20e076b4cf37f2f2233177a5a332e48f8af2fdcf505"
 dependencies = [
  "indexmap",
  "paste",
@@ -2738,8 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8497d8ffd96bab5dc5a4d2c1365598a7390f79ac75dd7961609e7f607b07840"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2751,8 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c752d0233bb34b61fefa01d20ed114c559950883d18a68a3023b91dced54a6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2772,8 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd2e4465f1af843b2f9e4c83c97d48c4a9c9e3522b4020e8dd9ef82d0ce5324a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",
@@ -2782,8 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262cbd26d4065b6d88d2a6fea7d26b3f400d0b85810f8e8c9975b10086aea127"
 dependencies = [
  "getrandom",
  "snarkvm-console",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -22,17 +22,14 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 
 [dependencies.snarkvm-circuit-network]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 default-features = false
 features = [
     "account",
@@ -45,38 +42,31 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 
 [dependencies.snarkvm-parameters]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-git = "https://github.com/ProvableHQ/snarkVM"
-rev = "e035becf3"
+version = "4.2.0"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provablehq/wasm",
   "version": "0.9.8",
-  "type":"module",
+  "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [
     "The Provable Team"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provablehq/wasm",
   "version": "0.9.8",
-  "type": "module",
+  "type":"module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [
     "The Provable Team"

--- a/wasm/src/record/record_plaintext.rs
+++ b/wasm/src/record/record_plaintext.rs
@@ -17,6 +17,7 @@
 use crate::{
     Address,
     Credits,
+    EncryptionToolkit,
     GraphKey,
     Plaintext,
     PrivateKey,
@@ -266,6 +267,18 @@ impl RecordPlaintext {
         Group::from_string(&self.nonce()).unwrap().scalar_multiply(&view_key.to_scalar()).to_x_coordinate()
     }
 
+    /// Decrypt the sender ciphertext associated with the record.
+    ///
+    /// @param {ViewKey} view_key View key associated with the record.
+    /// @param {Field} sender_ciphertext Sender ciphertext associated with the record.
+    ///
+    /// @returns {Address} address of the sender.
+    #[wasm_bindgen(js_name = decryptSender)]
+    pub fn decrypt_sender(&self, view_key: &ViewKey, sender_ciphertext: &Field) -> Result<Address, String> {
+        let record_view_key = self.record_view_key(view_key);
+        EncryptionToolkit::decrypt_sender_with_rvk(&record_view_key, sender_ciphertext)
+    }
+
     /// Clone the RecordPlaintext WASM object.
     ///
     /// @returns {RecordPlaintext} A clone of the RecordPlaintext WASM object.
@@ -318,6 +331,11 @@ impl FromStr for RecordPlaintext {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::{
+        types::native::{PrivateKeyNative, ViewKeyNative},
+        utilities::test::{CREDITS_RECORD_V1, CREDITS_SENDER_CIPHERTEXT, CREDITS_SENDER_PLAINTEXT, get_env},
+    };
 
     use wasm_bindgen_test::*;
 
@@ -448,5 +466,20 @@ mod tests {
             Some("The record plaintext string provided was invalid".into())
         );
         assert!(RecordPlaintext::from_string(invalid_bech32).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_record_decrypt_record_sender_ciphertext() {
+        // Get the private key corresponding to the record.
+        let private_key = PrivateKeyNative::from_str(&get_env("PUZZLE_PK")).unwrap();
+        let view_key = ViewKey::from(ViewKeyNative::try_from(private_key).unwrap());
+
+        // Construct the record and the sender ciphertext.
+        let record = RecordPlaintext::from_string(CREDITS_RECORD_V1).unwrap();
+        let sender_ciphertext = Field::from_string(CREDITS_SENDER_CIPHERTEXT).unwrap();
+
+        // Decrypt the sender ciphertext and ensure it's from the expected address.
+        let sender = record.decrypt_sender(&view_key, &sender_ciphertext).unwrap();
+        assert_eq!(sender.to_string(), CREDITS_SENDER_PLAINTEXT.to_string());
     }
 }

--- a/wasm/src/utilities/encrypt.rs
+++ b/wasm/src/utilities/encrypt.rs
@@ -15,6 +15,7 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    Address,
     Field,
     Group,
     RecordCiphertext,
@@ -22,9 +23,11 @@ use crate::{
     Transition,
     ViewKey,
     types::native::{
+        AddressNative,
         CiphertextEntryNative,
         CurrentNetwork,
         FieldNative,
+        GroupNative,
         PlaintextEntryNative,
         PlaintextNative,
         RecordPlaintextNative,
@@ -32,7 +35,7 @@ use crate::{
     },
 };
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
-use snarkvm_console::prelude::{FromFields, Itertools, Network, Visibility};
+use snarkvm_console::prelude::{FromField, FromFields, Itertools, Network, One, Visibility};
 
 use indexmap::IndexMap;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -253,12 +256,58 @@ impl EncryptionToolkit {
 
         Ok(owned_records)
     }
+
+    /// Decrypt the sender ciphertext associated with a record.
+    ///
+    /// @param {ViewKey} view_key View key associated with the record.
+    /// @param {RecordPlaintext} record Record plaintext associated with a sender.
+    /// @param {Field} sender_ciphertext Sender ciphertext associated with the record.
+    ///
+    /// @returns {Address} address of the sender.
+    #[wasm_bindgen(js_name = decryptSender)]
+    pub fn decrypt_sender(
+        view_key: &ViewKey,
+        record: &RecordPlaintext,
+        sender_ciphertext: &Field,
+    ) -> Result<Address, String> {
+        let record_view_key = record.record_view_key(view_key);
+        Self::decrypt_sender_with_rvk(&record_view_key, sender_ciphertext)
+    }
+
+    /// Decrypt the sender ciphertext associated with the record with the record view key.
+    ///
+    /// @param {Field} record_view_key Record view key associated with the record.
+    /// @param {Field} sender_ciphertext Sender ciphertext associated with the record.
+    ///
+    /// @return {Address} the address of the sender.
+    #[wasm_bindgen(js_name = decryptSenderWithRvk)]
+    pub fn decrypt_sender_with_rvk(record_view_key: &Field, sender_ciphertext: &Field) -> Result<Address, String> {
+        let encryption_domain = <CurrentNetwork as Network>::encryption_domain();
+        let record_view_key = FieldNative::from(record_view_key);
+        let randomizer =
+            <CurrentNetwork as Network>::hash_psd4(&[encryption_domain, record_view_key, FieldNative::one()])
+                .map_err(|e| e.to_string())?;
+        let address_x_coordinate = FieldNative::from(sender_ciphertext) - randomizer;
+        Ok(Address::from(AddressNative::new(
+            GroupNative::from_field(&address_x_coordinate).map_err(|e| e.to_string())?,
+        )))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use crate::{
+        test::{
+            CREDITS_RECORD_V1,
+            CREDITS_RECORD_VIEW_KEY,
+            CREDITS_SENDER_CIPHERTEXT,
+            CREDITS_SENDER_PLAINTEXT,
+            get_env,
+        },
+        types::native::{PrivateKeyNative, ViewKeyNative},
+    };
     use std::str::FromStr;
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -365,5 +414,26 @@ mod tests {
         // Verify that only the owned record is returned
         assert_eq!(owned_records.len(), 1, "Only one owned record should be returned");
         assert_eq!(owned_records[0].to_string(), OWNER_CIPHERTEXT, "Owned record should match the owner's ciphertext");
+    }
+
+    #[wasm_bindgen_test]
+    fn test_encryption_toolkit_decrypt_record_sender_ciphertext() {
+        // Get the private key corresponding to the record.
+        let private_key = PrivateKeyNative::from_str(&get_env("PUZZLE_PK")).unwrap();
+        let view_key = ViewKey::from(ViewKeyNative::try_from(private_key).unwrap());
+
+        // Construct the record and the sender ciphertext.
+        let record = RecordPlaintext::from_string(CREDITS_RECORD_V1).unwrap();
+        let record_view_key = Field::from_string(CREDITS_RECORD_VIEW_KEY).unwrap();
+        let sender_ciphertext = Field::from_string(CREDITS_SENDER_CIPHERTEXT).unwrap();
+
+        // Decrypt the sender ciphertext using the view and record and ensure it's from the expected address.
+        let credits_sender = CREDITS_SENDER_PLAINTEXT.to_string();
+        let sender = EncryptionToolkit::decrypt_sender(&view_key, &record, &sender_ciphertext).unwrap();
+        assert_eq!(sender.to_string(), credits_sender);
+
+        // Decrypt the sender ciphertext using only the record view key and ensure it's from the expected address.
+        let sender = EncryptionToolkit::decrypt_sender_with_rvk(&record_view_key, &sender_ciphertext).unwrap();
+        assert_eq!(sender.to_string(), credits_sender);
     }
 }

--- a/wasm/src/utilities/test/programs.rs
+++ b/wasm/src/utilities/test/programs.rs
@@ -18,6 +18,20 @@ use crate::{array, object};
 
 use js_sys::{Array, Object};
 
+/// V1 credits.aleo record.
+pub const CREDITS_RECORD_V1: &str = "{ owner: aleo12a4wll9ax6w5355jph0dr5wt2vla5sss2t4cnch0tc3vzh643v8qcfvc7a.private, microcredits: 1000000u64.private, _nonce: 3634848344765318974603121890869676775499130077229666060613233255327643175219group.public, _version: 1u8.public }";
+
+/// Record view key for the V1 credits.aleo record.
+pub const CREDITS_RECORD_VIEW_KEY: &str =
+    "5237002936265850807349726649400053591020997883662246784632368923777787639801field";
+
+/// Sender ciphertext of the credits.aleo record.
+pub const CREDITS_SENDER_CIPHERTEXT: &str =
+    "1182590395568997043375432557467567048762179115999922880321493200728848194550field";
+
+/// Sender plaintext of the credits.aleo record.
+pub const CREDITS_SENDER_PLAINTEXT: &str = "aleo1j92w9mhqznj2hvufad796y8suykjppk7f6n6xmncmktfm95vggzqx4sjlh";
+
 pub const HELLO_PROGRAM: &str = r#"program hello.aleo;
 function main:
     input r0 as u32.public;


### PR DESCRIPTION
## Motivation

Record sender ciphertexts appear in V1 record outputs. However, no out of box functionality exists for decrypting these records in Javascript. This PR adds the ability to decrypt record sender ciphertexts using a (`Record`, `ViewKey`, `SenderCiphertext`) tuple within the `RecordPlaintext` and `EncryptionToolbox` structs  or (`Record View Key`, `SenderCiphertext) tuple within the `EncryptionToolbox` struct.

## Test Plan

Both `javascript` and `wasm` tests are added to ensure decryption is successful..