### PR TITLE
[Feature] Enable test consensus version heights to be set

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -3,7 +3,11 @@
 Replace `$VERSION` with the desired new version (e.g. `0.7.0`):
 
 ```bash
+yarn build:all
 npm login
-yarn change-version $VERSION
-yarn deploy
+cd wasm && npm publish --access public
+cd ../sdk && npm publish --access public
+cd ../create-leo-app & npm publish --access public
+git tag vX.X.X
+git push origin vX.X.X
 ```

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && rollup -c rollup.config.js",
-    "test": "rimraf tmp && rollup -c rollup.test.js && mocha tmp/**/*.test.js --timeout 60000"
+    "test": "rimraf tmp && rollup -c rollup.test.js && mocha tmp/**/*.test.js --timeout 60000 && RUN_SKIPPED=true mocha tmp/**/wasm.test.js --timeout 60000 --grep Consensus"
   },
   "repository": {
     "type": "git",

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -112,7 +112,7 @@ export {
     VerifyingKey,
     ViewKey,
     initThreadPool,
-    setConsensusVersionTestHeights,
+    getOrInitConsensusVersionTestHeights,
     verifyFunctionExecution,
 } from "./wasm.js";
 

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -112,6 +112,7 @@ export {
     VerifyingKey,
     ViewKey,
     initThreadPool,
+    setConsensusVersionTestHeights,
     verifyFunctionExecution,
 } from "./wasm.js";
 

--- a/sdk/src/node.ts
+++ b/sdk/src/node.ts
@@ -1,13 +1,2 @@
 import "./node-polyfill.js";
-import { setConsensusVersionTestHeights } from "./browser.js";
 export * from "./browser.js";
-
-// Attempt to set the default test heights for the consensus versions from the CONSENSUS_VERSION_HEIGHTS envar when nodeJS loads its wasm module.
-function setDefaultTestHeights() {
-    const consensusVersionHeights = process.env["CONSENSUS_VERSION_HEIGHTS"];
-    if (consensusVersionHeights) {
-        setConsensusVersionTestHeights(consensusVersionHeights)
-    }
-}
-
-setDefaultTestHeights()

--- a/sdk/src/node.ts
+++ b/sdk/src/node.ts
@@ -1,2 +1,13 @@
 import "./node-polyfill.js";
+import { setConsensusVersionTestHeights } from "./browser.js";
 export * from "./browser.js";
+
+// Attempt to set the default test heights for the consensus versions from the CONSENSUS_VERSION_HEIGHTS envar when nodeJS loads its wasm module.
+function setDefaultTestHeights() {
+    const consensusVersionHeights = process.env["CONSENSUS_VERSION_HEIGHTS"];
+    if (consensusVersionHeights) {
+        setConsensusVersionTestHeights(consensusVersionHeights)
+    }
+}
+
+setDefaultTestHeights()

--- a/sdk/src/wasm.ts
+++ b/sdk/src/wasm.ts
@@ -48,6 +48,6 @@ export {
     VerifyingKey,
     ViewKey,
     initThreadPool,
-    setConsensusVersionTestHeights,
+    getOrInitConsensusVersionTestHeights,
     verifyFunctionExecution,
 } from "@provablehq/wasm/%%NETWORK%%.js";

--- a/sdk/src/wasm.ts
+++ b/sdk/src/wasm.ts
@@ -48,5 +48,6 @@ export {
     VerifyingKey,
     ViewKey,
     initThreadPool,
+    setConsensusVersionTestHeights,
     verifyFunctionExecution,
 } from "@provablehq/wasm/%%NETWORK%%.js";

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Address, AleoNetworkClient, CREDITS_PROGRAM_KEYS, Field, FunctionKeyPair, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext, EncryptionToolkit, Transition, VerifyingKey, AleoKeyProvider, setConsensusVersionTestHeights} from "../src/node.js";
+import { Address, AleoNetworkClient, CREDITS_PROGRAM_KEYS, Field, FunctionKeyPair, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext, EncryptionToolkit, Transition, VerifyingKey, AleoKeyProvider, getOrInitConsensusVersionTestHeights} from "../src/node.js";
 import {
     seed,
     message,
@@ -518,6 +518,15 @@ describe('WASM Objects', () => {
             const [transferPublicProver, transferPublicVerifier] = <FunctionKeyPair>await keyProvider.fetchCreditsKeys(CREDITS_PROGRAM_KEYS.transfer_public);
             const numConstraints = transferPublicVerifier.numConstraints();
             expect(numConstraints).to.equal(12326);
+        });
+    });
+    describe('Set development consensus version heights', () => {
+        it('Consensus version heights can be set externally', async () => {
+            if (process.env["RUN_SKIPPED"]) {
+                const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10");
+                console.log(heights);
+                expect(heights).to.deep.equal([0,1,2,3,4,5,6,7,8,9,10]);
+            }
         });
     });
 });

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Address, AleoNetworkClient, CREDITS_PROGRAM_KEYS, Field, FunctionKeyPair, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext, EncryptionToolkit, Transition, VerifyingKey, AleoKeyProvider} from "../src/node.js";
+import { Address, AleoNetworkClient, CREDITS_PROGRAM_KEYS, Field, FunctionKeyPair, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext, EncryptionToolkit, Transition, VerifyingKey, AleoKeyProvider, setConsensusVersionTestHeights} from "../src/node.js";
 import {
     seed,
     message,

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2018,9 +2018,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff92927dbd501b3975f3a35be4514f154c7bfde0db3dae2c89a4ebd0a6c2a31"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2046,9 +2045,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfedf2ae76fbb1b50228619777e403091d86afa68431977e3254047621d631eb"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2061,9 +2059,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9ada6b1454609b36c1f3b7bc267730e2f0cd0417b0757d8418202b7fa10023"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2072,9 +2069,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f7d5a0455572948306431129ac86f66e5a826c4d6483003f63c1aa06d66dcb"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2083,9 +2079,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279271263ba9c9643e791fa7b8a445761a02ac56fbb530faac6c7c350b85f10b"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2094,9 +2089,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1024c91b9bf4cb14268fafd7945b9a68e462132cd5c834bcec8e04def98cd207"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2113,15 +2107,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433b0c2fc969a514ac01f6e05756be6d928142eaae3f0ef6805aa6396159dd83"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220bee6126a7290a2697f44ba9dea9d46e586303827306637bd93a63ce505fe9"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2131,9 +2123,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf624e44496a2db2d28917acf62a3da026298909f60d051aae8ff022cb5e2f30"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2146,9 +2137,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e86fd576228776bcd748aca18926d17851120cfc8746bbf186481b9d7acdab"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2162,9 +2152,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fada6e6937fb8ae7d25ad0e84110f89492c30e079d71b25c4b952abb8ba5e0ee"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2176,9 +2165,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0dfd0497a5b5bede8cabbb79e5b95b9f2c0de6ff896e6f89295509243ef9d0"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2186,9 +2174,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9406f29259e02fc2a110022619cec95f8a7db420542c6daae6b8258ff7501205"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2197,9 +2184,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9978e0b3331faec1244931a62bae48d79b5b8d2b0d247aa8bc6f945b650d95a"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2210,9 +2196,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c68dd8c19158cf4734377ef906c3dab5c756465b05f7d5a838f4ee4adbca549"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2223,9 +2208,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbea45346dc6247f31d294c84ef4595c784d16766939dceb8ddfe3b18ea9feb9"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2235,9 +2219,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9467bba1edd47c201dfd863b8e5e67be6ea3c268bb705f084d98bbf72ff25385"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2248,9 +2231,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8819ed1e129aa99dc5636017a9397e18d356dfbd13b1141e4275816a0d817968"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2262,9 +2244,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eaeb0b8c5402d1e9ec0e22466d87e621a72b5c4d191e9e4282a2b4aec21707b"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2274,9 +2255,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09b9d82502ae99c20f335baa431977513e2676092970ff5deb9b8ef997b295"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2288,9 +2268,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e5d68b4a24c928ef579de5d46e882b0cf85d48206e29fd6f0413216204a249"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2300,9 +2279,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1220d41581ac064d916e953d78fcca4ce13c28648bef3df71eadd1359d61f594"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2321,9 +2299,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2cff4c435e430b62ee09304da850f26aa9839e5ccf0603618b62c2db745a2db"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2340,9 +2317,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86af968fb1d5777b235aca1a6819a291c2d89cdb971e939f60e0c8bebef169fb"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2361,9 +2337,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfc69ed664199bf8ec712dbba4174437f5b4e326b673c204d5070afcfd90d58"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2377,9 +2352,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3c338adfab1d4171c1333ea971cf4506165cf6cd4be5128f044cd50cb926f"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2389,18 +2363,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5306794f9ec3e380f8de5d8e3f1674182a6f758892604861b85d7292bd8496"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053872b00170acc87bbd010b6ec953e950cd80fd504aa9e789754358090bf2fc"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2409,9 +2381,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ccf05eb7691e7616fd5c8864d0be6b9c92664d9b360b14e41fe5b0c55f4c613"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2421,9 +2392,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa8e38818b6886411204f6263c081f9119f0b8173eb1d824ff1fb0446f6f60"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2433,9 +2403,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14823c16c5a3e5bf70e2346994f43386967d327835b7a622dc2ed086266e790"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2445,9 +2414,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253940e1e7754a14b2cf4e72f56db50b8c34bb28a5b896b76e35f29b250d92a"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2457,9 +2425,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f4cae48b8f560acbf178616b781877b4fe752e44ec6925f53b5d4805d1b6fe"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "rand",
  "rayon",
@@ -2472,9 +2439,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b58192c2da361f2b77b088d6da1c0e73d9f29cc6375cb3c03965a055bf0990"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2490,9 +2456,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bda7ffa0ed7626b39b11a992ccfb41a1a977737194699c2804069900f6d28c"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "anyhow",
  "rand",
@@ -2503,9 +2468,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18338abd3ea59b4447c5e02681dfe2bccc5dbd5b7f62a2be3bfd4be2c6318e18"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2524,9 +2488,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54083bd33e3e8401672cab534e484362ff54a947f234e566a64a07e13ee6f818"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2537,9 +2500,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3bef13150d91e07d57109520b27d99731520386d529500b874e7378ff727d4"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2551,9 +2513,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bd7ad7a309542acb0d640fefafb195d80b894c494a2c2c9c103017347ed87f"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2564,9 +2525,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae4b94d1c2899fac3ebc620f48c60ecd7ab9e27ced13efe1cf272cf4472a62"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2575,9 +2535,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7123458b2e723fbe1f12f04fc145d77eaebf37dac4e4aff06c45e10b27ab0928"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2591,9 +2550,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834e57f5d2f062aa27ecaca5e2a871e70014069030ec333bb263264899e8ecbd"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2601,9 +2559,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5d53b35ea5961ad0373a333a4804c0c98717b89788c0e10fb5431c4fb1b2b4"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2621,9 +2578,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c64b9c837315b38c736c4c7094e43b91f061404c526c81c7ffda7dcc5a4486"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2644,9 +2600,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8919e7e17484d214a717960036496459a3c39862cc0a3ec685b808e6f73c2ba"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2662,9 +2617,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d63c2459f69ed66343c4f8258cb997b29be201b59ae6d32d4bb8f973c9dea8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2686,9 +2640,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccae4ccd30d936f69a8470c1c06fdd53172ab25b6f0352c409205e6f0526213"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2712,9 +2665,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3f1b6a76f83dea1d10a36f51022507e38e04ea6420184522a12435e4e5bfb4"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2744,9 +2696,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202f8993b1d84e4b435e6f06655e5faf8611318b49a724db3bcc6521061b846c"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2769,9 +2720,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf311b775983ceeacd94a20e076b4cf37f2f2233177a5a332e48f8af2fdcf505"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "indexmap",
  "paste",
@@ -2788,9 +2738,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8497d8ffd96bab5dc5a4d2c1365598a7390f79ac75dd7961609e7f607b07840"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2802,9 +2751,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c752d0233bb34b61fefa01d20ed114c559950883d18a68a3023b91dced54a6"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2824,9 +2772,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2e4465f1af843b2f9e4c83c97d48c4a9c9e3522b4020e8dd9ef82d0ce5324a"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",
@@ -2835,9 +2782,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262cbd26d4065b6d88d2a6fea7d26b3f400d0b85810f8e8c9975b10086aea127"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
 dependencies = [
  "getrandom",
  "snarkvm-console",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -128,6 +128,9 @@ name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayref"
@@ -178,6 +181,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -309,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +424,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -509,10 +547,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding"
@@ -644,6 +713,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "flate2"
@@ -797,6 +876,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -828,6 +908,17 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -890,6 +981,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1247,6 +1347,18 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -1771,6 +1883,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +2024,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2064,12 @@ name = "semver"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -1993,6 +2134,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2046,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2060,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2070,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2080,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2090,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2108,12 +2259,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2124,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2138,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2153,7 +2304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2166,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2175,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2185,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2197,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2209,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2220,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2232,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2245,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2256,9 +2407,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "blake2s_simd",
+ "hex",
+ "k256",
  "smallvec",
  "snarkvm-console-types",
  "snarkvm-fields",
@@ -2269,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2280,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2300,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2318,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2326,6 +2479,7 @@ dependencies = [
  "indexmap",
  "num-derive",
  "num-traits",
+ "seq-macro",
  "serde_json",
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2338,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2353,7 +2507,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2364,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2372,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2382,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2393,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2404,7 +2558,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2415,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2426,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "rand",
  "rayon",
@@ -2440,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2457,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "anyhow",
  "rand",
@@ -2469,8 +2623,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
+ "anyhow",
  "indexmap",
  "rayon",
  "serde_json",
@@ -2484,12 +2639,13 @@ dependencies = [
  "snarkvm-ledger-puzzle",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2501,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2514,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2526,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2536,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2551,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2560,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2579,7 +2735,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2601,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2618,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2636,12 +2792,13 @@ dependencies = [
  "snarkvm-ledger-puzzle",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-parameters"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2666,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2697,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2721,8 +2878,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
+ "enum-iterator",
  "indexmap",
  "paste",
  "rand",
@@ -2739,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2752,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2767,13 +2925,14 @@ dependencies = [
  "smol_str",
  "snarkvm-utilities-derives",
  "thiserror 2.0.12",
+ "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",
@@ -2783,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-wasm"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=df90b14#df90b1439d1ad56b572c86d81b47768c34f77c18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
 dependencies = [
  "getrandom",
  "snarkvm-console",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -22,14 +22,17 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 
 [dependencies.snarkvm-circuit-network]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 default-features = false
 features = [
     "account",
@@ -42,31 +45,38 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 
 [dependencies.snarkvm-parameters]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-version = "4.2.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "df90b14"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -23,16 +23,16 @@ doctest = false
 
 [dependencies.snarkvm-algorithms]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 
 [dependencies.snarkvm-circuit-network]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 default-features = false
 features = [
     "account",
@@ -46,37 +46,37 @@ features = [
 
 [dependencies.snarkvm-ledger-block]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 
 [dependencies.snarkvm-parameters]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "df90b14"
+rev = "78a69b7"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/src/programs/snapshot_query.rs
+++ b/wasm/src/programs/snapshot_query.rs
@@ -271,7 +271,7 @@ mod tests {
             let commitments =
                 vec![FieldNative::from_str(commitment_0).unwrap(), FieldNative::from_str(commitment_1).unwrap()];
             let (height, state_paths) =
-                SnapshotQuery::snapshot_statepaths("http://34.169.215.4:3030", &commitments).await.unwrap();
+                SnapshotQuery::snapshot_statepaths("https://api.explorer.provable.com/v1", &commitments).await.unwrap();
             assert_eq!(state_paths.len(), 2);
             let (commitment_0_field, state_path_0) = &state_paths[0];
             let (commitment_1_field, state_path_1) = &state_paths[1];

--- a/wasm/src/utilities/mod.rs
+++ b/wasm/src/utilities/mod.rs
@@ -31,14 +31,14 @@ pub mod test;
 /// @params {string | undefined} heights The block heights at which each consensus version applies. This input should be a simple csv list of block heights and there should be one number for each consensus version. If left undefined, the default test heights will be applied.
 ///
 /// @example
-/// import { setConsensusVersionHeights } from @provablehq/sdk;
+/// import { getOrInitConsensusVersionHeights } from @provablehq/sdk;
 ///
 /// Set the consensus version heights.
-/// setConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9");
-#[wasm_bindgen::prelude::wasm_bindgen(js_name = setConsensusVersionTestHeights)]
-pub fn set_consensus_version_test_heights_js(heights: Option<String>) -> js_sys::Array {
+/// getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9");
+#[wasm_bindgen::prelude::wasm_bindgen(js_name = getOrInitConsensusVersionTestHeights)]
+pub fn get_or_init_consensus_version_heights(heights: Option<String>) -> js_sys::Array {
     // Call the underlying Rust function that returns [(ConsensusVersion, u32); N]
-    let pairs = snarkvm_console::network::set_consensus_version_test_heights(heights);
+    let pairs = snarkvm_console::network::get_or_init_consensus_version_heights(heights);
 
     // Map to just the heights (u32) and convert to JS array
     pairs.iter().map(|(_, height)| wasm_bindgen::JsValue::from_f64(*height as f64)).collect::<js_sys::Array>()
@@ -52,6 +52,6 @@ mod tests {
     #[wasm_bindgen_test]
     #[should_panic]
     fn test_set_genesis_block_non_zero_fails() {
-        set_consensus_version_test_heights_js(Some("9,8,7,6,5,4,3,2,1,0".to_string()));
+        get_or_init_consensus_version_heights(Some("9,8,7,6,5,4,3,2,1,0".to_string()));
     }
 }

--- a/wasm/src/utilities/mod.rs
+++ b/wasm/src/utilities/mod.rs
@@ -52,6 +52,6 @@ mod tests {
     #[wasm_bindgen_test]
     #[should_panic]
     fn test_set_genesis_block_non_zero_fails() {
-        set_consensus_version_test_heights(Some("9,8,7,6,5,4,3,2,1,0".to_string()));
+        set_consensus_version_test_heights_js(Some("9,8,7,6,5,4,3,2,1,0".to_string()));
     }
 }

--- a/wasm/src/utilities/mod.rs
+++ b/wasm/src/utilities/mod.rs
@@ -16,11 +16,42 @@
 
 mod array;
 mod bits;
-#[cfg(test)]
-pub mod test;
 
 pub mod encrypt;
 pub use encrypt::EncryptionToolkit;
 
 pub mod rest;
 pub use rest::{get, get_network, get_statepaths_for_commitments, latest_block_height, latest_stateroot};
+
+#[cfg(test)]
+pub mod test;
+
+/// Set test consensus version heights for testing.
+///
+/// @params {string | undefined} heights The block heights at which each consensus version applies. This input should be a simple csv list of block heights and there should be one number for each consensus version. If left undefined, the default test heights will be applied.
+///
+/// @example
+/// import { setConsensusVersionHeights } from @provablehq/sdk;
+///
+/// Set the consensus version heights.
+/// setConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9");
+#[wasm_bindgen::prelude::wasm_bindgen(js_name = setConsensusVersionTestHeights)]
+pub fn set_consensus_version_test_heights_js(heights: Option<String>) -> js_sys::Array {
+    // Call the underlying Rust function that returns [(ConsensusVersion, u32); N]
+    let pairs = snarkvm_console::network::set_consensus_version_test_heights(heights);
+
+    // Map to just the heights (u32) and convert to JS array
+    pairs.iter().map(|(_, height)| wasm_bindgen::JsValue::from_f64(*height as f64)).collect::<js_sys::Array>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    #[should_panic]
+    fn test_set_genesis_block_non_zero_fails() {
+        set_consensus_version_test_heights(Some("9,8,7,6,5,4,3,2,1,0".to_string()));
+    }
+}

--- a/wasm/src/utilities/rest.rs
+++ b/wasm/src/utilities/rest.rs
@@ -96,7 +96,8 @@ mod tests {
                 )
                 .unwrap(),
             ];
-            let state_paths = get_statepaths_for_commitments("http://34.169.215.4:3030", &commitments).await.unwrap();
+            let state_paths =
+                get_statepaths_for_commitments("https://api.explorer.provable.com/v1", &commitments).await.unwrap();
             assert_eq!(state_paths.len(), 2);
             assert_eq!(state_paths[0].global_state_root(), state_paths[1].global_state_root());
         }


### PR DESCRIPTION
## Motivation

Currently when the SDK is built, it defaults to the heights within the `mainnet`/`testnet`/`canary` Network trait impls and there is no way to set the consensus heights during testing. This PR adds functionality for ensuring test heights can be set.

