### PR TITLE
fix DFS in resolve program imports in wasm

### DIFF
--- a/wasm/src/programs/manager/mod.rs
+++ b/wasm/src/programs/manager/mod.rs
@@ -140,12 +140,12 @@ impl ProgramManager {
                     .as_string()
                 {
                     if &program_id != "credits.aleo" {
-                        log(&format!("Importing program: {program_id}"));
                         let import = ProgramNative::from_str(&import_string).map_err(|err| err.to_string())?;
-                        // If the program has imports, add them.
-                        Self::resolve_imports(process, &import, Some(imports.clone()))?;
-                        // If the process does not already contain the program, add it.
+                        // Only process if the program is not already in the process
                         if !process.contains_program(import.id()) {
+                            log(&format!("Importing program: {program_id}"));
+                            // If the program has imports, add them first (depth-first).
+                            Self::resolve_imports(process, &import, Some(imports.clone()))?;
                             log(&format!("Adding {program_id} to the process"));
                             process.add_program_with_edition(&import, 1).map_err(|err| err.to_string())?;
                         }


### PR DESCRIPTION
## Motivation

The same recursive program import call issue that was fixed [here](https://github.com/ProvableHQ/sdk/pull/1147) was present in the wasm program manager. This was caused by calling the buildAuthorization function > wasm [programManager.authorize()](https://github.com/ProvableHQ/sdk/blob/mainnet/wasm/src/programs/manager/authorize.rs#L58)

This calls the `resolve_imports` function that recursively calls itself before checking if the program already exists, leading to resource exhausting and triggering an error in the wasm 


## Test Plan

Tested with the program that was giving us issues:
```       
 const authorization = await programManager.buildAuthorizationUnchecked({
            programName: options.programName,
            functionName: options.functionName,
            inputs: inputs,
            programSource: fullProgramSource,
            privateKey: privateKey,
            programImports: programImports,
        });
```
and got `Full error: Failed to evaluate instruction`
rather than the prior error:
```
consoleReplace.ts:34 [worker] Creating authorization for amm_orcl_intrfc_v1.aleo:borrow_token
consoleReplace.ts:34 [worker] parsing inputs
aleo_wasm_testnet_0.9.14.wasm:0x50f94e Uncaught RuntimeError: unreachable
    at aleo_wasm_testnet_0.9.14.wasm:0x50f94e

[worker] Error fetching program imports:
....
```

