### PR TITLE
[Feature/Bug] Removing logging of program bytecode for delegated proving calls

### DIFF
--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -63,7 +63,7 @@ impl ProgramManager {
         unchecked: bool,
         edition: Option<u16>,
     ) -> Result<ProvingRequest, String> {
-        log(&format!("Creating proving request for {program}:{function_name}"));
+        log(&format!("Creating proving request for {function_name}"));
         let mut process_native = ProcessNative::load_web().map_err(|err| err.to_string())?;
         let process = &mut process_native;
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR removes logging the Aleo bytecode from the `buildProvingRequest` call.  Excessive logging is causing issues in GCP for deployed services like the USDCx bridge.
