### PR TITLE
[Feature] Authorization based execution fee estimation

### DIFF
--- a/docs/api_reference/sdk-src_function-key-provider.md
+++ b/docs/api_reference/sdk-src_function-key-provider.md
@@ -201,6 +201,30 @@ const [transferPublicProvingKey, transferPublicVerifyingKey] = await keyProvider
 
 ---
 
+### `transferPublicKeys() ► Promise.<FunctionKeyPair>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the proving and verifying keys for the transfer_public function.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<FunctionKeyPair>` | *Proving and verifying keys for the transfer_public function*
+
+---
+
+### `inclusionKeys() ► Promise.<FunctionKeyPair>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the proving and verifying keys for the inclusion proof.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<FunctionKeyPair>` | *Proving and verifying keys for the inclusion proof.*
+
+---
+
 ### `joinKeys() ► Promise.<FunctionKeyPair>`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -424,6 +448,30 @@ programManager.transfer(1, "aleo166q6ww6688cug7qxwe7nhctjpymydwzy2h7rscfmatqmfwn
 // Keys can also be fetched manually
 const [transferPublicProvingKey, transferPublicVerifyingKey] = await keyProvider.transferKeys("public");
 ```
+
+---
+
+### `transferPublicKeys() ► Promise.<FunctionKeyPair>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the proving and verifying keys for the transfer_public function.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<FunctionKeyPair>` | *Proving and verifying keys for the transfer_public function*
+
+---
+
+### `inclusionKeys() ► Promise.<FunctionKeyPair>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the proving and verifying keys for the inclusion proof.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<FunctionKeyPair>` | *Proving and verifying keys for the inclusion proof.*
 
 ---
 

--- a/docs/api_reference/sdk-src_offline-key-provider.md
+++ b/docs/api_reference/sdk-src_offline-key-provider.md
@@ -521,6 +521,18 @@ __*return*__ | `Promise.<FunctionKeyPair>` | *Proving and verifying keys for the
 
 ---
 
+### `inclusionKeys() ► Promise.<FunctionKeyPair>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the inclusion prover keys from. The keys must be cached prior to calling this method for it to work.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<FunctionKeyPair>` | *Proving and verifying keys for the inclusion prover*
+
+---
+
 ### `joinKeys() ► Promise.<FunctionKeyPair>`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -639,6 +651,20 @@ __provingKey__ | `undefined` | **
 Insert the proving and verifying keys for the fee_public function into the cache. Only the proving key needs
 to be inserted, the verifying key is automatically inserted by the SDK. This function will automatically check
 that the keys match the expected checksum for fee_public before inserting them into the cache.
+
+Parameters | Type | Description
+--- | --- | ---
+__provingKey__ | `undefined` | **
+
+---
+
+### `insertInclusionKeys(provingKey)`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Insert the proving and verifying keys for the inclusion prover into the cache. Only the proving key needs
+to be inserted, the verifying key is automatically inserted by the SDK. This function will automatically check
+that the keys match the expected checksum for the inclusion prover.
 
 Parameters | Type | Description
 --- | --- | ---
@@ -873,6 +899,18 @@ __*return*__ | `Promise.<FunctionKeyPair>` | *Proving and verifying keys for the
 
 ---
 
+### `inclusionKeys() ► Promise.<FunctionKeyPair>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the inclusion prover keys from. The keys must be cached prior to calling this method for it to work.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<FunctionKeyPair>` | *Proving and verifying keys for the inclusion prover*
+
+---
+
 ### `joinKeys() ► Promise.<FunctionKeyPair>`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -991,6 +1029,20 @@ __provingKey__ | `undefined` | **
 Insert the proving and verifying keys for the fee_public function into the cache. Only the proving key needs
 to be inserted, the verifying key is automatically inserted by the SDK. This function will automatically check
 that the keys match the expected checksum for fee_public before inserting them into the cache.
+
+Parameters | Type | Description
+--- | --- | ---
+__provingKey__ | `undefined` | **
+
+---
+
+### `insertInclusionKeys(provingKey)`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Insert the proving and verifying keys for the inclusion prover into the cache. Only the proving key needs
+to be inserted, the verifying key is automatically inserted by the SDK. This function will automatically check
+that the keys match the expected checksum for the inclusion prover.
 
 Parameters | Type | Description
 --- | --- | ---

--- a/docs/api_reference/sdk-src_program-manager.md
+++ b/docs/api_reference/sdk-src_program-manager.md
@@ -1253,15 +1253,23 @@ assert(isValid);
 
 ---
 
-### `createProgramFromSource(program) ► Program`
+### `createProgramFromSource(executionResponse, imports, importedVerifyingKeys, program) ► boolean`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Create a program object from a program&#x27;s source code
+Set the inclusion key bytes.
 
 Parameters | Type | Description
 --- | --- | ---
+__executionResponse__ | `executionResponse` | *The response from an offline function execution (via the &#x60;programManager.run&#x60; method)*
+__imports__ | `ImportedPrograms` | *The imported programs used in the execution. Specified as { &quot;programName&quot;: &quot;programSourceCode&quot;, ... }*
+__importedVerifyingKeys__ | `ImportedVerifyingKeys` | *The verifying keys in the execution. Specified as { &quot;programName&quot;: [[&quot;functionName&quot;, &quot;verifyingKey&quot;], ...], ... }*
 __program__ | `string` | *Program source code*
+__*return*__ | `boolean` | *True if the proof is valid, false otherwise
+
+
+    /**
+Create a program object from a program&#x27;s source code*
 __*return*__ | [Program](sdk-src_wasm.md) | *The program object*
 
 ---
@@ -2521,15 +2529,23 @@ assert(isValid);
 
 ---
 
-### `createProgramFromSource(program) ► Program`
+### `createProgramFromSource(executionResponse, imports, importedVerifyingKeys, program) ► boolean`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Create a program object from a program&#x27;s source code
+Set the inclusion key bytes.
 
 Parameters | Type | Description
 --- | --- | ---
+__executionResponse__ | `executionResponse` | *The response from an offline function execution (via the &#x60;programManager.run&#x60; method)*
+__imports__ | `ImportedPrograms` | *The imported programs used in the execution. Specified as { &quot;programName&quot;: &quot;programSourceCode&quot;, ... }*
+__importedVerifyingKeys__ | `ImportedVerifyingKeys` | *The verifying keys in the execution. Specified as { &quot;programName&quot;: [[&quot;functionName&quot;, &quot;verifyingKey&quot;], ...], ... }*
 __program__ | `string` | *Program source code*
+__*return*__ | `boolean` | *True if the proof is valid, false otherwise
+
+
+    /**
+Create a program object from a program&#x27;s source code*
 __*return*__ | [Program](sdk-src_wasm.md) | *The program object*
 
 ---

--- a/docs/api_reference/sdk-src_record-provider.md
+++ b/docs/api_reference/sdk-src_record-provider.md
@@ -21,11 +21,11 @@ Set the account used to search for records
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | *The account to use for searching for records*
+__account__ | [Account](sdk-src_account.md) | *The account used to use for searching for records.*
 
 ---
 
-### `findCreditsRecords(microcredits, unspent, nonces, searchParameters) ► Promise.<RecordPlaintext>`
+### `findCreditsRecords(microcredits, searchParameters) ► Promise.<Array.<OwnedRecord>>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -33,11 +33,9 @@ Find a list of credit records with a given number of microcredits by via the off
 
 Parameters | Type | Description
 --- | --- | ---
