### PR TITLE
[Feature] Add util function for converting string arrays to big int arrays to SealanceMerkleTree class

### DIFF
--- a/sdk/src/integrations/sealance/merkle-tree.ts
+++ b/sdk/src/integrations/sealance/merkle-tree.ts
@@ -121,7 +121,7 @@ class SealanceMerkleTree {
     * @param tree - Array of decimal string representations of U256 numbers.
     * @returns Array of BigInts.
     */
-    convertTreeToU256(tree: string[]): bigint[] {
+    convertTreeToBigInt(tree: string[]): bigint[] {
         return tree.map((element) => {
             try {
                 // decimal string → native bigint
@@ -277,7 +277,7 @@ class SealanceMerkleTree {
     formatMerkleProof(proof: { siblings: bigint[]; leaf_index: number }[]): string {
         const formatted = proof.map(item => {
             const siblings = item.siblings.map(s => `${s}field`).join(", ");
-            return `{ siblings: [${siblings}], leaf_index: ${item.leaf_index}u32 }`;
+            return `{siblings: [${siblings}], leaf_index: ${item.leaf_index}u32}`;
         }).join(", ");
   
         return `[${formatted}]`;

--- a/sdk/src/integrations/sealance/merkle-tree.ts
+++ b/sdk/src/integrations/sealance/merkle-tree.ts
@@ -116,6 +116,22 @@ class SealanceMerkleTree {
         return tree.map(element => BigInt(element.slice(0, element.length - "field".length)));
     }
 
+    /** Converts an array of decimal string representations of U256 numbers to an array of BigInts.
+    *
+    * @param tree - Array of decimal string representations of U256 numbers.
+    * @returns Array of BigInts.
+    */
+    convertTreeToU256(tree: string[]): bigint[] {
+        return tree.map((element) => {
+            try {
+                // decimal string → native bigint
+                return BigInt(element);
+            } catch {
+                throw new Error(`Invalid decimal U256 string: ${element}`);
+            }
+        });
+    }
+
     /**
     * Converts Aleo addresses to field elements, sorts them, pads with zero fields, and returns an array. This prepares addresses for Merkle tree construction.
     *

--- a/sdk/tests/sealance-merkle-tree.test.ts
+++ b/sdk/tests/sealance-merkle-tree.test.ts
@@ -149,6 +149,19 @@ describe("merkle_tree lib, getSiblingPath", () => {
   expect(proof.siblings).to.have.lengthOf(15); // Depth 15
   expect(proof.siblings[0]).to.equal(2n); // The leaf itself (index 1 = "2field")
   expect(proof.siblings[1]).to.equal(1n); // Its sibling (index 0 = "1field")
-  expect(formattedProof).to.equal("[{ siblings: [2field, 1field, 4560646903308595113151029585344265575242682454899063992850623350939538444867field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field], leaf_index: 1u32 }, { siblings: [2field, 1field, 4560646903308595113151029585344265575242682454899063992850623350939538444867field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field], leaf_index: 1u32 }]");
+  expect(formattedProof).to.equal("[{siblings: [2field, 1field, 4560646903308595113151029585344265575242682454899063992850623350939538444867field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field], leaf_index: 1u32}, {siblings: [2field, 1field, 4560646903308595113151029585344265575242682454899063992850623350939538444867field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field], leaf_index: 1u32}]");
+  });
+});
+
+describe("merkle_tree lib, formatMerkleProof", () => {
+  it("should format merkle proof correctly", () => {
+    const tree_string = ["0","3501665755452795161867664882580888971213780722176652848275908626939553697821","4539470720491009302557179633742244202521723448302096289013203539461297095738","7426353931016374702593127301815460123689343416970811802742952620156952318730","7052697765310872540032307615262912043079143561812812402660738198777516992718","7162588494104628985065247846816902886874444240334527780589295712502521092900","7179654795269183001911849426990084952297107287660910339902947270666145459461"];
+    const tree = sealance.convertTreeToBigInt(tree_string);
+    const indices = sealance.getLeafIndices(tree, "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px");
+    const proof1 = sealance.getSiblingPath(tree, indices[0], 15);
+    const proof2 = sealance.getSiblingPath(tree, indices[1], 15);
+    const formattedProof = sealance.formatMerkleProof([proof1, proof2]);
+
+    expect(formattedProof).to.equal("[{siblings: [0field, 3501665755452795161867664882580888971213780722176652848275908626939553697821field, 7162588494104628985065247846816902886874444240334527780589295712502521092900field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field], leaf_index: 0u32}, {siblings: [3501665755452795161867664882580888971213780722176652848275908626939553697821field, 0field, 7162588494104628985065247846816902886874444240334527780589295712502521092900field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field, 0field], leaf_index: 1u32}]");
   });
 });


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Wallets and UIs will be required to calculate Merkle exclusion proofs for compliant private transfers.  The API endpoint which calculates the current freeze list Merkle tree returns an array of strings.  In order for the wallet to use this object in order to generate exclusion proofs, the array must be converted to an array of big ints.  This PR adds a util function to the SealanceMerkleTree class to enable conversion between a string array to a big int array. 

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Unit tests were added which check that an exclusion proof is properly formatted when using a string array representation of the Merkle tree as an input.

Build the SDK locally and run `yarn test:sdk`.
