### PR TITLE
Fix - Prevent excessive API calls in getProgramImports due to circular dependencies

### DIFF
--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1059,19 +1059,40 @@ class AleoNetworkClient {
      * assert.deepStrictEqual(programImports, expectedImports);
      */
     async getProgramImports(inputProgram: Program | string): Promise<ProgramImports> {
-        try {
-            this.ctx = { "X-ALEO-METHOD": "getProgramImports" };
-            const imports: ProgramImports = {};
+            try {
+                this.ctx = { "X-ALEO-METHOD": "getProgramImports" };
+                const imports: ProgramImports = {};
+                const visited = new Set<string>();
+                
+                await this._getProgramImportsRecursive(inputProgram, imports, visited);
+                
+                return imports;
+            } catch (error: any) {
+                logAndThrow("Error fetching program imports: " + error.message);
+            } finally {
+                this.ctx = {};
+            }
+        }
 
+        private async _getProgramImportsRecursive(
+            inputProgram: Program | string,
+            imports: ProgramImports,
+            visited: Set<string>
+        ): Promise<void> {
             // Normalize input to a Program object
             let program: Program;
+            let programId: string;
+            
             if (inputProgram instanceof Program) {
                 program = inputProgram;
+                programId = program.id();
             } else {
                 try {
                     program = Program.fromString(inputProgram);
+                    programId = program.id();
                 } catch {
                     try {
+                        programId = inputProgram;
                         program = await this.getProgramObject(inputProgram);
                     } catch (error2) {
                         throw new Error(
@@ -1081,6 +1102,12 @@ class AleoNetworkClient {
                 }
             }
 
+            // Skip if already processed (prevents infinite recursion on circular dependencies)
+            if (visited.has(programId)) {
+                return;
+            }
+            visited.add(programId);
+
             // Get the list of programs that the program imports
             const importList = program.getImports();
 
@@ -1089,24 +1116,13 @@ class AleoNetworkClient {
                 const import_id = importList[i];
                 if (!imports.hasOwnProperty(import_id)) {
                     const programSource = <string>await this.getProgram(import_id);
-                    const nestedImports = <ProgramImports>await this.getProgramImports(import_id);
-
-                    for (const key in nestedImports) {
-                        if (!imports.hasOwnProperty(key)) {
-                            imports[key] = nestedImports[key];
-                        }
-                    }
-
                     imports[import_id] = programSource;
+                    
+                    // Recursively process nested imports with shared visited set
+                    // Pass the program source to avoid re-fetching
+                    await this._getProgramImportsRecursive(programSource, imports, visited);
                 }
             }
-
-            return imports;
-        } catch (error: any) {
-            logAndThrow("Error fetching program imports: " + error.message);
-        } finally {
-            this.ctx = {};
-        }
     }
 
 

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1085,18 +1085,13 @@ class AleoNetworkClient {
 
             // Normalize input to a Program object
             let program: Program;
-            let programId: string;
-            
             if (inputProgram instanceof Program) {
                 program = inputProgram;
-                programId = program.id();
             } else {
                 try {
                     program = Program.fromString(inputProgram);
-                    programId = program.id();
                 } catch {
                     try {
-                        programId = inputProgram;
                         program = await this.getProgramObject(inputProgram);
                     } catch (error2) {
                         throw new Error(
@@ -1104,11 +1099,6 @@ class AleoNetworkClient {
                         );
                     }
                 }
-            }
-
-            // Skip if already processed (prevents infinite recursion on circular dependencies)
-            if (imports.hasOwnProperty(programId)) {
-                return imports;
             }
 
             // Get the list of programs that the program imports
@@ -1119,10 +1109,15 @@ class AleoNetworkClient {
                 const import_id = importList[i];
                 if (!imports.hasOwnProperty(import_id)) {
                     const programSource = <string>await this.getProgram(import_id);
+                    const nestedImports = <ProgramImports>await this.getProgramImports(programSource, imports);
+
+                    for (const key in nestedImports) {
+                        if (!imports.hasOwnProperty(key)) {
+                            imports[key] = nestedImports[key];
+                        }
+                    }
+
                     imports[import_id] = programSource;
-                    
-                    // Recursively process nested imports, passing the shared imports object
-                    await this.getProgramImports(programSource, imports);
                 }
             }
 

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1079,27 +1079,10 @@ class AleoNetworkClient {
      * programImports = await networkClient.getProgramImports(double_test);
      * assert.deepStrictEqual(programImports, expectedImports);
      */
-    async getProgramImports(inputProgram: Program | string): Promise<ProgramImports> {
-            try {
-                this.ctx = { "X-ALEO-METHOD": "getProgramImports" };
-                const imports: ProgramImports = {};
-                const visited = new Set<string>();
-                
-                await this._getProgramImportsRecursive(inputProgram, imports, visited);
-                
-                return imports;
-            } catch (error: any) {
-                logAndThrow("Error fetching program imports: " + error.message);
-            } finally {
-                this.ctx = {};
-            }
-        }
+    async getProgramImports(inputProgram: Program | string, imports: ProgramImports = {}): Promise<ProgramImports> {
+        try {
+            this.ctx = { "X-ALEO-METHOD": "getProgramImports" };
 
-        private async _getProgramImportsRecursive(
-            inputProgram: Program | string,
-            imports: ProgramImports,
-            visited: Set<string>
-        ): Promise<void> {
             // Normalize input to a Program object
             let program: Program;
             let programId: string;
@@ -1124,10 +1107,9 @@ class AleoNetworkClient {
             }
 
             // Skip if already processed (prevents infinite recursion on circular dependencies)
-            if (visited.has(programId)) {
-                return;
+            if (imports.hasOwnProperty(programId)) {
+                return imports;
             }
-            visited.add(programId);
 
             // Get the list of programs that the program imports
             const importList = program.getImports();
@@ -1139,11 +1121,17 @@ class AleoNetworkClient {
                     const programSource = <string>await this.getProgram(import_id);
                     imports[import_id] = programSource;
                     
-                    // Recursively process nested imports with shared visited set
-                    // Pass the program source to avoid re-fetching
-                    await this._getProgramImportsRecursive(programSource, imports, visited);
+                    // Recursively process nested imports, passing the shared imports object
+                    await this.getProgramImports(programSource, imports);
                 }
             }
+
+            return imports;
+        } catch (error: any) {
+            logAndThrow("Error fetching program imports: " + error.message);
+        } finally {
+            this.ctx = {};
+        }
     }
 
 

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -732,7 +732,10 @@ describe("NodeConnection", () => {
     });
 
     describe("getProgramImports", () => {
-        it("should not fetch the same program multiple times with overlapping imports", async () => {
+        // Skip on mainnet - amm_orcl_intrfc_v.aleo only exists on testnet
+        const testFn = connection.network === "mainnet" ? it.skip : it;
+        
+        testFn("should not fetch the same program multiple times with overlapping imports", async () => {
             // Track all calls to getProgram to detect duplicates
             const fetchedPrograms = new Map<string, number>();
             const originalGetProgram = connection.getProgram.bind(connection);

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -730,4 +730,38 @@ describe("NodeConnection", () => {
             }
         });
     });
+
+    describe("getProgramImports", () => {
+        it("should not fetch the same program multiple times with overlapping imports", async () => {
+            // Track all calls to getProgram to detect duplicates
+            const fetchedPrograms = new Map<string, number>();
+            const originalGetProgram = connection.getProgram.bind(connection);
+            
+            connection.getProgram = async function(programId: string) {
+                const count = (fetchedPrograms.get(programId) || 0) + 1;
+                fetchedPrograms.set(programId, count);
+                return originalGetProgram(programId);
+            };
+
+            // Test with amm_orcl_intrfc_v.aleo which has 23 imports with heavy overlap
+            // This program previously caused exponentially recursive API calls resulting in rate limiting.
+            const imports = await connection.getProgramImports("amm_orcl_intrfc_v.aleo");
+            
+            // Verify we got all the imports
+            expect(Object.keys(imports).length).to.be.greaterThan(0);
+            
+            // Verify each program was fetched exactly once (no duplicates)
+            const duplicates = Array.from(fetchedPrograms.entries())
+                .filter(([_, count]) => count > 1);
+            
+            if (duplicates.length > 0) {
+                const duplicateNames = duplicates.map(([name, count]) => `${name} (${count}x)`).join(', ');
+                throw new Error(`Programs fetched multiple times: ${duplicateNames}`);
+            }
+            
+            // Verify total API calls equals number of unique imports
+            const totalCalls = Array.from(fetchedPrograms.values()).reduce((a, b) => a + b, 0);
+            expect(totalCalls).to.equal(fetchedPrograms.size);
+        });
+    });
 });

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -732,8 +732,8 @@ describe("NodeConnection", () => {
     });
 
     describe("getProgramImports", () => {
-        // Skip on mainnet - amm_orcl_intrfc_v.aleo only exists on testnet
-        const testFn = connection.network === "mainnet" ? it.skip : it;
+        // Only run on testnet - amm_orcl_intrfc_v.aleo only exists on testnet
+        const testFn = connection.network === "testnet" ? it : it.skip;
         
         testFn("should not fetch the same program multiple times with overlapping imports", async () => {
             // Track all calls to getProgram to detect duplicates

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -732,10 +732,13 @@ describe("NodeConnection", () => {
     });
 
     describe("getProgramImports", () => {
-        // Only run on testnet - amm_orcl_intrfc_v.aleo only exists on testnet
-        const testFn = connection.network === "testnet" ? it : it.skip;
-        
-        testFn("should not fetch the same program multiple times with overlapping imports", async () => {
+        it("should not fetch the same program multiple times with overlapping imports", async function() {
+            // Only run on testnet - amm_orcl_intrfc_v.aleo only exists on testnet
+            if (connection.network !== "testnet") {
+                this.skip();
+                return;
+            }
+            
             // Track all calls to getProgram to detect duplicates
             const fetchedPrograms = new Map<string, number>();
             const originalGetProgram = connection.getProgram.bind(connection);


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Problem
The getProgramImports() function was making hundreds of redundant API calls when processing programs with overlapping imports (e.g., Pondo AMM). This caused rate limiting errors (429) and extremely slow transaction building in wallets.
Example:
Expected: 24 programs = 24 API calls
Actual: 24 programs = 200+ API calls 

Each recursive call created a new imports object, so the duplicate check only worked at the current recursion level. Programs imported by multiple dependencies were fetched repeatedly.


## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Tested with `amm_orcl_intrfc_v.aleo` (23 imports with lots of overlap). Before it was doing exponential calls and getting rate limited, now it just does 23 calls.

Added a test in `/tests/network-client.test.ts` to ensure no duplicate program calls with a particularly problematic program.