-__microcredits__ | `Array.<number>` | *The number of microcredits to search for*
-__unspent__ | `boolean` | *Whether or not the record is unspent*
-__nonces__ | `Array.<string>` | *Nonces of records already found so that they are not found again*
-__searchParameters__ | `RecordSearchParams` | *Additional parameters to search for*
-__*return*__ | `Promise.<RecordPlaintext>` | *The record if found, otherwise an error*
+__microcredits__ | `Array.<number>` | *The number of microcredits to search for.*
+__searchParameters__ | `RecordSearchParams` | *Additional parameters to search for.*
+__*return*__ | `Promise.<Array.<OwnedRecord>>` | *The records if found, otherwise an error.*
 
 #### Examples
 
@@ -48,11 +46,11 @@ const keyProvider = new AleoKeyProvider();
 const recordProvider = new NetworkRecordProvider(account, networkClient);
 
 // The record provider can be used to find records with a given number of microcredits
-const record = await recordProvider.findCreditsRecord(5000, true, []);
+const record = await recordProvider.findCreditsRecord(5000, { unspent: true, nonces: [] });
 
 // When a record is found but not yet used, it's nonce should be added to the nonces parameter so that it is not
 // found again if a subsequent search is performed
-const records = await recordProvider.findCreditsRecords(5000, true, [record.nonce()]);
+const records = await recordProvider.findCreditsRecords(5000, { unspent: true, nonces: [record.nonce()] });
 
 // When the program manager is initialized with the record provider it will be used to find automatically find
 // fee records and amount records for value transfers so that they do not need to be specified manually
