### PR TITLE
[Feature] Add formatting method  merkle proofs

### DIFF
--- a/sdk/src/integrations/sealance/merkle-tree.ts
+++ b/sdk/src/integrations/sealance/merkle-tree.ts
@@ -243,6 +243,21 @@ class SealanceMerkleTree {
         return { siblings: siblingPath, leaf_index: leafIndex };
     }
 
+    /**
+    * Generates a formatted exclusion proof suitable for Aleo transactions.
+    *
+    * @param proof - An array of two {sibling path, leafindex} objects.
+    * @returns String representation of the exclusion proof.
+    *
+    * @example
+    * ```typescript
+    * const tree = buildTree(leaves);
+    * const proof = getSiblingPath(tree, 0, 15);
+    * const proof2 = getSiblingPath(tree, 1, 15);
+    * const formattedProof = formatMerkleProof([proof, proof2]);
+    * // formattedProof = "[{ siblings: [0field, 1field, ...], leaf_index: 0u32 }, { siblings: [0field, 2field, ...], leaf_index: 1u32 }]"
+    * ```
+    */
     formatMerkleProof(proof: { siblings: bigint[]; leaf_index: number }[]): string {
         const formatted = proof.map(item => {
             const siblings = item.siblings.map(s => `${s}field`).join(", ");

--- a/sdk/src/integrations/sealance/merkle-tree.ts
+++ b/sdk/src/integrations/sealance/merkle-tree.ts
@@ -242,6 +242,15 @@ class SealanceMerkleTree {
 
         return { siblings: siblingPath, leaf_index: leafIndex };
     }
+
+    formatMerkleProof(proof: { siblings: bigint[]; leaf_index: number }[]): string {
+        const formatted = proof.map(item => {
+            const siblings = item.siblings.map(s => `${s}field`).join(", ");
+            return `{ siblings: [${siblings}], leaf_index: ${item.leaf_index}u32 }`;
+        }).join(", ");
+  
+        return `[${formatted}]`;
+    }
 }
 
 export { SealanceMerkleTree };

--- a/sdk/tests/sealance-merkle-tree.test.ts
+++ b/sdk/tests/sealance-merkle-tree.test.ts
@@ -141,12 +141,14 @@ describe("merkle_tree lib, getSiblingPath", () => {
     // Get sibling path for leaf index 1 (odd index)
     // This will test the "index - 1" branch of the sibling index calculation
     const proof = sealance.getSiblingPath(tree, 1, 15);
+    const formattedProof = sealance.formatMerkleProof([proof, proof]);
 
-    expect(proof).to.not.be.undefined;
+  expect(proof).to.not.be.undefined;
   expect(proof.leaf_index).to.equal(1);
   expect(proof.siblings).to.not.be.undefined;
   expect(proof.siblings).to.have.lengthOf(15); // Depth 15
   expect(proof.siblings[0]).to.equal(2n); // The leaf itself (index 1 = "2field")
   expect(proof.siblings[1]).to.equal(1n); // Its sibling (index 0 = "1field")
+  expect(formattedProof).to.equal("[{ siblings: [2field, 1field, 4560646903308595113151029585344265575242682454899063992850623350939538444867field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field], leaf_index: 1u32 }, { siblings: [2field, 1field, 4560646903308595113151029585344265575242682454899063992850623350939538444867field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field], leaf_index: 1u32 }]");
   });
 });


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR adds a formatting method to the Sealance Merkle tree file so that the wallet can output correctly formatted exclusion proofs that are usable in Aleo transactions.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Unit test added to ensure string output is a correctly formatted merkle exclusion proof.
