### PR TITLE
Introduce github action to run CI on new snarkVM revs

### DIFF
--- a/.github/workflows/update-snarkvm.yml
+++ b/.github/workflows/update-snarkvm.yml
@@ -40,30 +40,7 @@ jobs:
             const latestCommit = branch.commit.sha;
             console.log('Latest snarkVM staging commit:', latestCommit);
             core.setOutput('latest_commit', latestCommit);
-            
-            // Get current commit from Cargo.toml snarkvm dependency section
-            const fs = require('fs');
-            const cargoToml = fs.readFileSync('wasm/Cargo.toml', 'utf8');
-            
-            // Find the snarkvm workspace dependency section and extract the rev
-            const snarkVmSection = cargoToml.match(/\[workspace\.dependencies\.snarkvm\]([\s\S]*?)(?=\n\[|$)/);
-            if (!snarkVmSection) {
-              throw new Error('Could not find snarkvm dependency section in Cargo.toml');
-            }
-            
-            const revMatch = snarkVmSection[1].match(/rev = "([^"]+)"/);
-            const currentCommit = revMatch ? revMatch[1] : '';
-            console.log('Current snarkVM commit:', currentCommit);
-            core.setOutput('current_commit', currentCommit);
-            
-            // Check if update is needed
-            if (latestCommit !== currentCommit) {
-              console.log('Update needed');
-              core.setOutput('update_needed', 'true');
-            } else {
-              console.log('No update needed');
-              core.setOutput('update_needed', 'false');
-            }
+            core.setOutput('update_needed', 'true');
 
       - name: Setup Git
         if: steps.snarkvm-commit.outputs.update_needed == 'true'

