### PR TITLE
build: update checkout action to v6

### DIFF
--- a/.github/workflows/update-snarkvm.yml
+++ b/.github/workflows/update-snarkvm.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout SDK
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: mainnet
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates `actions/checkout` to v6 in CI workflows. No code changes.

https://github.com/actions/checkout/releases/tag/v6.0.0