### PR TITLE
[Test] Add transfer private test to SDK CI

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -126,7 +126,7 @@ jobs:
         template:
           - node
           - node-ts
-          - template-private-transaction-ts
+          - private-transaction-ts
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-yarn

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -126,6 +126,7 @@ jobs:
         template:
           - node
           - node-ts
+          - template-private-transaction-ts
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-yarn

--- a/create-leo-app/template-private-transaction-ts/package.json
+++ b/create-leo-app/template-private-transaction-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rimraf dist/js && rollup --config",
-    "dev": "npm run build && node dist/index.js"
+    "start": "npm run build && node dist/index.js"
   },
   "dependencies": {
     "@provablehq/sdk": "^0.9.14"

--- a/create-leo-app/template-private-transaction-ts/src/index.ts
+++ b/create-leo-app/template-private-transaction-ts/src/index.ts
@@ -1,5 +1,5 @@
 import {Account, initThreadPool, ProgramManager, AleoKeyProvider} from "@provablehq/sdk/testnet.js";
-import { CREDITS_PROGRAM_KEYS } from "@provablehq/sdk/mainnet.js";
+import { CREDITS_PROGRAM_KEYS } from "@provablehq/sdk/testnet.js";
 
 // Initialize the threadpool to speed up proving.
 await initThreadPool();
@@ -25,12 +25,12 @@ keyProvider.useCache(true);
 // Initialize the keyProvider cache with all necessary keys.
 await Promise.all([keyProvider.transferKeys("private"), keyProvider.feePrivateKeys()]);
 programManager.setKeyProvider(keyProvider);
-programManager.setInclusionProver();
+await programManager.setInclusionProver();
 
 const start = Date.now();
 console.log("Starting transfer_private execution");
 // Construct the transfer_private transaction.
-const transfer_private_tx = await programManager.buildExecutionTransaction({
+await programManager.buildExecutionTransaction({
     programName: "credits.aleo",
     functionName: "transfer_private",
     priorityFee: 0,
@@ -40,4 +40,3 @@ const transfer_private_tx = await programManager.buildExecutionTransaction({
     keySearchParams: { "cacheKey" : CREDITS_PROGRAM_KEYS.getKey("transfer_private").locator}
 });
 console.log(`transfer_private Execute finished in ${Date.now() - start}ms`);
-console.log(`Private execution ${transfer_private_tx}`);


### PR DESCRIPTION
## Motivation

No tests that execute private transactions using records are yet available. This PR adds the test for `transfer_private` using the `create-leo-app/template-private-transaction-ts` example to CI in order to ensure the SDK tests transaction building using private records.
