### PR TITLE
[Fix] Account for external records when computing commitments in SnapshotQuery

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "hex",
  "indexmap",
  "js-sys",
+ "log",
  "rand",
  "rayon",
  "reqwest 0.11.27",

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provablehq/wasm",
   "version": "0.9.8",
-  "type": "module",
+  "type":"module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [
     "The Provable Team"

--- a/wasm/src/programs/snapshot_query.rs
+++ b/wasm/src/programs/snapshot_query.rs
@@ -113,7 +113,7 @@ impl SnapshotQuery {
             .enumerate()
             .filter_map(|(index, js_value)| {
                 if let Some(s) = js_value.as_string() {
-                    // Detect if the string contains a nonce to indicate it's a plaintext record.
+                    // Detect if the string contains a nonce to indicate the input is a plaintext record.
                     if !s.contains("_nonce") {
                         return None;
                     };
@@ -125,13 +125,15 @@ impl SnapshotQuery {
                         let program_id = program.id();
                         let function = program.get_function(function_id).ok()?;
                         let input = function.inputs().get_index(index)?;
-                        let record_name = match input.value_type() {
-                            &ValueTypeNative::Record(record_name) => record_name,
-                            _ => return None,
-                        };
-
-                        // Compute the commitment.
-                        record.to_commitment(program_id, &record_name, &record_view_key).ok()
+                        match input.value_type() {
+                            &ValueTypeNative::Record(record_name) => {
+                                record.to_commitment(program_id, &record_name, &record_view_key).ok()
+                            }
+                            &ValueTypeNative::ExternalRecord(locator) => {
+                                record.to_commitment(locator.program_id(), locator.resource(), &record_view_key).ok()
+                            }
+                            _ => None,
+                        }
                     } else {
                         None
                     }
@@ -246,7 +248,12 @@ impl QueryTrait<CurrentNetwork> for SnapshotQuery {
 
 mod tests {
     use super::*;
-    use crate::{test::PROVABLE_API, utilities::rest::get_network};
+    use crate::{
+        test::{PROVABLE_API, TOKEN_REGISTRY_RECORD_OWNER_VIEW_KEY, TOKEN_REGISTRY_RECORD_V1},
+        types::native::ProgramIDNative,
+        utilities::{rest::get_network, test::programs::EXTERNAL_RECORDS_DEMO},
+    };
+    use snarkvm_synthesizer_program::Program;
     use wasm_bindgen_test::*;
 
     #[wasm_bindgen_test]
@@ -273,5 +280,26 @@ mod tests {
             assert_eq!(state_path_0.global_state_root(), state_path_1.global_state_root());
             assert!(height > 10_000_000);
         }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_correct_commitment_computation() {
+        let record = RecordPlaintextNative::from_str(TOKEN_REGISTRY_RECORD_V1).unwrap();
+        let view_key = ViewKeyNative::from_str(TOKEN_REGISTRY_RECORD_OWNER_VIEW_KEY).unwrap();
+        let program_id = ProgramIDNative::from_str("token_registry.aleo").unwrap();
+        let record_name = IdentifierNative::from_str("Token").unwrap();
+        let rvk = (*record.nonce() * *view_key).to_x_coordinate();
+        let commitment = record.to_commitment(&program_id, &record_name, &rvk).unwrap();
+        let program = Program::from_str(EXTERNAL_RECORDS_DEMO).unwrap();
+        let function_id = IdentifierNative::from_str("deposit_private_token").unwrap();
+
+        let input_1 = JsValue::from_str("aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4t");
+        let input_2 = JsValue::from_str("5u128");
+        let input_3 = JsValue::from_str(TOKEN_REGISTRY_RECORD_V1);
+        let inputs = vec![input_1, input_2, input_3];
+
+        let commitments =
+            SnapshotQuery::collect_commitments_from_inputs(&program, &function_id, &view_key, &inputs).unwrap();
+        assert_eq!(commitments[0], commitment);
     }
 }

--- a/wasm/src/record/record_plaintext.rs
+++ b/wasm/src/record/record_plaintext.rs
@@ -334,9 +334,10 @@ mod tests {
 
     use crate::{
         types::native::{PrivateKeyNative, ViewKeyNative},
-        utilities::test::{CREDITS_RECORD_V1, CREDITS_SENDER_CIPHERTEXT, CREDITS_SENDER_PLAINTEXT, get_env},
+        utilities::test::get_env,
     };
 
+    use crate::utilities::test::record::{CREDITS_RECORD_V1, CREDITS_SENDER_CIPHERTEXT, CREDITS_SENDER_PLAINTEXT};
     use wasm_bindgen_test::*;
 
     const CREDITS_RECORD: &str = r"{

--- a/wasm/src/utilities/encrypt.rs
+++ b/wasm/src/utilities/encrypt.rs
@@ -298,16 +298,15 @@ impl EncryptionToolkit {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::{
-        test::{
+        test::get_env,
+        types::native::{PrivateKeyNative, ViewKeyNative},
+        utilities::test::record::{
             CREDITS_RECORD_V1,
             CREDITS_RECORD_VIEW_KEY,
             CREDITS_SENDER_CIPHERTEXT,
             CREDITS_SENDER_PLAINTEXT,
-            get_env,
         },
-        types::native::{PrivateKeyNative, ViewKeyNative},
     };
     use std::str::FromStr;
     use wasm_bindgen_test::wasm_bindgen_test;

--- a/wasm/src/utilities/test/mod.rs
+++ b/wasm/src/utilities/test/mod.rs
@@ -23,5 +23,8 @@ pub use plaintext::*;
 pub mod programs;
 pub use programs::*;
 
+pub mod record;
+pub use record::*;
+
 pub mod uri;
 pub use uri::*;

--- a/wasm/src/utilities/test/programs.rs
+++ b/wasm/src/utilities/test/programs.rs
@@ -18,19 +18,19 @@ use crate::{array, object};
 
 use js_sys::{Array, Object};
 
-/// V1 credits.aleo record.
-pub const CREDITS_RECORD_V1: &str = "{ owner: aleo12a4wll9ax6w5355jph0dr5wt2vla5sss2t4cnch0tc3vzh643v8qcfvc7a.private, microcredits: 1000000u64.private, _nonce: 3634848344765318974603121890869676775499130077229666060613233255327643175219group.public, _version: 1u8.public }";
+pub const EXTERNAL_RECORDS_DEMO: &str = r#"
+import token_registry.aleo;
+program external_record_test.aleo;
 
-/// Record view key for the V1 credits.aleo record.
-pub const CREDITS_RECORD_VIEW_KEY: &str =
-    "5237002936265850807349726649400053591020997883662246784632368923777787639801field";
+function deposit_private_token:
+    input r0 as address.private;
+    input r1 as u128.private;
+    input r2 as token_registry.aleo/Token.record;
+    output r2 as token_registry.aleo/Token.record;
 
-/// Sender ciphertext of the credits.aleo record.
-pub const CREDITS_SENDER_CIPHERTEXT: &str =
-    "1182590395568997043375432557467567048762179115999922880321493200728848194550field";
-
-/// Sender plaintext of the credits.aleo record.
-pub const CREDITS_SENDER_PLAINTEXT: &str = "aleo1j92w9mhqznj2hvufad796y8suykjppk7f6n6xmncmktfm95vggzqx4sjlh";
+constructor:
+    assert.eq program_owner aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+"#;
 
 pub const HELLO_PROGRAM: &str = r#"program hello.aleo;
 function main:

--- a/wasm/src/utilities/test/record.rs
+++ b/wasm/src/utilities/test/record.rs
@@ -1,0 +1,40 @@
+// Copyright (C) 2019-2025 Provable Inc.
+// This file is part of the Provable SDK library.
+
+// The Provable SDK library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Provable SDK library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
+
+/// V1 credits.aleo record.
+pub const CREDITS_RECORD_V1: &str = "{ owner: aleo12a4wll9ax6w5355jph0dr5wt2vla5sss2t4cnch0tc3vzh643v8qcfvc7a.private, microcredits: 1000000u64.private, _nonce: 3634848344765318974603121890869676775499130077229666060613233255327643175219group.public, _version: 1u8.public }";
+/// Record view key for the V1 credits.aleo record.
+pub const CREDITS_RECORD_VIEW_KEY: &str =
+    "5237002936265850807349726649400053591020997883662246784632368923777787639801field";
+/// Sender ciphertext of the credits.aleo record.
+pub const CREDITS_SENDER_CIPHERTEXT: &str =
+    "1182590395568997043375432557467567048762179115999922880321493200728848194550field";
+/// Sender plaintext of the credits.aleo record.
+pub const CREDITS_SENDER_PLAINTEXT: &str = "aleo1j92w9mhqznj2hvufad796y8suykjppk7f6n6xmncmktfm95vggzqx4sjlh";
+
+/// Token registry record view_key.
+pub const TOKEN_REGISTRY_RECORD_OWNER_VIEW_KEY: &str = "AViewKey1pTzjTxeAYuDpACpz2k72xQoVXvfY4bJHrjeAQp6Ywe5g";
+
+/// Token registry test vector.
+pub const TOKEN_REGISTRY_RECORD_V1: &str = r#"{
+      owner: aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4t.private,
+      amount: 1000u128.private,
+      token_id: 1751493913335802797273486270793650302076377624243810059080883537084141842600field.private,
+      external_authorization_required: false.private,
+      authorized_until: 0u32.private,
+      _nonce: 353510505137682717871934563523691055502582931368477380633253282125012046603group.public,
+      _version: 1u8.public
+    }"#;


### PR DESCRIPTION
## Motivation

The SnapshotQuery didn't originally account for the case of `ExternalRecords` in function inputs. This PR modifies the SnapshotQuery to make use of external records.

## Test Plan

This PR adds tests to ensure external record inputs are accounted for in the commitment computations.