### PR TITLE
[Feature] Replace API key with JWT in submitProvingRequest method

### DIFF
--- a/docs/api_reference/sdk-src_network-client.md
+++ b/docs/api_reference/sdk-src_network-client.md
@@ -1040,6 +1040,20 @@ __*return*__ | `Promise.<string>` | *The solution id of the submitted solution o
 
 ---
 
+### `refreshJwt(apiKey, consumerId) ► Promise.<string>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Refreshes the JWT by making a POST request to /jwts/{consumer_id}
+
+Parameters | Type | Description
+--- | --- | ---
+__apiKey__ | `string` | *The API key for authentication.*
+__consumerId__ | `string` | *The consumer ID associated with the API key.*
+__*return*__ | `Promise.<string>` | *The JWT token*
+
+---
+
 ### `submitProvingRequest(options) ► Promise.<ProvingResponse>`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -2187,5 +2201,19 @@ Parameters | Type | Description
 __url__ | `undefined` | *The URL to POST to.*
 __options__ | `undefined` | *The RequestInit options for the POST request.*
 __*return*__ | `undefined` | *The Response object from the POST request.*
+
+---
+
+### `refreshJwt(apiKey, consumerId) ► Promise.<string>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Refreshes the JWT by making a POST request to /jwts/{consumer_id}
+
+Parameters | Type | Description
+--- | --- | ---
+__apiKey__ | `string` | *The API key for authentication.*
+__consumerId__ | `string` | *The consumer ID associated with the API key.*
+__*return*__ | `Promise.<string>` | *The JWT token*
 
 ---

--- a/docs/api_reference/sdk-src_network-client.md
+++ b/docs/api_reference/sdk-src_network-client.md
@@ -1040,7 +1040,7 @@ __*return*__ | `Promise.<string>` | *The solution id of the submitted solution o
 
 ---
 
-### `refreshJwt(apiKey, consumerId) ► Promise.<string>`
+### `refreshJwt(apiKey, consumerId) ► Promise.<JwtData>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
@@ -1050,7 +1050,7 @@ Parameters | Type | Description
 --- | --- | ---
 __apiKey__ | `string` | *The API key for authentication.*
 __consumerId__ | `string` | *The consumer ID associated with the API key.*
-__*return*__ | `Promise.<string>` | *The JWT token*
+__*return*__ | `Promise.<JwtData>` | *The JWT token and expiration time*
 
 ---
 
@@ -2204,7 +2204,7 @@ __*return*__ | `undefined` | *The Response object from the POST request.*
 
 ---
 
-### `refreshJwt(apiKey, consumerId) ► Promise.<string>`
+### `refreshJwt(apiKey, consumerId) ► Promise.<JwtData>`
 
 ![modifier: private](images/badges/modifier-private.svg)
 
@@ -2214,6 +2214,6 @@ Parameters | Type | Description
 --- | --- | ---
 __apiKey__ | `string` | *The API key for authentication.*
 __consumerId__ | `string` | *The consumer ID associated with the API key.*
-__*return*__ | `Promise.<string>` | *The JWT token*
+__*return*__ | `Promise.<JwtData>` | *The JWT token and expiration time*
 
 ---

--- a/docs/api_reference/sdk-src_wasm.md
+++ b/docs/api_reference/sdk-src_wasm.md
@@ -126,6 +126,19 @@ __*return*__ | [Address](sdk-src_wasm.md) | *Address corresponding to the view k
 
 ---
 
+### `fromProgramId(program_id) ► Address`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get the address of a program based on the program ID.
+
+Parameters | Type | Description
+--- | --- | ---
+__program_id__ | `string` | *The program ID string.*
+__*return*__ | [Address](sdk-src_wasm.md) | *The address corresponding to the program ID.*
+
+---
+
 ### `from_compute_key(compute_key) ► Address`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -118,3 +118,5 @@ export const RECORD_DOMAIN = "RecordScannerV0";
  * Zero address on Aleo blockchain that corresponds to field element 0. Used as padding in Merkle trees and as a sentinel value.
  */
 export const ZERO_ADDRESS = "aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc";
