### PR TITLE
[Fix] Change use of `getProgramObject` to `createProgramFromSource` in on-chain execution for provable.tools

### DIFF
--- a/website/src/workers/worker.js
+++ b/website/src/workers/worker.js
@@ -101,7 +101,7 @@ self.addEventListener("message", (ev) => {
             try {
                 const privateKeyObject = aleo.PrivateKey.from_string(privateKey)
                 // Ensure the program is valid and that it contains the function specified
-                const program = await programManager.networkClient.getProgramObject(remoteProgram);
+                const program = await programManager.createProgramFromSource(remoteProgram);
                 const program_id = program.id();
                 if (!program.hasFunction(aleoFunction)) {
                     throw new Error(`Program ${program_id} does not contain function ${aleoFunction}`);


### PR DESCRIPTION
## Motivation

The current setup breaks when trying to execute on-chain. A request is made with the entire program source in the url. This PR fixes that by switching its use of `getProgramObject` for `createProgramFromSource`.
