### PR TITLE
[Fix] Re-add type:module in package.json

### DIFF
--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provablehq/wasm",
   "version": "0.9.11",
-  
+  "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [
     "The Provable Team"


### PR DESCRIPTION
## Motivation

The latest commit removed the `type: "module` from the `wasm's` `package.json`. This fixes that removal.