+
+export const FIVE_MINUTES = 5 * 60 * 1000; // 5 minutes in milliseconds

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1,5 +1,6 @@
 import { get, post, parseJSON, logAndThrow, retryWithBackoff, environment } from "./utils.js";
 import { Account } from "./account.js";
+import { FIVE_MINUTES } from "./constants.js";
 import { BlockJSON } from "./models/blockJSON.js";
 import { TransactionJSON } from "./models/transaction/transactionJSON.js";
 import {
@@ -60,6 +61,8 @@ interface DelegatedProvingParams {
  *
  * // Connection to a public beacon node
  * const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+ * const apiKey = process.env.apiKey;
+ * const consumerId = process.env.consumerId;
  * const publicNetworkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined, account);
  */
 class AleoNetworkClient {
@@ -1692,7 +1695,7 @@ class AleoNetworkClient {
         let jwtData = options.jwtData ?? this.jwtData
 
         // Check if JWT is expired or missing
-        const bufferTime = 5 * 60 * 1000; // 5 minutes buffer
+        const bufferTime = FIVE_MINUTES; // 5 minutes buffer
         const isExpired = jwtData && Date.now() >= jwtData.expiration - bufferTime;
         if (!jwtData || isExpired) {
             if (options.apiKey && options.consumerId) {
@@ -1700,13 +1703,10 @@ class AleoNetworkClient {
                 // Update both the class and the options with the new JWT
                 this.jwtData = jwtData;
                 options.jwtData = jwtData;
-            
-        } else {
+            } else {
                 throw new Error('JWT or both apiKey and consumerId are required');
+            }
         }
-    }
-        
-
 
         const headers: Record<string, string> = {
             ...this.headers,

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -22,18 +22,31 @@ interface AleoNetworkClientOptions {
 }
 
 /**
+ * Interface for the JWT data.
+ * 
+ * @property jwt {string} The JWT token string.
+ * @property expiration {number} The expiration time of the JWT token in UNIX timestamp format.
+ */
+interface JWTData {
+    jwt: string;
+    expiration: number;
+}
+
+/**
  * Options for submitting a proving request.
  *
  * @property provingRequest {ProvingRequest | string} The proving request being submitted to the network.
  * @property url {string} The URL of the delegated proving service.
  * @property apiKey {string} The API key used for generating a JWT.
  * @property consumerId {string} The consumer ID associated with the API key.
+ * @property jwt {string} An optional JWT token used for authenticating with the proving service.
  */
 interface DelegatedProvingParams {
-    provingRequest: ProvingRequest | string;
-    url?: string;
-    apiKey?: string;
-    consumerId?: string;
+  provingRequest: ProvingRequest | string;
+  url?: string;
+  apiKey?: string;
+  consumerId?: string;
+  jwtData?: JWTData;
 }
 
 /**
@@ -1633,28 +1646,30 @@ class AleoNetworkClient {
      * 
      * @param {string} apiKey - The API key for authentication.
      * @param {string} consumerId - The consumer ID associated with the API key.
-     * @returns {Promise<string>} The JWT token
+     * @returns {Promise<JwtData>} The JWT token and expiration time
      */
-    private async refreshJwt(apiKey: string, consumerId: string): Promise<string> {
+    private async refreshJwt(apiKey: string, consumerId: string): Promise<JWTData> {
         if (!apiKey || !consumerId) {
             throw new Error('API key and consumer ID are required to refresh JWT');
         }
-
         const response = await post(
             `https://api.provable.com/jwts/${consumerId}`,
             {
-            headers: {
-                'X-Provable-API-Key': apiKey
+                headers: {
+                    'X-Provable-API-Key': apiKey
                 }
             }
         );
-
         const authHeader = response.headers.get('authorization');
         if (!authHeader) {
             throw new Error('No authorization header in JWT refresh response');
         }
-
-        return authHeader;
+        const body = await response.json();
+        
+        return {
+            jwt: authHeader,
+            expiration: body.exp * 1000 // Convert to milliseconds
+        };
     }
 
     /**
@@ -1669,33 +1684,39 @@ class AleoNetworkClient {
             ? options.provingRequest.toString()
             : options.provingRequest;
 
-        const apiKey = options.apiKey;
-        const consumerId = options.consumerId;
+        let jwtData = options.jwtData;
 
-        // Build headers with proper auth fallback
-        const headers: Record<string, string> = {
-          ...this.headers,
-          "X-ALEO-METHOD": "submitProvingRequest",
-          "Content-Type": "application/json"
-        };
-
-        // Refresh JWT if apiKey and consumerId are provided
-        if (apiKey && consumerId) {
-          try {
-            const jwt = await this.refreshJwt(apiKey, consumerId);
-            headers["Authorization"] = `${jwt}`;
-          } catch (error) {
-            throw new Error(`Failed to refresh JWT: ${error instanceof Error ? error.message : 'Unknown error'}`);
-          }
+        // Check if JWT is expired or missing
+        if (jwtData) {
+            if (Date.now() >= jwtData.expiration) {
+            jwtData = await this.refreshJwt(options.apiKey!, options.consumerId!);
+            options.jwtData = jwtData;
+            }
+        } else {
+            // If no JWT provided, get one
+            if (options.apiKey && options.consumerId) {
+            jwtData = await this.refreshJwt(options.apiKey, options.consumerId);
+            options.jwtData = jwtData;
+            } else {
+            throw new Error('JWT or both apiKey and consumerId are required');
+            }
         }
-        console.log("Headers are:", headers);
+
+        const headers: Record<string, string> = {
+            ...this.headers,
+            "X-ALEO-METHOD": "submitProvingRequest",
+            "Content-Type": "application/json",
+        };
+        if (jwtData?.jwt) {
+            headers["Authorization"] = jwtData.jwt;
+        }
 
         try {
             const response = await retryWithBackoff(() =>
-                post(`${proverUri}`, {
+            post(`${proverUri}`, {
                 body: provingRequestString,
-                 headers
-                })
+                headers
+            })
             );
             const responseText = await response.text();
             return parseJSON(responseText);

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -69,6 +69,8 @@ class AleoNetworkClient {
     ctx: { [key: string]: string };
     verboseErrors: boolean;
     readonly network: string;
+    apiKey?: string;
+    consumerId?: string;
     jwtData?: JWTData;
 
     constructor(host: string, options?: AleoNetworkClientOptions) {
@@ -1685,6 +1687,8 @@ class AleoNetworkClient {
             ? options.provingRequest.toString()
             : options.provingRequest;
 
+        const apiKey = options.apiKey ?? this.apiKey;
+        const consumerId = options.consumerId ?? this.consumerId;    
         let jwtData = options.jwtData ?? this.jwtData
 
         // Check if JWT is expired or missing
@@ -1692,7 +1696,7 @@ class AleoNetworkClient {
         const isExpired = jwtData && Date.now() >= jwtData.expiration - bufferTime;
         if (!jwtData || isExpired) {
             if (options.apiKey && options.consumerId) {
-                jwtData = await this.refreshJwt(options.apiKey!, options.consumerId!);
+                jwtData = await this.refreshJwt(apiKey!, consumerId!);
                 // Update both the class and the options with the new JWT
                 this.jwtData = jwtData;
                 options.jwtData = jwtData;

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -69,6 +69,7 @@ class AleoNetworkClient {
     ctx: { [key: string]: string };
     verboseErrors: boolean;
     readonly network: string;
+    jwtData?: JWTData;
 
     constructor(host: string, options?: AleoNetworkClientOptions) {
         this.host = host + "/%%NETWORK%%";
@@ -1684,24 +1685,24 @@ class AleoNetworkClient {
             ? options.provingRequest.toString()
             : options.provingRequest;
 
-        let jwtData = options.jwtData;
+        let jwtData = options.jwtData ?? this.jwtData
 
         // Check if JWT is expired or missing
         const bufferTime = 5 * 60 * 1000; // 5 minutes buffer
-        if (jwtData) {
-            if (Date.now() >= jwtData.expiration - bufferTime) {
-                jwtData = await this.refreshJwt(options.apiKey!, options.consumerId!);
-                options.jwtData = jwtData;
-            }
-        } else {
-            // If no JWT provided, get one
+        const isExpired = jwtData && Date.now() >= jwtData.expiration - bufferTime;
+        if (!jwtData || isExpired) {
             if (options.apiKey && options.consumerId) {
-                jwtData = await this.refreshJwt(options.apiKey, options.consumerId);
+                jwtData = await this.refreshJwt(options.apiKey!, options.consumerId!);
+                // Update both the class and the options with the new JWT
+                this.jwtData = jwtData;
                 options.jwtData = jwtData;
-            } else {
+            
+        } else {
                 throw new Error('JWT or both apiKey and consumerId are required');
-            }
         }
+    }
+        
+
 
         const headers: Record<string, string> = {
             ...this.headers,

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1652,7 +1652,7 @@ class AleoNetworkClient {
 
         try {
             const response = await retryWithBackoff(() =>
-                post(`${proverUri}/prove`, {
+                post(`${proverUri}`, {
                 body: provingRequestString,
                  headers
                 })

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1687,18 +1687,19 @@ class AleoNetworkClient {
         let jwtData = options.jwtData;
 
         // Check if JWT is expired or missing
+        const bufferTime = 5 * 60 * 1000; // 5 minutes buffer
         if (jwtData) {
-            if (Date.now() >= jwtData.expiration) {
-            jwtData = await this.refreshJwt(options.apiKey!, options.consumerId!);
-            options.jwtData = jwtData;
+            if (Date.now() >= jwtData.expiration - bufferTime) {
+                jwtData = await this.refreshJwt(options.apiKey!, options.consumerId!);
+                options.jwtData = jwtData;
             }
         } else {
             // If no JWT provided, get one
             if (options.apiKey && options.consumerId) {
-            jwtData = await this.refreshJwt(options.apiKey, options.consumerId);
-            options.jwtData = jwtData;
+                jwtData = await this.refreshJwt(options.apiKey, options.consumerId);
+                options.jwtData = jwtData;
             } else {
-            throw new Error('JWT or both apiKey and consumerId are required');
+                throw new Error('JWT or both apiKey and consumerId are required');
             }
         }
 

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -26,12 +26,12 @@ interface AleoNetworkClientOptions {
  *
  * @property provingRequest {ProvingRequest | string} The proving request being submitted to the network.
  * @property url {string} The URL of the delegated proving service.
- * @property apiKey {string} The API key to use for authentication.
+ * @property jwt {string} The JWT used for authentication.
  */
 interface DelegatedProvingParams {
     provingRequest: ProvingRequest | string;
     url?: string;
-    apiKey?: string;
+    jwt?: string;
 }
 
 /**
@@ -1646,8 +1646,8 @@ class AleoNetworkClient {
         };
 
         // Add auth header based on what's available
-        if (options.apiKey) {
-          headers["X-Provable-API-Key"] = options.apiKey;
+        if (options.jwt) {
+          headers["Authorization"] = `Bearer ${options.jwt}`;
         }
 
         try {

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -26,12 +26,14 @@ interface AleoNetworkClientOptions {
  *
  * @property provingRequest {ProvingRequest | string} The proving request being submitted to the network.
  * @property url {string} The URL of the delegated proving service.
- * @property jwt {string} The JWT used for authentication.
+ * @property apiKey {string} The API key used for generating a JWT.
+ * @property consumerId {string} The consumer ID associated with the API key.
  */
 interface DelegatedProvingParams {
     provingRequest: ProvingRequest | string;
     url?: string;
-    jwt?: string;
+    apiKey?: string;
+    consumerId?: string;
 }
 
 /**
@@ -1627,6 +1629,32 @@ class AleoNetworkClient {
     }
 
     /**
+     * Refreshes the JWT by making a POST request to /jwts/{consumer_id}
+     * @returns {Promise<string>} The JWT token
+     */
+    private async refreshJwt(apiKey: string, consumerId: string): Promise<string> {
+        if (!apiKey || !consumerId) {
+            throw new Error('API key and consumer ID are required to refresh JWT');
+        }
+
+        const response = await post(
+            `https://api.provable.com/jwts/${consumerId}`,
+            {
+            headers: {
+                'X-Provable-API-Key': apiKey
+                }
+            }
+        );
+
+        const authHeader = response.headers.get('authorization');
+        if (!authHeader) {
+            throw new Error('No authorization header in JWT refresh response');
+        }
+
+        return authHeader;
+    }
+
+    /**
      * Submit a `ProvingRequest` to a remote proving service for delegated proving. If the broadcast flag of the `ProvingRequest` is set to `true` the remote service will attempt to broadcast the result `Transaction` on behalf of the requestor.
      *
      * @param {DelegatedProvingParams} options - The optional parameters required to submit a proving request.
@@ -1638,6 +1666,9 @@ class AleoNetworkClient {
             ? options.provingRequest.toString()
             : options.provingRequest;
 
+        const apiKey = options.apiKey;
+        const consumerId = options.consumerId;
+
         // Build headers with proper auth fallback
         const headers: Record<string, string> = {
           ...this.headers,
@@ -1645,10 +1676,16 @@ class AleoNetworkClient {
           "Content-Type": "application/json"
         };
 
-        // Add auth header based on what's available
-        if (options.jwt) {
-          headers["Authorization"] = `Bearer ${options.jwt}`;
+        // Refresh JWT if apiKey and consumerId are provided
+        if (apiKey && consumerId) {
+          try {
+            const jwt = await this.refreshJwt(apiKey, consumerId);
+            headers["Authorization"] = `${jwt}`;
+          } catch (error) {
+            throw new Error(`Failed to refresh JWT: ${error instanceof Error ? error.message : 'Unknown error'}`);
+          }
         }
+        console.log("Headers are:", headers);
 
         try {
             const response = await retryWithBackoff(() =>

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1630,6 +1630,9 @@ class AleoNetworkClient {
 
     /**
      * Refreshes the JWT by making a POST request to /jwts/{consumer_id}
+     * 
+     * @param {string} apiKey - The API key for authentication.
+     * @param {string} consumerId - The consumer ID associated with the API key.
      * @returns {Promise<string>} The JWT token
      */
     private async refreshJwt(apiKey: string, consumerId: string): Promise<string> {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR modifies the `submitProvingRequest` method to accept a jwt instead of an API key.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

The following script was used to test a DPS request:
```typescript
import {Account, initThreadPool, ProgramManager, AleoKeyProvider, OfflineKeyProvider} from "@provablehq/sdk";

await initThreadPool();

const apiKey= "{YOUR_API_KEY_HERE}";
const consumerId = "{YOUR_CONSUMER_ID_HERE}";
const endpoint = " https://api.provable.com/prove/testnet/prove";


async function localProgramExecution() {
    const programManager = new ProgramManager();

    // Create a temporary account for the execution of the program
    const account = new Account({privateKey: "{YOUR_PRIVATE_KEY_HERE}"});
    programManager.setAccount(account);

    // Create a key provider in order to re-use the same key for each execution
    const keyProvider = new AleoKeyProvider();
    const offlineKeyProvider = new OfflineKeyProvider();
    keyProvider.useCache(true);
    programManager.setKeyProvider(keyProvider);

    // Build a proving request for the "spin" function of "puzzle_spinner_v002.aleo".
    const provingRequest = await programManager.provingRequest({
        programName: "credits.aleo",
        functionName: "transfer_public",
        baseFee: 0.01,
        priorityFee: 0,
        privateFee: false,
        inputs: [
            "{YOUR_ADDRESS_HERE}",
            "1000000u64",
        ],
        broadcast: false,
    });

    // Submit the proving request to the network client.
    const provingResponse = await programManager.networkClient.submitProvingRequest({
        provingRequest: provingRequest,
        url: endpoint,
        apiKey: apiKey,
        consumerId: consumerId,
});
    console.log("Proving response:", provingResponse);
}

const start = Date.now();
console.log("Starting execute!");
await localProgramExecution();
console.log("Execute finished!", Date.now() - start);
```
