### PR TITLE
Simplify XMLHttpRequest polyfill

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -56,7 +56,6 @@
     "comlink": "^4.4.2",
     "core-js": "^3.40.0",
     "mime": "^4.0.6",
-    "sync-request": "^6.1.0",
     "xmlhttprequest-ssl": "^4.0.0"
   },
   "devDependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -57,7 +57,7 @@
     "core-js": "^3.40.0",
     "mime": "^4.0.6",
     "sync-request": "^6.1.0",
-    "xmlhttprequest-ssl": "^3.1.0"
+    "xmlhttprequest-ssl": "^4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^6.0.2",

--- a/sdk/src/polyfill/xmlhttprequest.ts
+++ b/sdk/src/polyfill/xmlhttprequest.ts
@@ -2,8 +2,9 @@
 import $xmlhttprequest from "xmlhttprequest-ssl";
 
 if (globalThis.XMLHttpRequest == null) {
-    function XMLHttpRequest(opts?: any) {
-        return new $xmlhttprequest.XMLHttpRequest({syncPolicy: "enabled", ...opts});
-    }
-    (globalThis as any).XMLHttpRequest = XMLHttpRequest;
+    (globalThis as any).XMLHttpRequest = class extends $xmlhttprequest.XMLHttpRequest {
+        constructor(opts?: any) {
+            super({ syncPolicy: "enabled", ...opts });
+        }
+    };
 }

--- a/sdk/src/polyfill/xmlhttprequest.ts
+++ b/sdk/src/polyfill/xmlhttprequest.ts
@@ -1,67 +1,9 @@
 // @ts-ignore
 import $xmlhttprequest from "xmlhttprequest-ssl";
-import $request from "sync-request";
 
 if (globalThis.XMLHttpRequest == null) {
-    globalThis.XMLHttpRequest = class extends $xmlhttprequest.XMLHttpRequest {
-        // We have to override the methods inside of the `constructor`
-        // because `xmlhttprequest-ssl` doesn't use a regular class,
-        // instead it defines all of the methods inside of the constructor.
-        constructor(...args: Array<any>) {
-            super(...args);
-
-            const open = (this as any).open;
-            const send = (this as any).send;
-
-            let _async: boolean = true;
-            let _url: null | string = null;
-            let _mime: string = "text/xml";
-
-            function reset() {
-                _async = true;
-                _url = null;
-                _mime = "text/xml";
-            }
-
-            (this as any).open = function (method: string, url: string, async: boolean, user?: string, password?: string) {
-                // Special behavior for synchronous requests
-                if (method === "GET" && !async && !user && !password) {
-                    _async = false;
-                    _url = url;
-
-                // Default to the normal polyfill for async requests
-                } else {
-                    reset();
-                    return open.call(this, method, url, async, user, password);
-                }
-            };
-
-            (this as any).send = function (data: any) {
-                if (_async) {
-                    return send.call(this, data);
-
-                // Use `sync-request` for synchronous requests.
-                } else {
-                    const response = $request("GET", _url!, {
-                        headers: {
-                            "Content-Type": _mime,
-                        }
-                    });
-
-                    const buffer = (response.body as Buffer).buffer as any;
-
-                    const responseText = new TextDecoder("iso-8859-5", { fatal: true }).decode(buffer);
-
-                    (this as any).status = 200;
-                    (this as any).response = (this as any).responseText = responseText;
-
-                    reset();
-                }
-            };
-
-            (this as any).overrideMimeType = function (mime: string) {
-                _mime = mime;
-            };
-        }
-    } as any;
+    function XMLHttpRequest(opts?: any) {
+        return new $xmlhttprequest.XMLHttpRequest({syncPolicy: "enabled", ...opts});
+    }
+    (globalThis as any).XMLHttpRequest = XMLHttpRequest
 }

--- a/sdk/src/polyfill/xmlhttprequest.ts
+++ b/sdk/src/polyfill/xmlhttprequest.ts
@@ -5,5 +5,5 @@ if (globalThis.XMLHttpRequest == null) {
     function XMLHttpRequest(opts?: any) {
         return new $xmlhttprequest.XMLHttpRequest({syncPolicy: "enabled", ...opts});
     }
-    (globalThis as any).XMLHttpRequest = XMLHttpRequest
+    (globalThis as any).XMLHttpRequest = XMLHttpRequest;
 }


### PR DESCRIPTION
## Motivation

Hyperlane encountered a bundling issue with the Provable SDK due to its dependency on `sync-request`. One of `sync-request`’s transitive dependencies (`sync-rpc`) relies on legacy CommonJS require() syntax, which breaks Hyperlane’s ESM-based build:

```
node cli-bundle/index.js --version                               took  6s at  14:18:36
file:///Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/cli/cli-bundle/index.js:389077
    throw new Error(
          ^

Error: file:///Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/cli/cli-bundle/find-port.js:3
const getPort = require('get-port');
                ^

ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/cli/cli-bundle/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at file:///Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/cli/cli-bundle/find-port.js:3:17
    at ModuleJob.run (node:internal/modules/esm/module_job:371:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:702:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
```

```
@hyperlane-xyz/monorepo
└─┬ @hyperlane-xyz/cli@19.11.0 -> ./typescript/cli
  └─┬ @hyperlane-xyz/aleo-sdk@19.11.0 -> ./typescript/aleo-sdk
    └─┬ @provablehq/sdk@0.9.13
      └─┬ sync-request@6.1.0 <- package only used in xml polyfill
        └─┬ sync-rpc@1.3.6 <- this package uses old commonjs require syntax which breaks on our side
          └── get-port@3.2.0
```

The SDK currently uses both:
* `xmlhttprequest-ssl`
* `sync-request`
to polyfill XMLHttpRequest in Node.js.

This dual approach exists because the version of `xmlhttprequest-ssl` previously in use incorrectly decoded synchronous responses as UTF-8, corrupting binary data. To work around this, synchronous requests were routed through `sync-request`, which preserves raw bytes correctly.

However, newer versions of `xmlhttprequest-ssl` now handle response decoding properly, eliminating the need for `sync-request` entirely.

Note that sync requests are not desirable and long-term we should move away from that entirely, but that requires changes to snarkVM before the JS SDK can support that.

## Test Plan
To verify this work I ran Hyperlane's test utility (https://github.com/troykessler/aleo-sdk-deploy) and was able to get it to work ([with some minor changes](https://github.com/troykessler/aleo-sdk-deploy/pull/1)).

I've also ran the [aleo-multisig unit tests](https://github.com/AleoNet/aleo-multisig/tree/main/tests) with this modified SDK and they passed.
