### PR TITLE
Add cargo semver-checks to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,18 @@ jobs:
             cargo clippy --features testnet
             cargo clippy --features mainnet
 
+  check-cargo-semver:
+    executor: rust-node
+    steps:
+      - checkout
+      - cargo_fetch:
+          working_directory: wasm
+      - run:
+          working_directory: wasm
+          command: |
+            cargo install cargo-semver-checks@0.43.0 --locked
+            cargo semver-checks --workspace --features testnet
+
   check-fmt:
     executor: rust-node
     steps:
@@ -170,6 +182,7 @@ workflows:
   main-workflow:
     jobs:
       - check-fmt
+      - check-cargo-semver
       - check-clippy
       - sdk
       - sdk-test:


### PR DESCRIPTION
## Motivation

Proof of concept to showcase: https://github.com/ProvableHQ/snarkVM/pull/2912

You may want to cache the `target` folder too like we do in that PR, where we get a speedup from from 40 minutes down to 15 minutes.

By default checks are made against the most recent published release. The approach I take in snarkVM is to manually append a `--baseline-rev eff84712b` if I want to just compare against a recent commit in between releases.