--- a/.github/workflows/update-snarkvm.yml
+++ b/.github/workflows/update-snarkvm.yml
@@ -1,0 +1,159 @@
+name: Update snarkVM dependency
+
+on:
+  schedule:
+    # Run every hour to check for new commits in snarkVM staging
+    - cron: '0 * * * *'
+  push:
+    branches:
+      - 'ci/snarkvm-update'
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  update-snarkvm-staging:
+    name: Update snarkVM to latest staging
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout SDK
+        uses: actions/checkout@v5
+        with:
+          ref: staging
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest snarkVM staging commit
+        id: snarkvm-commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Get the latest commit hash from snarkVM staging branch
+            const { data: branch } = await github.rest.repos.getBranch({
+              owner: 'ProvableHQ',
+              repo: 'snarkVM',
+              branch: 'staging'
+            });
+            
+            const latestCommit = branch.commit.sha;
+            console.log('Latest snarkVM staging commit:', latestCommit);
+            core.setOutput('latest_commit', latestCommit);
+            
+            // Get current commit from Cargo.toml snarkvm dependency section
+            const fs = require('fs');
+            const cargoToml = fs.readFileSync('wasm/Cargo.toml', 'utf8');
+            
+            // Find the snarkvm workspace dependency section and extract the rev
+            const snarkVmSection = cargoToml.match(/\[workspace\.dependencies\.snarkvm\]([\s\S]*?)(?=\n\[|$)/);
+            if (!snarkVmSection) {
+              throw new Error('Could not find snarkvm dependency section in Cargo.toml');
+            }
+            
+            const revMatch = snarkVmSection[1].match(/rev = "([^"]+)"/);
+            const currentCommit = revMatch ? revMatch[1] : '';
+            console.log('Current snarkVM commit:', currentCommit);
+            core.setOutput('current_commit', currentCommit);
+            
+            // Check if update is needed
+            if (latestCommit !== currentCommit) {
+              console.log('Update needed');
+              core.setOutput('update_needed', 'true');
+            } else {
+              console.log('No update needed');
+              core.setOutput('update_needed', 'false');
+            }
+
+      - name: Setup Git
+        if: steps.snarkvm-commit.outputs.update_needed == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create new update-snarkvm-staging branch from staging
+        if: steps.snarkvm-commit.outputs.update_needed == 'true'
+        run: |
+          # Always create a fresh branch from staging
+          echo "Creating new update-snarkvm-staging branch from staging"
+          git checkout -B update-snarkvm-staging staging
+          echo "Created fresh update-snarkvm-staging branch from staging"
+
+      - name: Update snarkVM dependency
+        if: steps.snarkvm-commit.outputs.update_needed == 'true'
+        run: |
+          # Validate the commit hash format (should be 40 chars hex or 7+ chars)
+          LATEST_COMMIT="${{ steps.snarkvm-commit.outputs.latest_commit }}"
+          if [[ ! "$LATEST_COMMIT" =~ ^[a-f0-9]{7,40}$ ]]; then
+            echo "Error: Invalid commit hash format: $LATEST_COMMIT"
+            exit 1
+          fi
+          
+          # First, update the rev in Cargo.toml to point to the new commit
+          cd wasm
+          cargo add snarkvm-algorithms --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+          cargo add snarkvm-circuit-network --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+          cargo add snarkvm-console --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+          cargo add snarkvm-ledger-block --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+          cargo add snarkvm-ledger-query --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+          cargo add snarkvm-ledger-store --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+          cargo add snarkvm-parameters --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+          cargo add snarkvm-synthesizer-program --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+          cargo add snarkvm-synthesizer --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+          cargo add snarkvm-wasm --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
+
+          echo "✅ Successfully updated snarkVM dependency to $LATEST_COMMIT"
+
+      - name: Commit and push changes
+        if: steps.snarkvm-commit.outputs.update_needed == 'true'
+        run: |
+          git add wasm/Cargo.toml wasm/Cargo.lock
+          git commit --no-verify -m "Update snarkVM to latest staging commit ${{ steps.snarkvm-commit.outputs.latest_commit }}
+
+          Previous commit: ${{ steps.snarkvm-commit.outputs.current_commit }}
+          Latest commit: ${{ steps.snarkvm-commit.outputs.latest_commit }}
+          
+          This update was performed automatically by the snarkVM update workflow."
+          git push --force-with-lease origin update-snarkvm-staging
+
+      - name: Create or update PR
+        if: steps.snarkvm-commit.outputs.update_needed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Check if a PR already exists from update-snarkvm-staging to staging
+            const { data: prs } = await github.rest.pulls.list({
+              owner: 'ProvableHQ',
+              repo: 'sdk',
+              head: 'ProvableHQ:update-snarkvm-staging',
+              base: 'staging',
+              state: 'open'
+            });
+            
+            if (prs.length === 0) {
+              // No PR exists, create one
+              const { data: pr } = await github.rest.pulls.create({
+                owner: 'ProvableHQ',
+                repo: 'sdk',
+                title: 'Update snarkVM to latest staging commit',
+                head: 'update-snarkvm-staging',
+                base: 'staging',
+                body: 'This PR updates the snarkVM dependency to track the latest staging commit.\n\nLatest commit: ${{ steps.snarkvm-commit.outputs.latest_commit }}\nPrevious commit: ${{ steps.snarkvm-commit.outputs.current_commit }}\n\nThis PR was created automatically by the snarkVM update workflow.'
+              });
+              console.log(`Created PR #${pr.number}: ${pr.html_url}`);
+            } else {
+              console.log(`PR already exists: ${prs[0].html_url}`);
+            }
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Workflow Summary (staging)" >> $GITHUB_STEP_SUMMARY
+          echo "- Current snarkVM commit: ${{ steps.snarkvm-commit.outputs.current_commit }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Latest snarkVM commit: ${{ steps.snarkvm-commit.outputs.latest_commit }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Update needed: ${{ steps.snarkvm-commit.outputs.update_needed }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.snarkvm-commit.outputs.update_needed }}" = "true" ]; then
+            echo "- ✅ snarkVM dependency updated successfully" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ℹ️ No update required" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Motivation

Similar to: https://github.com/ProvableHQ/snarkOS/pull/3814

Introduces a github action to allow automated testing on snarkVM updates:
- Pushes to a `update-snarkvm-staging` branch if a new snarkVM `staging` branch rev was found
- Opens a PR if it wasn't opened yet

## Test Plan

You can try it out by pushing this as a branch to `ProvableHQ/SDK:ci/snarkvm-update`

I don't have write permissions to the SDK repo so I can't push there or add reviewers, so doing a manual tag: @iamalwaysuncomfortable 
