### PR TITLE
[Feature] Add toBytesRaw, toBitsRaw, and toFieldsRaw to the Plaintext object

### DIFF
--- a/create-leo-app/package.json
+++ b/create-leo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-leo-app",
-  "version": "0.9.9",
+  "version": "0.9.10-testnet-rc",
   "type": "module",
   "license": "GPL-3.0",
   "collaborators": [

--- a/create-leo-app/template-extension/package.json
+++ b/create-leo-app/template-extension/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf static/js && rollup --config"
   },
   "devDependencies": {
-    "@provablehq/sdk": "^0.9.9",
+    "@provablehq/sdk": "^0.9.10-testnet-rc",
     "@web/rollup-plugin-import-meta-assets": "^2.2.1",
     "rimraf": "^6.0.1",
     "rollup": "^4.32.0"

--- a/create-leo-app/template-nextjs-ts/package.json
+++ b/create-leo-app/template-nextjs-ts/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.9",
+    "@provablehq/sdk": "^0.9.10-testnet-rc",
     "next": "15.4.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/create-leo-app/template-node-ts/package.json
+++ b/create-leo-app/template-node-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.9"
+    "@provablehq/sdk": "^0.9.10-testnet-rc"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-node/package.json
+++ b/create-leo-app/template-node/package.json
@@ -7,6 +7,6 @@
     "dev": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.9"
+    "@provablehq/sdk": "^0.9.10-testnet-rc"
   }
 }

--- a/create-leo-app/template-offline-public-transaction-ts/package.json
+++ b/create-leo-app/template-offline-public-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.9"
+    "@provablehq/sdk": "^0.9.10-testnet-rc"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-react-leo/package.json
+++ b/create-leo-app/template-react-leo/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.9",
+    "@provablehq/sdk": "^0.9.10-testnet-rc",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-managed-worker/package.json
+++ b/create-leo-app/template-react-managed-worker/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.9",
+    "@provablehq/sdk": "^0.9.10-testnet-rc",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/create-leo-app/template-react-ts/package.json
+++ b/create-leo-app/template-react-ts/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.9",
+    "@provablehq/sdk": "^0.9.10-testnet-rc",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-vanilla/package.json
+++ b/create-leo-app/template-vanilla/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@provablehq/sdk": "^0.9.9",
+        "@provablehq/sdk": "^0.9.10-testnet-rc",
         "tslib": "^2.8.1",
         "vite": "^6.3.6"
     }

--- a/e2e/mainnet/package.json
+++ b/e2e/mainnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.9"
+    "@provablehq/sdk": "^0.9.10-testnet-rc"
   }
 }