@@ -62,7 +60,7 @@ programManager.transfer(1, "aleo166q6ww6688cug7qxwe7nhctjpymydwzy2h7rscfmatqmfwn
 
 ---
 
-### `findCreditsRecord(microcredits, unspent, nonces, searchParameters) ► Promise.<RecordPlaintext>`
+### `findCreditsRecord(microcredits, searchParameters) ► Promise.<OwnedRecord>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -70,11 +68,9 @@ Find a credit record with a given number of microcredits by via the official Ale
 
 Parameters | Type | Description
 --- | --- | ---
-__microcredits__ | `number` | *The number of microcredits to search for*
-__unspent__ | `boolean` | *Whether or not the record is unspent*
-__nonces__ | `Array.<string>` | *Nonces of records already found so that they are not found again*
-__searchParameters__ | `RecordSearchParams` | *Additional parameters to search for*
-__*return*__ | `Promise.<RecordPlaintext>` | *The record if found, otherwise an error*
+__microcredits__ | `number` | *The number of microcredits to search for.*
+__searchParameters__ | `RecordSearchParams` | *Additional parameters to search for.*
+__*return*__ | `Promise.<OwnedRecord>` | *The record if found, otherwise an error.*
 
 #### Examples
 
@@ -85,11 +81,11 @@ const keyProvider = new AleoKeyProvider();
 const recordProvider = new NetworkRecordProvider(account, networkClient);
 
 // The record provider can be used to find records with a given number of microcredits
-const record = await recordProvider.findCreditsRecord(5000, true, []);
+const record = await recordProvider.findCreditsRecord(5000, { unspent: true, nonces: [] });
 
 // When a record is found but not yet used, it's nonce should be added to the nonces parameter so that it is not
 // found again if a subsequent search is performed
-const records = await recordProvider.findCreditsRecords(5000, true, [record.nonce()]);
+const records = await recordProvider.findCreditsRecords(5000, { unspent: true, nonces: [record.nonce()] });
 
 // When the program manager is initialized with the record provider it will be used to find automatically find
 // fee records and amount records for value transfers so that they do not need to be specified manually
@@ -123,11 +119,11 @@ Set the account used to search for records
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | *The account to use for searching for records*
+__account__ | [Account](sdk-src_account.md) | *The account used to use for searching for records.*
 
 ---
 
-### `findCreditsRecords(microcredits, unspent, nonces, searchParameters) ► Promise.<RecordPlaintext>`
+### `findCreditsRecords(microcredits, searchParameters) ► Promise.<Array.<OwnedRecord>>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -135,11 +131,9 @@ Find a list of credit records with a given number of microcredits by via the off
 
 Parameters | Type | Description
 --- | --- | ---
-__microcredits__ | `Array.<number>` | *The number of microcredits to search for*
-__unspent__ | `boolean` | *Whether or not the record is unspent*
-__nonces__ | `Array.<string>` | *Nonces of records already found so that they are not found again*
-__searchParameters__ | `RecordSearchParams` | *Additional parameters to search for*
-__*return*__ | `Promise.<RecordPlaintext>` | *The record if found, otherwise an error*
+__microcredits__ | `Array.<number>` | *The number of microcredits to search for.*
+__searchParameters__ | `RecordSearchParams` | *Additional parameters to search for.*
+__*return*__ | `Promise.<Array.<OwnedRecord>>` | *The records if found, otherwise an error.*
 
 #### Examples
 
@@ -150,11 +144,11 @@ const keyProvider = new AleoKeyProvider();
 const recordProvider = new NetworkRecordProvider(account, networkClient);
 
 // The record provider can be used to find records with a given number of microcredits
-const record = await recordProvider.findCreditsRecord(5000, true, []);
+const record = await recordProvider.findCreditsRecord(5000, { unspent: true, nonces: [] });
 
 // When a record is found but not yet used, it's nonce should be added to the nonces parameter so that it is not
 // found again if a subsequent search is performed
-const records = await recordProvider.findCreditsRecords(5000, true, [record.nonce()]);
+const records = await recordProvider.findCreditsRecords(5000, { unspent: true, nonces: [record.nonce()] });
 
 // When the program manager is initialized with the record provider it will be used to find automatically find
 // fee records and amount records for value transfers so that they do not need to be specified manually
@@ -164,7 +158,7 @@ programManager.transfer(1, "aleo166q6ww6688cug7qxwe7nhctjpymydwzy2h7rscfmatqmfwn
 
 ---
 
-### `findCreditsRecord(microcredits, unspent, nonces, searchParameters) ► Promise.<RecordPlaintext>`
+### `findCreditsRecord(microcredits, searchParameters) ► Promise.<OwnedRecord>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -172,11 +166,9 @@ Find a credit record with a given number of microcredits by via the official Ale
 
 Parameters | Type | Description
 --- | --- | ---
-__microcredits__ | `number` | *The number of microcredits to search for*
-__unspent__ | `boolean` | *Whether or not the record is unspent*
-__nonces__ | `Array.<string>` | *Nonces of records already found so that they are not found again*
-__searchParameters__ | `RecordSearchParams` | *Additional parameters to search for*
-__*return*__ | `Promise.<RecordPlaintext>` | *The record if found, otherwise an error*
+__microcredits__ | `number` | *The number of microcredits to search for.*
+__searchParameters__ | `RecordSearchParams` | *Additional parameters to search for.*
+__*return*__ | `Promise.<OwnedRecord>` | *The record if found, otherwise an error.*
 
 #### Examples
 
@@ -187,11 +179,11 @@ const keyProvider = new AleoKeyProvider();
 const recordProvider = new NetworkRecordProvider(account, networkClient);
 
 // The record provider can be used to find records with a given number of microcredits
-const record = await recordProvider.findCreditsRecord(5000, true, []);
+const record = await recordProvider.findCreditsRecord(5000, { unspent: true, nonces: [] });
 
 // When a record is found but not yet used, it's nonce should be added to the nonces parameter so that it is not
 // found again if a subsequent search is performed
-const records = await recordProvider.findCreditsRecords(5000, true, [record.nonce()]);
+const records = await recordProvider.findCreditsRecords(5000, { unspent: true, nonces: [record.nonce()] });
 
 // When the program manager is initialized with the record provider it will be used to find automatically find
 // fee records and amount records for value transfers so that they do not need to be specified manually
@@ -201,7 +193,7 @@ programManager.transfer(1, "aleo166q6ww6688cug7qxwe7nhctjpymydwzy2h7rscfmatqmfwn
 
 ---
 
-### `findRecord(unspent, nonces, searchParameters) ► Promise.<RecordPlaintext>`
+### `findRecord(searchParameters) ► Promise.<OwnedRecord>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -209,14 +201,12 @@ Find an arbitrary record. WARNING: This function is not implemented yet and will
 
 Parameters | Type | Description
 --- | --- | ---
-__unspent__ | `boolean` | **
-__nonces__ | `Array` | **
 __searchParameters__ | `RecordSearchParams` | **
-__*return*__ | `Promise.<RecordPlaintext>` | **
+__*return*__ | `Promise.<OwnedRecord>` | **
 
 ---
 
-### `findRecords(unspent, nonces, searchParameters) ► Promise.<Array>`
+### `findRecords(searchParameters) ► Promise.<Array>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -224,8 +214,6 @@ Find multiple records from a specified program.
 
 Parameters | Type | Description
 --- | --- | ---
-__unspent__ | `boolean` | **
-__nonces__ | `Array` | **
 __searchParameters__ | `RecordSearchParams` | **
 __*return*__ | `Promise.<Array>` | **
 
@@ -249,5 +237,5 @@ const recordProvider = new NetworkRecordProvider(account, networkClient);
 
 // The record provider can be used to find records with a given number of microcredits and the block height search
 // can be used to find records within a given block height range
-const record = await recordProvider.findCreditsRecord(5000, true, [], params);
+const record = await recordProvider.findCreditsRecord(5000, { unspent: true, nonces: [], ...params });
 ```

--- a/docs/api_reference/sdk-src_wasm.md
+++ b/docs/api_reference/sdk-src_wasm.md
@@ -1158,6 +1158,19 @@ __*return*__ | [Field](sdk-src_wasm.md) | **
 
 ---
 
+### `newDomainSeparator(domain) ► Field`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Initializes a new field as a domain separator.
+
+Parameters | Type | Description
+--- | --- | ---
+__domain__ | `string` | **
+__*return*__ | [Field](sdk-src_wasm.md) | **
+
+---
+
 ### `add(other) ► Field`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -1711,11 +1724,11 @@ assert( JSON.stringify(bondStateObject) === JSON.stringify(expectedObject) );
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Get the left endian boolean array representation of the bits of the plaintext.
+Get the little endian boolean array representation of the bits of the plaintext.
 
 Parameters | Type | Description
 --- | --- | ---
-__*return*__ | `Array` | *The left endian boolean array representation of the bits of the plaintext.*
+__*return*__ | `Array` | *The little endian boolean array representation of the bits of the plaintext.*
 
 ---
 
@@ -1749,11 +1762,11 @@ __*return*__ | [Plaintext](sdk-src_wasm.md) | *The plaintext object.*
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Get the left endian byte array representation of the plaintext.
+Get the little endian byte array representation of the plaintext.
 
 Parameters | Type | Description
 --- | --- | ---
-__*return*__ | `Uint8Array` | *The left endian byte array representation of the plaintext.*
+__*return*__ | `Uint8Array` | *The little endian byte array representation of the plaintext.*
 
 ---
 
@@ -1765,7 +1778,7 @@ Get a plaintext object from a series of bits represented as a boolean array.
 
 Parameters | Type | Description
 --- | --- | ---
-__bits__ | `Array` | *A left endian boolean array representing the bits plaintext.*
+__bits__ | `Array` | *A little endian boolean array representing the bits plaintext.*
 __*return*__ | [Plaintext](sdk-src_wasm.md) | *The plaintext object.*
 
 ---
@@ -1778,8 +1791,20 @@ Get a plaintext object from a series of bytes.
 
 Parameters | Type | Description
 --- | --- | ---
-__bytes__ | `Uint8Array` | *A left endian byte array representing the plaintext.*
+__bytes__ | `Uint8Array` | *A little endian byte array representing the plaintext.*
 __*return*__ | [Plaintext](sdk-src_wasm.md) | *The plaintext object.*
+
+---
+
+### `toFieldsRaw() ► Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the raw field array representation of the plaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array` | *The raw field array representation of the plaintext.*
 
 ---
 
@@ -1792,6 +1817,54 @@ Gives the type of the plaintext.
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `string` | *The type of the plaintext.*
+
+---
+
+### `toBitsRawBe() ► Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the raw big endian boolean array representation of the bits of the plaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array` | *The raw big endian boolean array representation of the bits of the plaintext.*
+
+---
+
+### `toBitsRawLe() ► Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the raw little endian boolean array representation of the bits of the plaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array` | *The raw little endian boolean array representation of the bits of the plaintext.*
+
+---
+
+### `toBytesRawBe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the raw big endian byte array representation of the plaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | *The raw big endian byte array representation of the plaintext.*
+
+---
+
+### `toBytesRawLe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the raw little endian byte array representation of the plaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | *The raw little endian byte array representation of the plaintext.*
 
 ---
 
@@ -1892,7 +1965,7 @@ __*return*__ | [PrivateKey](sdk-src_wasm.md) | **
 
 ## Methods
 
-### `sign_value(message) ► Signature`
+### `signValue(message) ► Signature`
 
 ![modifier: public](images/badges/modifier-public.svg)
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2186,8 +2186,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2213,8 +2213,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2227,8 +2227,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2237,8 +2237,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2247,8 +2247,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2257,8 +2257,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2275,13 +2275,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2291,8 +2291,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2305,8 +2305,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2320,8 +2320,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2333,8 +2333,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2342,8 +2342,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2352,8 +2352,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2364,8 +2364,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2376,8 +2376,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2387,8 +2387,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2399,8 +2399,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2412,8 +2412,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2423,8 +2423,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2438,8 +2438,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2449,8 +2449,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2469,8 +2469,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2487,8 +2487,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2508,8 +2508,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2523,8 +2523,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2534,16 +2534,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2552,8 +2552,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2563,8 +2563,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2574,8 +2574,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2585,8 +2585,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2596,8 +2596,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "rand",
  "rayon",
@@ -2610,8 +2610,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2627,8 +2627,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "anyhow",
  "rand",
@@ -2639,8 +2639,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2661,8 +2661,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2673,8 +2673,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2686,8 +2686,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2698,8 +2698,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2708,8 +2708,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2723,8 +2723,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2732,8 +2732,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2751,8 +2751,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2773,8 +2773,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2790,8 +2790,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2814,8 +2814,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2839,8 +2839,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2870,8 +2870,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2894,8 +2894,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -2913,8 +2913,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2926,8 +2926,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2948,8 +2948,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",
@@ -2958,8 +2958,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb44d39#eb44d391b7b10d241f753c4aa2a4b8af3339d697"
+version = "4.3.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
 dependencies = [
  "getrandom",
  "snarkvm-console",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -304,7 +304,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2186,8 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f86971b37e69b5306aef35c69d0f72161a060b1f8b32aca3d212f1ed2d04637"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2213,8 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf787de3f5a32684c6133dce0d7cc9e60a275e1f8d4693f64ed8c6b440f6607"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2227,8 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d949b4afd5d8f82f5b4eb77415992b10946bd9751a39cc2f6a065a6b7a6f5360"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2237,8 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313bcc7cdfedb85fe5be3eb2e15f2e02b68b36ba82fc06d5cf4948518acc057b"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2247,8 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa18201496366b5b4df792b2a8390cd4a3b43fbda450391b53622af519bc8008"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2257,8 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8604e360ae3af16bdb7d24755260d93c76461b8701dfe1541db1622fa8b106b3"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2275,13 +2281,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d99ae833a7aaddbe07e27ba9670bf2784e5bb50ba0b0e798b2f393dcd989c9"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191442c2657e9331232b5eb4b7dcb2d092b8bbeba62d05e8cf5586a297eedcf1"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2291,8 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6838f4bbc73db38e163b9d4da521004e10b051cbb3aadf5d98a132bbb8e5bc7a"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2305,8 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "181b57e5fdfd2c0e727ccbe6235eec867cc99748df725896ec7285478a1bcdf4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2320,8 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16af5c272f68f6b2ab10cfcc68d8170297a604c4dcaece052b5cd7f3a253600c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2333,8 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be45db5be35742275f1f59e36c0e8ff56bc117848029636dc64563f18e298ee3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2342,8 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a4754c415165409c9e77f8f0f02e60e18b04e6bbfe8aa91b44948b3fd1f45f3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2352,8 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2fe589b309d79926bca0505a2a9e7978e95fb4b18899f9a0108e1e6e975cdc5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2364,8 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4a33327a1f2a2858bf21f9a5ae9afb2f2b85d97494c4bb707e007e822a2c78"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2376,8 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0ec6bacf1997791fef10d31d7be1c2efdb26b2ef73e05d1c1986b58d62d82f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2387,8 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e689dc2153df5a1603cac825e094b9ec3df809c74dda2b6d0b67ee06f56f35cd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2399,8 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dea6574370cf8ac3c758dc1f0dd1265497af0c1e7f01a8955610a95cf8ec9e4"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2412,8 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea7c6463add8b7625bddd527348eecf8cda97b5a596bdfc7e67206f8c05d2ede"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2423,8 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f6669a797f6b8ec7919e359988b1b3ef4f6e1e7900864e4d455f2708708b9a9"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2438,8 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f04696546d115687ad110ced1dc517a0cd68c743881ff0bb78821225dd5b06"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2449,8 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54edb16375212ce535092cfff04182886929712a6d5530ed4ab586ae00092fa1"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2469,8 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a00b34d968e01f49c6f8da53119c31b23f779777d1e45762337566d926f58"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2487,8 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2724a0f9c3e07e39ae100fb365f9a54e7d3e572f46ae0d2d709d670d8f0889b8"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2508,8 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd89b14c1d1a77f492e07c0b50f77e2d706a7b75d44ab1685a35a01a36fee766"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2523,8 +2548,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935164389f178ffd7da422263d36661377c21e6ddad4fd9eb24a4700ac44ebe5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2534,16 +2560,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "910a4367a81f30731c3b0535eceed9a280aaf478b2e9e3298ea32a7ca04d71cf"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e9a52034ccfb9308e23b4b236b6d4075ed6bec6566d2d33a51f4f23c4b438c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2552,8 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41b75c933082fa878f29070405dacf085c7a5e3b8f066f0524c4eed590d07e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2563,8 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831ffa9a56f9211b58d46080a4c9e3f94eace41c61a71b9303ad21732baf86c7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2574,8 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab607e15f5f3cb1eafa1d28d4a40fcef2f75a95034ab1f5defbeca7227c93e46"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2585,8 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f505fa474dc70240f9e9331c686f38af82df977e85427cb37b63b68a29666b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2596,8 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2adf8d9a2acbafca5575f83a9d78774e6d79bd3526b02b746ee63ec167e7d9"
 dependencies = [
  "rand",
  "rayon",
@@ -2610,8 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cc3b1f09847f7da99b556167b64f9eceb3eedc7af0f5917727007c9194123f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2627,8 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002e33a0a88ad237da5c57aca5067a19191acea7ae4488c5476e4ace47babf3e"
 dependencies = [
  "anyhow",
  "rand",
@@ -2639,8 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "386dc4871c03423e02bf210719a248fdfaca0682d48f5fc97b6d3bd92544a0f3"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2661,8 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33028e2cc8325895d30461b7bea220cd7eb824dfcf2587e0d44b638de90d9135"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2673,8 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d3d400a147baa29db3a84ad85341efebb12283c3605c164affef165e182d93"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2686,8 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58769eb72fe63f91acf711f4c76693a5fca72064295726f59fcb070c192f06bf"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2698,8 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6f6e4d203b4596284326c8bc5f31dc9dc5255cbfac3d00d77a2547dce9722f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2708,8 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7653bd1c28cfe27718a87e8f6712e3fbd84e2f7f74c055ca2d3501f78b762afa"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2723,8 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc3a8e2ca8db6946e741d9b5fca15fb845b6647f1c8f812ef5a909995735cc2"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2732,8 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112817b750d364635271c73cb057ce87b93c7e7ed4f90ff07c2e7502aaf89b1b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2751,8 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8189964b8431b596ca13c205ad75a06955724d7944b61260496c5008e416843b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2773,8 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d498ad741971e12b904a6f8352cf574a63df52bde4e1b4e947a7bde9e735d92"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2790,8 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128f2bce363f115e18db532f5d62cd86854d92b88520734a606969f94233ebcc"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2814,8 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25165b3f146ed21d737ab1077dac1b011d6d845f0026bd86771a79077661c875"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2839,8 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6181e0c1cbfc89bae764cd5f627a0663ca0e321f153f32233e63cc21a2defee1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2870,8 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8ba692ccaa27582ca0499e84d9162837b22c5a1bb98588e2c55006fbda0631"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2894,8 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4700d448ce9c5591b5d7de628e9a8c450096cc09796c08e2e10254e1def6123d"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -2913,8 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581b7f70cf5a53ace9a99d6c126d1d17d0c659d568484cb3dc64ae10c37bf89f"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2926,8 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abfb48a504c75ce3860aefcea4b7c67143087810e88cb0d25533bb183fc4958"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2948,8 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d2b40fbea924467662de1deeb3ca6e4c1b7c0d49bb3eccebb6d982e5d39535"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",
@@ -2958,8 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "4.2.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0345be0d84019f1dfbfdc6e9e8815e8e5b7475b99090ef461b39715b8372b44"
 dependencies = [
  "getrandom",
  "snarkvm-console",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2186,8 +2186,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2213,8 +2213,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2227,8 +2227,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2237,8 +2237,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2247,8 +2247,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2257,8 +2257,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2275,13 +2275,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2291,8 +2291,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2305,8 +2305,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2320,8 +2320,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2333,8 +2333,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2342,8 +2342,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2352,8 +2352,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2364,8 +2364,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2376,8 +2376,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2387,8 +2387,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2399,8 +2399,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2412,8 +2412,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2423,8 +2423,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2438,8 +2438,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2449,8 +2449,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2469,8 +2469,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2487,8 +2487,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2508,8 +2508,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2523,8 +2523,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2534,16 +2534,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2552,8 +2552,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2563,8 +2563,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2574,8 +2574,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2585,8 +2585,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2596,8 +2596,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "rand",
  "rayon",
@@ -2610,8 +2610,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2627,8 +2627,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "anyhow",
  "rand",
@@ -2639,8 +2639,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2661,8 +2661,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2673,8 +2673,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2686,8 +2686,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2698,8 +2698,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2708,8 +2708,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2723,8 +2723,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2732,8 +2732,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2751,8 +2751,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2773,8 +2773,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2790,8 +2790,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2814,8 +2814,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2839,8 +2839,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2870,8 +2870,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2894,8 +2894,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -2913,8 +2913,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2926,8 +2926,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2948,8 +2948,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",
@@ -2958,8 +2958,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=99260b9#99260b9ccea9fced9e3a4dbded668fbe58259bb8"
+version = "4.2.1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=93635d0#93635d088a38152187ecff155599ab829afe7ce9"
 dependencies = [
  "getrandom",
  "snarkvm-console",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -23,16 +23,16 @@ doctest = false
 
 [dependencies.snarkvm-algorithms]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 
 [dependencies.snarkvm-circuit-network]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 default-features = false
 features = [
     "account",
@@ -46,37 +46,37 @@ features = [
 
 [dependencies.snarkvm-ledger-block]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 
 [dependencies.snarkvm-parameters]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb44d39"
+rev = "99260b9"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -22,17 +22,20 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 
 [dependencies.snarkvm-circuit-network]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 default-features = false
 features = [
     "account",
@@ -45,38 +48,45 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 
 [dependencies.snarkvm-parameters]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "93635d0"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "93635d0"
+version = "4.3.1"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -23,16 +23,16 @@ doctest = false
 
 [dependencies.snarkvm-algorithms]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 
 [dependencies.snarkvm-circuit-network]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 default-features = false
 features = [
     "account",
@@ -46,37 +46,37 @@ features = [
 
 [dependencies.snarkvm-ledger-block]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 
 [dependencies.snarkvm-parameters]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "99260b9"
+rev = "93635d0"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provablehq/wasm",
   "version": "0.9.10-testnet-rc",
-  "type": "module",
+  
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [
     "The Provable Team"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provablehq/wasm",
   "version": "0.9.10-testnet-rc",
-  
+  "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [
     "The Provable Team"

--- a/wasm/src/programs/macros.rs
+++ b/wasm/src/programs/macros.rs
@@ -296,6 +296,7 @@ macro_rules! execute_fee {
 #[macro_export]
 macro_rules! calculate_minimum_fee {
     ($offline_query:expr, $node_url: expr, $process:expr, $execution_ref:expr) => {{
+        // Get the block height.
         let block_height = if let Some(ref offline_query) = $offline_query {
             let block_height = offline_query.current_block_height().map_err(|e| e.to_string())?;
             block_height
@@ -303,13 +304,12 @@ macro_rules! calculate_minimum_fee {
             let block_height = latest_block_height($node_url).await.map_err(|e| e.to_string())?;
             block_height
         };
-        let (minimum_execution_cost, (_, _)) =
-            if block_height >= CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap() {
-                execution_cost($process, $execution_ref, ConsensusVersion::V2).map_err(|err| err.to_string())?
-            } else {
-                execution_cost($process, $execution_ref, ConsensusVersion::V1).map_err(|err| err.to_string())?
-            };
 
+        // Calculate the execution cost based on the consensus version.
+        let consensus_version =
+            <CurrentNetwork as Network>::CONSENSUS_VERSION(block_height).map_err(|e| e.to_string())?;
+        let (minimum_execution_cost, (_, _)) =
+            execution_cost($process, $execution_ref, consensus_version).map_err(|err| err.to_string())?;
         minimum_execution_cost
     }};
 }

--- a/wasm/src/programs/macros.rs
+++ b/wasm/src/programs/macros.rs
@@ -305,9 +305,9 @@ macro_rules! calculate_minimum_fee {
         };
         let (minimum_execution_cost, (_, _)) =
             if block_height >= CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap() {
-                execution_cost_v2($process, $execution_ref).map_err(|err| err.to_string())?
+                execution_cost($process, $execution_ref, ConsensusVersion::V2).map_err(|err| err.to_string())?
             } else {
-                execution_cost_v1($process, $execution_ref).map_err(|err| err.to_string())?
+                execution_cost($process, $execution_ref, ConsensusVersion::V1).map_err(|err| err.to_string())?
             };
 
         minimum_execution_cost

--- a/wasm/src/programs/manager/execute.rs
+++ b/wasm/src/programs/manager/execute.rs
@@ -17,8 +17,10 @@
 use super::*;
 
 use crate::{
+    Address,
     ExecutionResponse,
     OfflineQuery,
+    Plaintext,
     PrivateKey,
     RecordPlaintext,
     SnapshotQuery,
@@ -42,10 +44,12 @@ use crate::{
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
 use snarkvm_console::{
     network::{ConsensusVersion, Network},
-    program::Value,
+    program::{ArrayType, PlaintextType, Value, ValueType},
 };
 use snarkvm_ledger_query::QueryTrait;
 use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost, execution_cost_for_authorization};
+use snarkvm_synthesizer_program::FunctionCore;
+use wasm_bindgen::JsValue;
 
 use crate::types::native::{PrivateKeyNative, ViewKeyNative};
 use core::ops::Add;
@@ -307,10 +311,8 @@ impl ProgramManager {
     #[wasm_bindgen(js_name = estimateExecutionFee)]
     #[allow(clippy::too_many_arguments)]
     pub async fn estimate_execution_fee(
-        private_key: &PrivateKey,
         program: &str,
         function: &str,
-        inputs: Array,
         url: Option<String>,
         imports: Option<Object>,
         offline_query: Option<OfflineQuery>,
@@ -327,6 +329,35 @@ impl ProgramManager {
         log("Check program imports are valid and add them to the process");
         let program_native = ProgramNative::from_str(program).map_err(|e| e.to_string())?;
 
+        let rng = &mut StdRng::from_entropy();
+        // Initialize a burner private key.
+        let burner_private_key = PrivateKey::new();
+        // Compute the burner address.
+        let burner_address = Address::from_private_key(&burner_private_key);
+
+        let function_native = program_native
+            .get_function(&IdentifierNative::from_str(function).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+
+        let mut inputs: Vec<Value<CurrentNetwork>> = vec![];
+        for input_type in function_native.input_types() {
+            match input_type {
+                ValueType::ExternalRecord(locator) => {
+                    let stack = process.get_stack(locator.program_id()).map_err(|e| e.to_string())?;
+                    inputs.push(
+                        stack
+                            .sample_value(&burner_address, &ValueType::Record(*locator.resource()).into(), rng)
+                            .map_err(|e| e.to_string())?,
+                    );
+                }
+                _ => {
+                    let stack = process.get_stack(program_native.id()).map_err(|e| e.to_string())?;
+                    inputs
+                        .push(stack.sample_value(&burner_address, &input_type.into(), rng).map_err(|e| e.to_string())?);
+                }
+            }
+        }
+
         let program_id = program_native.id();
         let edition = edition.unwrap_or(1);
 
@@ -338,30 +369,16 @@ impl ProgramManager {
         }
 
         ProgramManager::resolve_imports(process, &program_native, imports)?;
-        let rng = &mut StdRng::from_entropy();
 
         let authorization = process
-            .authorize::<CurrentAleo, StdRng>(
-                private_key,
-                program_id,
-                function,
-                inputs.iter().map(|v| Value::from_str(&v.as_string().unwrap_or_default())),
-                rng,
-            )
+            .authorize::<CurrentAleo, StdRng>(&burner_private_key, program_id, function, inputs.iter(), rng)
             .map_err(|e| e.to_string())?;
 
         let node_url = url.as_deref().unwrap_or(DEFAULT_URL);
         let latest_height = if let Some(offline_query) = offline_query.as_ref() {
             offline_query.current_block_height().map_err(|e| e.to_string())?
         } else {
-            let function_name = IdentifierNative::from_str(function).map_err(|err| err.to_string())?;
-            let view_key =
-                ViewKeyNative::try_from(PrivateKeyNative::from(private_key)).map_err(|err| err.to_string())?;
-            let query =
-                SnapshotQuery::try_from_inputs(node_url, &program_native, &function_name, &view_key, &inputs.to_vec())
-                    .await
-                    .map_err(|err| err.to_string())?;
-            query.current_block_height().map_err(|e| e.to_string())?
+            latest_block_height(node_url).await.map_err(|err| err.to_string())?
         };
 
         let consensus_version =

--- a/wasm/src/programs/manager/execute.rs
+++ b/wasm/src/programs/manager/execute.rs
@@ -40,11 +40,12 @@ use crate::{
     },
 };
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
-use snarkvm_console::{network::{ConsensusVersion, Network}, program::Value};
-use snarkvm_ledger_query::QueryTrait;
-use snarkvm_synthesizer::{
-    prelude::{InclusionVersion, execution_cost, execution_cost_for_authorization},
+use snarkvm_console::{
+    network::{ConsensusVersion, Network},
+    program::Value,
 };
+use snarkvm_ledger_query::QueryTrait;
+use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost, execution_cost_for_authorization};
 
 use crate::types::native::{PrivateKeyNative, ViewKeyNative};
 use core::ops::Add;
@@ -339,10 +340,16 @@ impl ProgramManager {
         ProgramManager::resolve_imports(process, &program_native, imports)?;
         let rng = &mut StdRng::from_entropy();
 
-        let authorization =
-            process.authorize::<CurrentAleo, StdRng>(private_key, program_id, function, inputs.iter().map(|v| Value::from_str(&v.as_string().unwrap_or_default())), rng).map_err(|e| e.to_string())?;
+        let authorization = process
+            .authorize::<CurrentAleo, StdRng>(
+                private_key,
+                program_id,
+                function,
+                inputs.iter().map(|v| Value::from_str(&v.as_string().unwrap_or_default())),
+                rng,
+            )
+            .map_err(|e| e.to_string())?;
 
-        
         let node_url = url.as_deref().unwrap_or(DEFAULT_URL);
         let latest_height = if let Some(offline_query) = offline_query.as_ref() {
             offline_query.current_block_height().map_err(|e| e.to_string())?

--- a/wasm/src/programs/manager/execute.rs
+++ b/wasm/src/programs/manager/execute.rs
@@ -20,7 +20,6 @@ use crate::{
     Address,
     ExecutionResponse,
     OfflineQuery,
-    Plaintext,
     PrivateKey,
     RecordPlaintext,
     SnapshotQuery,
@@ -44,12 +43,10 @@ use crate::{
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
 use snarkvm_console::{
     network::{ConsensusVersion, Network},
-    program::{ArrayType, PlaintextType, Value, ValueType},
+    program::{Value, ValueType},
 };
 use snarkvm_ledger_query::QueryTrait;
 use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost, execution_cost_for_authorization};
-use snarkvm_synthesizer_program::FunctionCore;
-use wasm_bindgen::JsValue;
 
 use crate::types::native::{PrivateKeyNative, ViewKeyNative};
 use core::ops::Add;
@@ -297,10 +294,8 @@ impl ProgramManager {
     ///
     /// Disclaimer: Fee estimation is experimental and may not represent a correct estimate on any current or future network
     ///
-    /// @param private_key The private key of the sender
     /// @param program The source code of the program to estimate the execution fee for
     /// @param function The name of the function to execute
-    /// @param inputs A javascript array of inputs to the function
     /// @param url The url of the Aleo network node to send the transaction to
     /// @param imports (optional) Provide a list of imports to use for the fee estimation in the
     /// form of a javascript object where the keys are a string of the program name and the values
@@ -335,10 +330,12 @@ impl ProgramManager {
         // Compute the burner address.
         let burner_address = Address::from_private_key(&burner_private_key);
 
+        // Get the function.
         let function_native = program_native
             .get_function(&IdentifierNative::from_str(function).map_err(|e| e.to_string())?)
             .map_err(|e| e.to_string())?;
 
+        // Create sample inputs.
         let mut inputs: Vec<Value<CurrentNetwork>> = vec![];
         for input_type in function_native.input_types() {
             match input_type {
@@ -358,9 +355,9 @@ impl ProgramManager {
             }
         }
 
+        // Add the program to the process.
         let program_id = program_native.id();
         let edition = edition.unwrap_or(1);
-
         if program_id.to_string() != "credits.aleo" {
             if !process.contains_program(program_id) {
                 log("Adding program to the process");
@@ -368,22 +365,25 @@ impl ProgramManager {
             }
         }
 
+        // Resolve program imports.
         ProgramManager::resolve_imports(process, &program_native, imports)?;
 
+        // Create the authorization.
         let authorization = process
             .authorize::<CurrentAleo, StdRng>(&burner_private_key, program_id, function, inputs.iter(), rng)
             .map_err(|e| e.to_string())?;
 
+        // Get the ConsensusVersion.
         let node_url = url.as_deref().unwrap_or(DEFAULT_URL);
         let latest_height = if let Some(offline_query) = offline_query.as_ref() {
             offline_query.current_block_height().map_err(|e| e.to_string())?
         } else {
             latest_block_height(node_url).await.map_err(|err| err.to_string())?
         };
-
         let consensus_version =
             <CurrentNetwork as Network>::CONSENSUS_VERSION(latest_height).map_err(|err| err.to_string())?;
 
+        // Get the cost final cost
         let (minimum_cost, _) =
             execution_cost_for_authorization(&process, &authorization, consensus_version).map_err(|e| e.to_string())?;
 
@@ -419,63 +419,21 @@ impl ProgramManager {
 
 #[cfg(test)]
 mod tests {
-    use js_sys::Array;
-    use snarkvm_console::prelude::ConsensusVersion;
-    use snarkvm_synthesizer::process::execution_cost;
-    use wasm_bindgen::JsValue;
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    use crate::{
-        PrivateKey,
-        ProgramManager,
-        types::native::{ProcessNative, ProgramNative},
-    };
+    use crate::{ProgramManager, types::native::ProgramNative};
 
     #[wasm_bindgen_test]
     pub async fn test_estimate_execution_fee() {
-        for (function, inputs) in [
-            ("transfer_public", vec![
-                JsValue::from_str("aleo1q8zc0asncaw9d83ft2dynyqz08fcpq3p40depmrj4wjda28rdvrsvegg45"),
-                JsValue::from_str("1u64"),
-            ]),
-            ("bond_public", vec![
-                JsValue::from_str("aleo1q8zc0asncaw9d83ft2dynyqz08fcpq3p40depmrj4wjda28rdvrsvegg45"),
-                JsValue::from_str("aleo1q8zc0asncaw9d83ft2dynyqz08fcpq3p40depmrj4wjda28rdvrsvegg45"),
-                JsValue::from_str("1u64"),
-            ]),
-        ] {
-            let private_key = PrivateKey::new();
-
-            let mut process_native = ProcessNative::load_web().map_err(|err| err.to_string()).unwrap();
-            let process = &mut process_native;
-
+        for (function, cost) in [("transfer_public", 2725u64), ("transfer_public_to_private", 2304u64)] {
             let program = ProgramNative::credits().unwrap();
 
-            let resp = ProgramManager::execute_function_offline(
-                &private_key,
-                &program.to_string(),
-                function,
-                Array::from_iter(inputs.iter()),
-                false,
-                true,
-                None,
-                None,
-                None,
-                None,
-                None,
-                Some(1),
-            )
-            .await
-            .unwrap();
-
-            let (execution_estimate, _) =
-                execution_cost(&process, &resp.get_execution().unwrap(), ConsensusVersion::V3).unwrap();
             let authorization_estimate =
                 ProgramManager::estimate_execution_fee(&program.to_string(), function, None, None, None, Some(1))
                     .await
                     .unwrap();
 
-            assert_eq!(execution_estimate, authorization_estimate);
+            assert_eq!(authorization_estimate, cost);
         }
     }
 }

--- a/wasm/src/programs/manager/execute.rs
+++ b/wasm/src/programs/manager/execute.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
 use snarkvm_console::{
-    network::{ConsensusVersion, Network},
+    network::Network,
     program::{Value, ValueType},
 };
 use snarkvm_ledger_query::QueryTrait;

--- a/wasm/src/programs/manager/execute.rs
+++ b/wasm/src/programs/manager/execute.rs
@@ -40,9 +40,11 @@ use crate::{
     },
 };
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
-use snarkvm_console::network::{ConsensusVersion, Network};
+use snarkvm_console::{network::{ConsensusVersion, Network}, program::Value};
 use snarkvm_ledger_query::QueryTrait;
-use snarkvm_synthesizer::prelude::{InclusionVersion, cost_in_microcredits_v1, execution_cost_v1, execution_cost_v2};
+use snarkvm_synthesizer::{
+    prelude::{InclusionVersion, execution_cost, execution_cost_for_authorization},
+};
 
 use crate::types::native::{PrivateKeyNative, ViewKeyNative};
 use core::ops::Add;
@@ -298,8 +300,8 @@ impl ProgramManager {
     /// @param imports (optional) Provide a list of imports to use for the fee estimation in the
     /// form of a javascript object where the keys are a string of the program name and the values
     /// are a string representing the program source code \{ "hello.aleo": "hello.aleo source code" \}
-    /// @param proving_key (optional) Provide a verifying key to use for the fee estimation
-    /// @param verifying_key (optional) Provide a verifying key to use for the fee estimation
+    /// @param offline_query The offline query object used to insert the global state root and state paths needed to create
+    /// a valid inclusion proof offline.
     /// @returns {u64} Fee in microcredits
     #[wasm_bindgen(js_name = estimateExecutionFee)]
     #[allow(clippy::too_many_arguments)]
@@ -310,8 +312,6 @@ impl ProgramManager {
         inputs: Array,
         url: Option<String>,
         imports: Option<Object>,
-        proving_key: Option<ProvingKey>,
-        verifying_key: Option<VerifyingKey>,
         offline_query: Option<OfflineQuery>,
         edition: Option<u16>,
     ) -> Result<u64, String> {
@@ -325,30 +325,26 @@ impl ProgramManager {
 
         log("Check program imports are valid and add them to the process");
         let program_native = ProgramNative::from_str(program).map_err(|e| e.to_string())?;
+
+        let program_id = program_native.id();
+        let edition = edition.unwrap_or(1);
+
+        if program_id.to_string() != "credits.aleo" {
+            if !process.contains_program(program_id) {
+                log("Adding program to the process");
+                process.add_program_with_edition(&program_native, edition).map_err(|e| e.to_string())?;
+            }
+        }
+
         ProgramManager::resolve_imports(process, &program_native, imports)?;
         let rng = &mut StdRng::from_entropy();
 
-        log("Generating execution trace");
-        let edition = edition.unwrap_or(1);
-        let (_, mut trace) = execute_program!(
-            process,
-            process_inputs!(inputs),
-            program,
-            function,
-            private_key,
-            proving_key,
-            verifying_key,
-            rng,
-            edition
-        );
+        let authorization =
+            process.authorize::<CurrentAleo, StdRng>(private_key, program_id, function, inputs.iter().map(|v| Value::from_str(&v.as_string().unwrap_or_default())), rng).map_err(|e| e.to_string())?;
 
-        // Execute the program
+        
         let node_url = url.as_deref().unwrap_or(DEFAULT_URL);
-        let program = ProgramNative::from_str(program).map_err(|err| err.to_string())?;
-        let locator = program.id().to_string().add("/").add(function);
-
-        let block_height = if let Some(offline_query) = offline_query.as_ref() {
-            trace.prepare_async(offline_query).await.map_err(|err| err.to_string())?;
+        let latest_height = if let Some(offline_query) = offline_query.as_ref() {
             offline_query.current_block_height().map_err(|e| e.to_string())?
         } else {
             let function_name = IdentifierNative::from_str(function).map_err(|err| err.to_string())?;
@@ -358,38 +354,16 @@ impl ProgramManager {
                 SnapshotQuery::try_from_inputs(node_url, &program_native, &function_name, &view_key, &inputs.to_vec())
                     .await
                     .map_err(|err| err.to_string())?;
-            trace.prepare_async(&query).await.map_err(|err| err.to_string())?;
             query.current_block_height().map_err(|e| e.to_string())?
         };
-        let execution =
-            trace.prove_execution::<CurrentAleo, _>(&locator, VarunaVersion::V2, rng).map_err(|e| e.to_string())?;
 
-        // Get the storage cost in bytes for the program execution
-        log("Estimating cost");
-        let storage_cost = execution.size_in_bytes().map_err(|e| e.to_string())?;
+        let consensus_version =
+            <CurrentNetwork as Network>::CONSENSUS_VERSION(latest_height).map_err(|err| err.to_string())?;
 
-        // Compute the finalize cost in microcredits.
-        let mut finalize_cost = 0u64;
-        // Iterate over the transitions to accumulate the finalize cost.
-        for transition in execution.transitions() {
-            // Retrieve the function name, program id, and program.
-            let function_name = transition.function_name();
-            let program_id = transition.program_id();
-            let stack = process.get_stack(program_id).map_err(|e| e.to_string())?;
+        let (minimum_cost, _) =
+            execution_cost_for_authorization(&process, &authorization, consensus_version).map_err(|e| e.to_string())?;
 
-            // Calculate the finalize cost for the function identified in the transition
-            let cost = if block_height >= CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V2).unwrap() {
-                cost_in_microcredits_v2(&stack, function_name).map_err(|e| e.to_string())?
-            } else {
-                cost_in_microcredits_v1(&stack, function_name).map_err(|e| e.to_string())?
-            };
-
-            // Accumulate the finalize cost.
-            finalize_cost = finalize_cost
-                .checked_add(cost)
-                .ok_or("The finalize cost computation overflowed for an execution".to_string())?;
-        }
-        Ok(storage_cost + finalize_cost)
+        Ok(minimum_cost)
     }
 
     /// Estimate the finalize fee component for executing a function. This fee is additional to the

--- a/wasm/src/programs/manager/execute.rs
+++ b/wasm/src/programs/manager/execute.rs
@@ -416,3 +416,66 @@ impl ProgramManager {
         cost_in_microcredits_v2(&stack, &function_id).map_err(|e| e.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use js_sys::Array;
+    use snarkvm_console::prelude::ConsensusVersion;
+    use snarkvm_synthesizer::process::execution_cost;
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use crate::{
+        PrivateKey,
+        ProgramManager,
+        types::native::{ProcessNative, ProgramNative},
+    };
+
+    #[wasm_bindgen_test]
+    pub async fn test_estimate_execution_fee() {
+        for (function, inputs) in [
+            ("transfer_public", vec![
+                JsValue::from_str("aleo1q8zc0asncaw9d83ft2dynyqz08fcpq3p40depmrj4wjda28rdvrsvegg45"),
+                JsValue::from_str("1u64"),
+            ]),
+            ("bond_public", vec![
+                JsValue::from_str("aleo1q8zc0asncaw9d83ft2dynyqz08fcpq3p40depmrj4wjda28rdvrsvegg45"),
+                JsValue::from_str("aleo1q8zc0asncaw9d83ft2dynyqz08fcpq3p40depmrj4wjda28rdvrsvegg45"),
+                JsValue::from_str("1u64"),
+            ]),
+        ] {
+            let private_key = PrivateKey::new();
+
+            let mut process_native = ProcessNative::load_web().map_err(|err| err.to_string()).unwrap();
+            let process = &mut process_native;
+
+            let program = ProgramNative::credits().unwrap();
+
+            let resp = ProgramManager::execute_function_offline(
+                &private_key,
+                &program.to_string(),
+                function,
+                Array::from_iter(inputs.iter()),
+                false,
+                true,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(1),
+            )
+            .await
+            .unwrap();
+
+            let (execution_estimate, _) =
+                execution_cost(&process, &resp.get_execution().unwrap(), ConsensusVersion::V3).unwrap();
+            let authorization_estimate =
+                ProgramManager::estimate_execution_fee(&program.to_string(), function, None, None, None, Some(1))
+                    .await
+                    .unwrap();
+
+            assert_eq!(execution_estimate, authorization_estimate);
+        }
+    }
+}

--- a/wasm/src/programs/manager/join.rs
+++ b/wasm/src/programs/manager/join.rs
@@ -41,7 +41,7 @@ use crate::{
     },
 };
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
-use snarkvm_console::prelude::{ConsensusVersion, Network};
+use snarkvm_console::prelude::Network;
 use snarkvm_ledger_query::QueryTrait;
 use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost};
 use snarkvm_synthesizer_program::StackTrait;

--- a/wasm/src/programs/manager/join.rs
+++ b/wasm/src/programs/manager/join.rs
@@ -43,7 +43,7 @@ use crate::{
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
 use snarkvm_console::prelude::{ConsensusVersion, Network};
 use snarkvm_ledger_query::QueryTrait;
-use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost_v1, execution_cost_v2};
+use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost};
 use snarkvm_synthesizer_program::StackTrait;
 
 use js_sys::Array;

--- a/wasm/src/programs/manager/transfer.rs
+++ b/wasm/src/programs/manager/transfer.rs
@@ -41,7 +41,7 @@ use crate::{
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
 use snarkvm_console::prelude::{ConsensusVersion, Network};
 use snarkvm_ledger_query::QueryTrait;
-use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost_v1, execution_cost_v2};
+use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost};
 use snarkvm_synthesizer_program::StackTrait;
 
 use crate::types::native::{PrivateKeyNative, ViewKeyNative};

--- a/wasm/src/programs/manager/transfer.rs
+++ b/wasm/src/programs/manager/transfer.rs
@@ -39,7 +39,7 @@ use crate::{
     },
 };
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
-use snarkvm_console::prelude::{ConsensusVersion, Network};
+use snarkvm_console::prelude::Network;
 use snarkvm_ledger_query::QueryTrait;
 use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost};
 use snarkvm_synthesizer_program::StackTrait;

--- a/website/src/workers/worker.js
+++ b/website/src/workers/worker.js
@@ -181,7 +181,6 @@ self.addEventListener("message", (ev) => {
                 }
 
                 // Estimate the execution fee
-                const [provingKey, verifyingKey] = programManager.keyProvider.getKeys(cacheKey);
                 let executeFee = await aleo.ProgramManagerBase.estimateExecutionFee(
                     privateKeyObject,
                     remoteProgram,
@@ -189,8 +188,6 @@ self.addEventListener("message", (ev) => {
                     inputs,
                     url,
                     imports,
-                    provingKey,
-                    verifyingKey,
                     undefined,
                     edition
                 );

--- a/website/src/workers/worker.js
+++ b/website/src/workers/worker.js
@@ -182,10 +182,8 @@ self.addEventListener("message", (ev) => {
 
                 // Estimate the execution fee
                 let executeFee = await aleo.ProgramManagerBase.estimateExecutionFee(
-                    privateKeyObject,
                     remoteProgram,
                     aleoFunction,
-                    inputs,
                     url,
                     imports,
                     undefined,


### PR DESCRIPTION
## Motivation

Currently execution fees are estimated from an execution which is costly, the new `execution_cost_for_authorization` function in snarkVM allows estimation from the authorization which is less costly.

## Changes

Change the existing `estimateExecutionFee` function to generate the authorization, including generated inputs, and estimate the fee using that authorization with the new snarkVM `execution_cost_for_authorization` function.
The function now takes fewer arguments as `proving_key` and `verifying_key` are no longer needed. 

## Test Plan

A unit test has been introduced comparing the output of the fee estimation of an authorization to the output of the fee estimation of the execution itself.