### PR TITLE
[Fix] Enable the maximum wasm memory during `wasm` builds

### DIFF
--- a/wasm/build.js
+++ b/wasm/build.js
@@ -30,9 +30,9 @@ async function buildWasm(network) {
                         "--no-default-features",
                         "--features", `browser,${network}`,
                     ],
-                    /*rustc: [
+                    rustc: [
                         "-C", "link-arg=--max-memory=4294967296",
-                    ],*/
+                    ],
                     wasmOpt: ["-O", "--enable-threads", "--enable-bulk-memory", "--enable-bulk-memory-opt", "--enable-nontrapping-float-to-int"],
                 },
 


### PR DESCRIPTION
## Motivation

By default, the rust compiler with the `+atomics` flag when compiling `wasm` limits memory to 1 GB. This PR raises the maximum memory of a `wasm` process to `U32::MAX` bytes (~4GB).

This solves issues such as crashes on insertion of the inclusion prover and when proving larger functions.