--- a/e2e/nodenext/package.json
+++ b/e2e/nodenext/package.json
@@ -2,7 +2,7 @@
     "name": "nodenext",
     "type": "module",
     "dependencies": {
-        "@provablehq/sdk": "^0.9.9",
+        "@provablehq/sdk": "^0.9.10-testnet-rc",
         "typescript": "^5.7.3"
     },
     "scripts": {

--- a/e2e/testnet/package.json
+++ b/e2e/testnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.9"
+    "@provablehq/sdk": "^0.9.10-testnet-rc"
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/sdk",
-  "version": "0.9.9",
+  "version": "0.9.10-testnet-rc",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Provable Team"
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/ProvableHQ/sdk#readme",
   "dependencies": {
-    "@provablehq/wasm": "^0.9.9",
+    "@provablehq/wasm": "^0.9.10-testnet-rc",
     "comlink": "^4.4.2",
     "core-js": "^3.40.0",
     "mime": "^4.0.6",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "14edf4007a98323f763701688bcbe3bc6ecf33e20c3a81b3eb8d6661ff01b217"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.9.9"
+version = "0.9.10-testnet-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2211,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2221,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2259,12 +2259,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2289,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2304,7 +2304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2317,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2326,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2336,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2360,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2383,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2396,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2422,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2433,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2453,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2507,7 +2507,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2518,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2558,7 +2558,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2569,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "rand",
  "rayon",
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "anyhow",
  "rand",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2657,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2682,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2707,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2735,7 +2735,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2798,7 +2798,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2854,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-wasm"
 version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=78a69b7#78a69b70387d917ed1c16a09741a5b6d16862f17"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
 dependencies = [
  "getrandom",
  "snarkvm-console",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-wasm"
-version = "0.9.9"
+version = "0.9.10-testnet-rc"
 authors = [ "The Provable Team" ]
 description = "WebAssembly based toolkit for developing zero-knowledge applications with Aleo"
 homepage = "https://provable.com"
@@ -23,16 +23,16 @@ doctest = false
 
 [dependencies.snarkvm-algorithms]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 
 [dependencies.snarkvm-circuit-network]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 default-features = false
 features = [
     "account",
@@ -46,37 +46,37 @@ features = [
 
 [dependencies.snarkvm-ledger-block]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 
 [dependencies.snarkvm-parameters]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "78a69b7"
+rev = "eb44d39"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/wasm",
-  "version": "0.9.9",
+  "version": "0.9.10-testnet-rc",
   "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [

--- a/wasm/src/account/signature.rs
+++ b/wasm/src/account/signature.rs
@@ -17,7 +17,6 @@
 use crate::{
     Address,
     Field,
-    Group,
     Plaintext,
     PrivateKey,
     Scalar,
@@ -218,9 +217,12 @@ impl FromStr for Signature {
 mod tests {
     use super::*;
 
-    use crate::utilities::test::{
-        plaintext::{INVALID_NESTED_STRUCT, NESTED_STRUCT},
-        records::{INVALID_CREDITS_RECORD, VALID_CREDITS_RECORD},
+    use crate::{
+        Group,
+        utilities::test::{
+            plaintext::{INVALID_NESTED_STRUCT, NESTED_STRUCT},
+            records::{INVALID_CREDITS_RECORD, VALID_CREDITS_RECORD},
+        },
     };
     use rand::{Rng, SeedableRng, rngs::StdRng};
     use wasm_bindgen_test::*;

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -22,12 +22,12 @@ use crate::{
     from_js_typed_array,
     from_wasm_object_array,
     js_array_from_fields,
-    native::{FieldNative, LiteralNative},
+    native::{FieldNative, LiteralNative, U8Native},
     plaintext_to_js_value,
     to_bits_array_le,
     types::native::{IdentifierNative, PlaintextNative},
 };
-use snarkvm_console::prelude::{FromBits, FromBytes, FromFields, ToBits, ToBytes, ToFields};
+use snarkvm_console::prelude::{FromBits, FromBytes, FromFields, ToBits, ToBitsRaw, ToBytes, ToFields, ToFieldsRaw};
 
 use js_sys::{Array, Uint8Array};
 use std::{ops::Deref, str::FromStr, sync::OnceLock};
@@ -105,7 +105,7 @@ impl Plaintext {
 
     /// Get a plaintext object from a series of bytes.
     ///
-    /// @param {Uint8Array} bytes A left endian byte array representing the plaintext.
+    /// @param {Uint8Array} bytes A little endian byte array representing the plaintext.
     ///
     /// @returns {Plaintext} The plaintext object.
     #[wasm_bindgen(js_name = "fromBytesLe")]
@@ -115,18 +115,55 @@ impl Plaintext {
         Ok(Self(native))
     }
 
-    /// Get the left endian byte array representation of the plaintext.
+    /// Get the little endian byte array representation of the plaintext.
     ///
-    /// @returns {Uint8Array} The left endian byte array representation of the plaintext.
+    /// @returns {Uint8Array} The little endian byte array representation of the plaintext.
     #[wasm_bindgen(js_name = "toBytesLe")]
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
         let rust_bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
         Ok(Uint8Array::from(rust_bytes.as_slice()))
     }
 
+    /// Get the raw little endian byte array representation of the plaintext.
+    ///
+    /// @returns {Uint8Array} The raw little endian byte array representation of the plaintext.
+    #[wasm_bindgen(js_name = "toBytesRawLe")]
+    pub fn to_bytes_raw_le(&self) -> Result<Uint8Array, String> {
+        let bits_le = self.0.to_bits_raw_le();
+        // Pack the little endian bits into u8 elements and transform them into bytes.
+        let rust_bytes = bits_le
+            .chunks(8)
+            .map(|chunk| U8Native::from_bits_le(chunk).map_err(|e| e.to_string()))
+            .collect::<Result<Vec<U8Native>, String>>()?
+            .into_iter()
+            .map(|u8| u8.to_bytes_le().unwrap())
+            .flatten()
+            .collect::<Vec<u8>>();
+        Ok(Uint8Array::from(rust_bytes.as_slice()))
+    }
+
+    /// Get the raw big endian byte array representation of the plaintext.
+    ///
+    /// @returns {Uint8Array} The raw big endian byte array representation of the plaintext.
+    #[wasm_bindgen(js_name = "toBytesRawBe")]
+    pub fn to_bytes_raw_be(&self) -> Result<Uint8Array, String> {
+        let bits_be = self.0.to_bits_raw_be();
+        // Pack the big endian bits into u8 elements and transform them into bytes.
+        let mut rust_bytes = bits_be
+            .chunks(8)
+            .map(|chunk| U8Native::from_bits_be(chunk).map_err(|e| e.to_string()))
+            .collect::<Result<Vec<U8Native>, String>>()?
+            .into_iter()
+            .map(|u8| u8.to_bytes_le().unwrap())
+            .flatten()
+            .collect::<Vec<u8>>();
+        rust_bytes.reverse();
+        Ok(Uint8Array::from(rust_bytes.as_slice()))
+    }
+
     /// Get a plaintext object from a series of bits represented as a boolean array.
     ///
-    /// @param {Array} bits A left endian boolean array representing the bits plaintext.
+    /// @param {Array} bits A little endian boolean array representing the bits plaintext.
     ///
     /// @returns {Plaintext} The plaintext object.
     #[wasm_bindgen(js_name = "fromBitsLe")]
@@ -136,12 +173,28 @@ impl Plaintext {
         Ok(Self(native))
     }
 
-    /// Get the left endian boolean array representation of the bits of the plaintext.
+    /// Get the little endian boolean array representation of the bits of the plaintext.
     ///
-    /// @returns {Array} The left endian boolean array representation of the bits of the plaintext.
+    /// @returns {Array} The little endian boolean array representation of the bits of the plaintext.
     #[wasm_bindgen(js_name = "toBitsLe")]
     pub fn to_bits_le(&self) -> Array {
         to_bits_array_le!(self)
+    }
+
+    /// Get the raw little endian boolean array representation of the bits of the plaintext.
+    ///
+    /// @returns {Array} The raw little endian boolean array representation of the bits of the plaintext.
+    #[wasm_bindgen(js_name = "toBitsRawLe")]
+    pub fn to_bits_raw_le(&self) -> Array {
+        self.0.to_bits_raw_le().iter().map(|x| wasm_bindgen::JsValue::from_bool(*x)).collect::<js_sys::Array>()
+    }
+
+    /// Get the raw big endian boolean array representation of the bits of the plaintext.
+    ///
+    /// @returns {Array} The raw big endian boolean array representation of the bits of the plaintext.
+    #[wasm_bindgen(js_name = "toBitsRawBe")]
+    pub fn to_bits_raw_be(&self) -> Array {
+        self.0.to_bits_raw_be().iter().map(|x| wasm_bindgen::JsValue::from_bool(*x)).collect::<js_sys::Array>()
     }
 
     /// Get a plaintext object from an array of fields.
@@ -164,6 +217,16 @@ impl Plaintext {
         let native = self.0.clone();
         let native_fields = native.to_fields().map_err(|e| e.to_string())?;
         Ok(js_array_from_fields!(&native_fields))
+    }
+
+    /// Get the raw field array representation of the plaintext.
+    ///
+    /// @returns {Array} The raw field array representation of the plaintext.
+    #[wasm_bindgen(js_name = "toFieldsRaw")]
+    pub fn to_fields_raw(&self) -> Result<Array, String> {
+        let native = self.0.clone();
+        let native_fields_raw = native.to_fields_raw().map_err(|e| e.to_string())?;
+        Ok(js_array_from_fields!(&native_fields_raw))
     }
 
     /// Returns the string representation of the plaintext.

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
         "@codemirror/language": "^6.10.8",
         "@codemirror/legacy-modes": "^6.4.2",
         "@codemirror/stream-parser": "^0.19.9",
-        "@provablehq/sdk": "^0.9.9",
+        "@provablehq/sdk": "^0.9.10-testnet-rc",
         "@uiw/codemirror-theme-noctis-lilac": "^4.23.7",
         "@uiw/codemirror-theme-okaidia": "^4.23.7",
         "@uiw/react-codemirror": "^4.23.7",


### PR DESCRIPTION
## Motivation

Plaintext objects were recently given `toBitsRaw` and `toFieldsRaw` methods within SnarkVM, this PR adds this functionality to the corresponding Plaintext object in the SDK.