### PR TITLE
[DPS] Add functionality for encrypting ProvingRequests

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -56,6 +56,7 @@
     "comlink": "^4.4.2",
     "core-js": "^3.40.0",
     "mime": "^4.0.6",
+    "libsodium-wrappers": "^0.8.2",
     "xmlhttprequest-ssl": "^4.0.0"
   },
   "devDependencies": {

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -27,7 +27,7 @@ import { PlaintextLiteral} from "./models/plaintext/literal.js";
 import { PlaintextObject } from "./models/plaintext/plaintext.js";
 import { PlaintextStruct} from "./models/plaintext/struct.js";
 import { ProvingRequestJSON } from "./models/provingRequest.js";
-import { ProvingResponse } from "./models/provingResponse.js";
+import { ProvingResponse, BroadcastResponse, BroadcastResult, ProvingResult, ProvingFailure, ProvingSuccess, ProveApiErrorBody, ProvingRequestError, isProvingResponse, isProveApiErrorBody } from "./models/provingResponse.js";
 import { RatificationJSON } from "./models/ratification.js";
 import { RecordsFilter } from "./models/record-scanner/recordsFilter.js";
 import { RecordsResponseFilter } from "./models/record-scanner/recordsResponseFilter.js";
@@ -144,6 +144,8 @@ export {
     AleoNetworkClient,
     BlockJSON,
     BlockHeightSearch,
+    BroadcastResponse,
+    BroadcastResult,
     CachedKeyPair,
     ConfirmedTransactionJSON,
     CryptoBoxPubKey,
@@ -161,6 +163,8 @@ export {
     FunctionKeyPair,
     FunctionKeyProvider,
     Header,
+    isProvingResponse,
+    isProveApiErrorBody,
     ImportedPrograms,
     ImportedVerifyingKeys,
     InputJSON,
@@ -181,7 +185,12 @@ export {
     PlaintextObject,
     PlaintextStruct,
     ProgramImports,
+    ProveApiErrorBody,
+    ProvingFailure,
+    ProvingRequestError,
     ProvingRequestJSON,
+    ProvingResult,
+    ProvingSuccess,
     ProvingResponse,
     RatificationJSON,
     RecordsFilter,

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -199,4 +199,4 @@ export {
     VerifyingKeys,
 };
 
-export { encryptAuthorization, encryptProvingRequest, encryptViewKey} from "./security.js";
+export { encryptAuthorization, encryptProvingRequest, encryptViewKey, encryptRegistrationRequest } from "./security.js";

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -4,8 +4,10 @@ import { Account } from "./account.js";
 import { AleoNetworkClient, ProgramImports } from "./network-client.js";
 import { BlockJSON, Header, Metadata } from "./models/blockJSON.js";
 import { ConfirmedTransactionJSON } from "./models/confirmed_transaction.js";
+import { CryptoBoxPubKey } from "./models/cryptoBoxPubkey.js";
 import { DeploymentJSON, VerifyingKeys } from "./models/deployment/deploymentJSON.js";
 import { DeploymentObject } from "./models/deployment/deploymentObject.js";
+import { EncryptedProvingRequest } from "./models/encryptedProvingRequest.js";
 import { EncryptedRecord } from "./models/record-provider/encryptedRecord.js";
 import { ExecutionJSON, FeeExecutionJSON } from "./models/execution/executionJSON.js";
 import { ExecutionObject, FeeExecutionObject } from "./models/execution/executionObject.js";
@@ -144,8 +146,10 @@ export {
     BlockHeightSearch,
     CachedKeyPair,
     ConfirmedTransactionJSON,
+    CryptoBoxPubKey,
     DeploymentJSON,
     DeploymentObject,
+    EncryptedProvingRequest,
     EncryptedRecord,
     ExecutionJSON,
     ExecutionObject,
@@ -194,3 +198,5 @@ export {
     TransitionObject,
     VerifyingKeys,
 };
+
+export { encryptAuthorization, encryptProvingRequest, encryptViewKey} from "./security.js";

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -118,5 +118,3 @@ export const RECORD_DOMAIN = "RecordScannerV0";
  * Zero address on Aleo blockchain that corresponds to field element 0. Used as padding in Merkle trees and as a sentinel value.
  */
 export const ZERO_ADDRESS = "aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc";
-
-export const FIVE_MINUTES = 5 * 60 * 1000; // 5 minutes in milliseconds

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -118,3 +118,5 @@ export const RECORD_DOMAIN = "RecordScannerV0";
  * Zero address on Aleo blockchain that corresponds to field element 0. Used as padding in Merkle trees and as a sentinel value.
  */
 export const ZERO_ADDRESS = "aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc";
+export const FIVE_MINUTES = 5 * 60 * 1000; // 5 minutes in milliseconds
+

--- a/sdk/src/models/cryptoBoxPubkey.ts
+++ b/sdk/src/models/cryptoBoxPubkey.ts
@@ -1,0 +1,4 @@
+export interface CryptoBoxPubKey {
+    key_id: string,
+    public_key: string,
+}

--- a/sdk/src/models/encryptedProvingRequest.ts
+++ b/sdk/src/models/encryptedProvingRequest.ts
@@ -1,0 +1,4 @@
+export interface EncryptedProvingRequest {
+    key_id: string,
+    ciphertext: string,
+}

--- a/sdk/src/models/provingResponse.ts
+++ b/sdk/src/models/provingResponse.ts
@@ -2,14 +2,14 @@ import { TransactionJSON } from "./transaction/transactionJSON.js";
 
 /** HTTP status and optional message from snarkOS broadcast (Accepted/Rejected variants). */
 export interface BroadcastResponse {
-    status_code: bigint;
+    status_code: bigint | number;
     message?: string;
 }
 
 /** Result of the optional broadcast step. Discriminated by `status`. */
 export type BroadcastResult =
-    | { status: "Accepted"; status_code: number; message?: string }
-    | { status: "Rejected"; status_code: number; message?: string }
+    | { status: "Accepted"; status_code: bigint | number; message?: string }
+    | { status: "Rejected"; status_code: bigint | number; message?: string }
     | { status: "Failed"; message: string }
     | { status: "Skipped" };
 
@@ -26,7 +26,7 @@ export interface ProveApiErrorBody {
 
 /** Error thrown on prove API failure; `status` is set for retry logic (e.g. retryWithBackoff checks error.status >= 500). */
 export interface ProvingRequestError extends Error {
-    status?: number;
+    status?: bigint | number;
 }
 
 /** Success variant of a proving request result. */
@@ -38,11 +38,11 @@ export interface ProvingSuccess {
 /** Failure variant of a proving request result (HTTP 400, 500, 503). */
 export interface ProvingFailure {
     ok: false;
-    status: number;
+    status: bigint | number;
     error: ProveApiErrorBody;
 }
 
-/** Result of a proving request. Use this when you want to handle status yourself instead of throwing. */
+/** Result of a proving request. Type used to give callers the ability to self-handle errors. */
 export type ProvingResult = ProvingSuccess | ProvingFailure;
 
 /** Type guard: value is a ProvingResponse. */

--- a/sdk/src/models/provingResponse.ts
+++ b/sdk/src/models/provingResponse.ts
@@ -1,11 +1,12 @@
 import { TransactionJSON } from "./transaction/transactionJSON";
 
-export interface BroadcastResult {
+export interface BroadcastResponse {
     status_code: bigint,
     status?: string
 }
 
 export interface ProvingResponse {
-    transaction: TransactionJSON,
-    broadcast_result: BroadcastResult,
+    message?: string, // Potential error message.
+    transaction?: TransactionJSON, // Transaction if successful.
+    broadcast_result?: BroadcastResponse, // Broadcast result if successful.
 }

--- a/sdk/src/models/provingResponse.ts
+++ b/sdk/src/models/provingResponse.ts
@@ -1,6 +1,11 @@
 import { TransactionJSON } from "./transaction/transactionJSON";
 
+export interface BroadcastResult {
+    status_code: bigint,
+    status?: string
+}
+
 export interface ProvingResponse {
     transaction: TransactionJSON,
-    broadcast?: boolean,
+    broadcast_result: BroadcastResult,
 }

--- a/sdk/src/models/provingResponse.ts
+++ b/sdk/src/models/provingResponse.ts
@@ -1,12 +1,66 @@
-import { TransactionJSON } from "./transaction/transactionJSON";
+import { TransactionJSON } from "./transaction/transactionJSON.js";
 
+/** HTTP status and optional message from snarkOS broadcast (Accepted/Rejected variants). */
 export interface BroadcastResponse {
-    status_code: bigint,
-    status?: string
+    status_code: bigint;
+    message?: string;
 }
 
+/** Result of the optional broadcast step. Discriminated by `status`. */
+export type BroadcastResult =
+    | { status: "Accepted"; status_code: number; message?: string }
+    | { status: "Rejected"; status_code: number; message?: string }
+    | { status: "Failed"; message: string }
+    | { status: "Skipped" };
+
+/** Success response body for POST /prove (HTTP 200). */
 export interface ProvingResponse {
-    message?: string, // Potential error message.
-    transaction?: TransactionJSON, // Transaction if successful.
-    broadcast_result?: BroadcastResponse, // Broadcast result if successful.
+    transaction: TransactionJSON;
+    broadcast_result: BroadcastResult;
+}
+
+/** Error response body for POST /prove (HTTP 400, 500, 503). Same shape for all error cases. */
+export interface ProveApiErrorBody {
+    message: string;
+}
+
+/** Error thrown on prove API failure; `status` is set for retry logic (e.g. retryWithBackoff checks error.status >= 500). */
+export interface ProvingRequestError extends Error {
+    status?: number;
+}
+
+/** Success variant of a proving request result. */
+export interface ProvingSuccess {
+    ok: true;
+    data: ProvingResponse;
+}
+
+/** Failure variant of a proving request result (HTTP 400, 500, 503). */
+export interface ProvingFailure {
+    ok: false;
+    status: number;
+    error: ProveApiErrorBody;
+}
+
+/** Result of a proving request. Use this when you want to handle status yourself instead of throwing. */
+export type ProvingResult = ProvingSuccess | ProvingFailure;
+
+/** Type guard: value is a ProvingResponse. */
+export function isProvingResponse(value: unknown): value is ProvingResponse {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "transaction" in value &&
+        "broadcast_result" in value &&
+        typeof (value as ProvingResponse).broadcast_result === "object"
+    );
+}
+
+/** Type guard: value is a ProveApiErrorBody. */
+export function isProveApiErrorBody(value: unknown): value is ProveApiErrorBody {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "message" in value
+    );
 }

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1749,11 +1749,6 @@ class AleoNetworkClient {
     async submitProvingRequest(options: DelegatedProvingParams): Promise<ProvingResponse> {
         const proverUri = (options.url ?? this.proverUri) ?? this.host;
 
-        // If no prover URI is provided, throw an error.
-        if (!proverUri) {
-            logAndThrow("A prover uri must be either passed in via the `url` parameter or configured on the AleoNetworkClient instance.");
-        }
-
         const provingRequestString = options.provingRequest instanceof ProvingRequest
             ? options.provingRequest.toString()
             : options.provingRequest;

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1747,7 +1747,7 @@ class AleoNetworkClient {
      * @returns {Promise<ProvingResponse>} The ProvingResponse containing the transaction result and the result of the broadcast if the `broadcast` flag was set to `true`.
      */
     async submitProvingRequest(options: DelegatedProvingParams): Promise<ProvingResponse> {
-        const proverUri = options.url ?? this.proverUri;
+        const proverUri = (options.url ?? this.proverUri) ?? this.host;
 
         // If no prover URI is provided, throw an error.
         if (!proverUri) {

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1788,27 +1788,31 @@ class AleoNetworkClient {
         // If private DPS is enabled, send an encrypted payload.
         if (options.dpsPrivacy) {
             try {
-                // First, get the service pubkey.
-                const pubKeyResponse = await retryWithBackoff(() =>
-                    get(proverUri + '/pubkey', {
+                // One pubkey per request is required, so the entire flow is wrapped in a retry.
+                const response = await retryWithBackoff(async () => {
+                    // First, get the service pubkey.
+                    const pubKeyResponse = await get(proverUri + '/pubkey', {
+                        headers
+                    });
+                    // Parse the pubkey.
+                    const pubkey: CryptoBoxPubKey = parseJSON(await pubKeyResponse.text());
+
+                    // Encrypt the proving request against the service pubkey.
+                    const ciphertext = encryptProvingRequest(pubkey.public_key, ProvingRequest.fromString(provingRequestString));
+
+                    // Create the encrypted proving request payload.
+                    const payload: EncryptedProvingRequest = { "key_id": pubkey.key_id, "ciphertext": ciphertext };
+
+                    // Stringify the key and post it.
+                    const encryptedProvingRequestString = JSON.stringify(payload);
+                    return await post(`${proverUri + '/prove/encrypted'}`, {
+                        body: encryptedProvingRequestString,
                         headers
                     })
-                );
-                const pubkey: CryptoBoxPubKey = parseJSON(await pubKeyResponse.text());
+                });
 
-                // Encrypt the proving request against the service pubkey.
-                const ciphertext = await encryptProvingRequest(pubkey.public_key, ProvingRequest.fromString(provingRequestString));
-
-                // Create the encrypted proving request payload.
-                const payload: EncryptedProvingRequest = { "key_id": pubkey.key_id, "ciphertext": ciphertext };
-                const encryptedProvingRequestString = JSON.stringify(payload);
-                const provingResponse = await post(`${proverUri + '/prove/encrypted'}`, {
-                    body: encryptedProvingRequestString,
-                    headers
-                })
-
-                // Return the result.
-                return parseJSON(await provingResponse.text());
+                // Return the result as JSON.
+                return parseJSON(await response.text());
             } catch (error) {
                 throw new Error(`Error sending encrypted proving request: ${error}`);
             }

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1751,13 +1751,18 @@ class AleoNetworkClient {
      * Parses a /prove or /prove/encrypted response. Returns a result object (never throws for 200/400/500/503).
      */
     private async handleProvingResponse(response: Response): Promise<ProvingResult> {
+        // Get the proving response text.
         const text = await response.text();
         let body: unknown;
+
+        // Parse the body.
         try {
             body = parseJSON(text);
         } catch {
             body = {};
         }
+
+        // If the status is 200, attempt to parse the Proving Request along its expected structure.
         if (response.status === 200) {
             if (isProvingResponse(body)) {
                 return { ok: true, data: body };
@@ -1768,6 +1773,8 @@ class AleoNetworkClient {
                 error: { message: "Invalid response from proving service" },
             };
         }
+
+        // If the response is non 200, return the information back to the caller so it can be handled.
         if (response.status === 400 || response.status === 500 || response.status === 503) {
             const error: ProveApiErrorBody = isProveApiErrorBody(body)
                 ? body
@@ -1804,16 +1811,18 @@ class AleoNetworkClient {
      * @returns {Promise<ProvingResult>} `{ ok: true, data }` on success (200), or `{ ok: false, status, error }` on 400/500/503. Check `result.ok` and then either `result.data` or `result.status` / `result.error.message`.
      */
     async submitProvingRequestSafe(options: DelegatedProvingParams): Promise<ProvingResult> {
+        // Attempt to get the Prover URI first from the options, then from any configured globally, or third try the main configured host.
         const proverUri = (options.url ?? this.proverUri) ?? this.host;
-
         const provingRequestString = options.provingRequest instanceof ProvingRequest
             ? options.provingRequest.toString()
             : options.provingRequest;
 
+        // Try to get JWT data to access the Provable API.
         const apiKey = options.apiKey ?? this.apiKey;
         const consumerId = options.consumerId ?? this.consumerId;
         let jwtData = options.jwtData ?? this.jwtData;
 
+        // Check to see if the JWT needs refreshing.
         const isExpired = jwtData && Date.now() >= jwtData.expiration - FIVE_MINUTES;
         if (!jwtData || isExpired) {
             if (options.apiKey && options.consumerId) {
@@ -1825,6 +1834,7 @@ class AleoNetworkClient {
             }
         }
 
+        // Create the necessary headers to hit the provable api.
         const headers: Record<string, string> = {
             ...this.headers,
             "X-ALEO-METHOD": "submitProvingRequest",
@@ -1834,38 +1844,63 @@ class AleoNetworkClient {
             headers["Authorization"] = jwtData.jwt;
         }
 
+        // Encapsulate the requests in a locally scoped function that can be run with a retry closure.
         const runRequest = async (): Promise<ProvingResult> => {
             // If DPS privacy is set, call invoke the encrypted flow.
             if (options.dpsPrivacy) {
                 // Get an ephemeral public key from a DPS service.
-                const pubKeyResponse = await get(proverUri + '/pubkey', { headers });
+                const pubKeyResponse = await get(proverUri + "/pubkey", {
+                    headers,
+                });
 
                 // Encrypt the provingRequest.
-                const pubkey: CryptoBoxPubKey = parseJSON(await pubKeyResponse.text());
-                const ciphertext = encryptProvingRequest(pubkey.public_key, ProvingRequest.fromString(provingRequestString));
-                const payload: EncryptedProvingRequest = { "key_id": pubkey.key_id, "ciphertext": ciphertext };
+                const pubkey: CryptoBoxPubKey = parseJSON(
+                    await pubKeyResponse.text(),
+                );
+                const ciphertext = encryptProvingRequest(
+                    pubkey.public_key,
+                    ProvingRequest.fromString(provingRequestString),
+                );
+
+                // Form the expected query a DPS service expects (including the key_id).
+                const payload: EncryptedProvingRequest = {
+                    key_id: pubkey.key_id,
+                    ciphertext: ciphertext,
+                };
                 const res = await fetch(`${proverUri}/prove/encrypted`, {
                     method: "POST",
                     body: JSON.stringify(payload),
                     headers,
                 });
+
+                // Properly handle the proving response.
                 return this.handleProvingResponse(res);
             }
-            const proveEndpoint = (<string>proverUri).endsWith("/prove") ? proverUri : proverUri + '/prove';
+
+            // If encrypted usage is not specified use the unencrypted endpoint.
+            const proveEndpoint = (<string>proverUri).endsWith("/prove")
+                ? proverUri
+                : proverUri + "/prove";
             const res = await fetch(proveEndpoint, {
                 method: "POST",
                 body: provingRequestString,
                 headers,
             });
+
+            // Properly handle the proving response.
             return this.handleProvingResponse(res);
         };
 
         try {
+            // Run the request with retries.
             return await retryWithBackoff(async () => {
+                // Run the encrypted or non-encrypted flow as specified by the flags.
                 const result = await runRequest();
                 if (result.ok) {
                     return result;
                 }
+
+                // If 500s are hit responses are returned, attempt retries.
                 if (result.status === 500 || result.status === 503) {
                     const err = new Error(result.error.message) as ProvingRequestError;
                     err.status = result.status;
@@ -1874,6 +1909,7 @@ class AleoNetworkClient {
                 return result;
             });
         } catch (err) {
+            // If an error is returned, provide usable information to the caller.
             const e = err as ProvingRequestError;
             return {
                 ok: false,

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1,6 +1,5 @@
 import { get, post, parseJSON, logAndThrow, retryWithBackoff, environment } from "./utils.js";
 import { Account } from "./account.js";
-import { FIVE_MINUTES } from "./constants.js";
 import { BlockJSON } from "./models/blockJSON.js";
 import { TransactionJSON } from "./models/transaction/transactionJSON.js";
 import {
@@ -14,7 +13,14 @@ import {
     Transaction,
 } from "./wasm.js";
 import { ConfirmedTransactionJSON } from "./models/confirmed_transaction.js";
-import { ProvingResponse } from "./models/provingResponse.js";
+import {
+    ProveApiErrorBody,
+    ProvingResponse,
+    ProvingResult,
+    ProvingRequestError,
+    isProvingResponse,
+    isProveApiErrorBody,
+} from "./models/provingResponse.js";
 import { CryptoBoxPubKey } from "./models/cryptoBoxPubkey.js";
 import { EncryptedProvingRequest } from "./models/encryptedProvingRequest.js";
 import { encryptProvingRequest } from "./security.js"
@@ -1741,12 +1747,62 @@ class AleoNetworkClient {
 
 
     /**
-     * Submit a `ProvingRequest` to a remote proving service for delegated proving. If the broadcast flag of the `ProvingRequest` is set to `true` the remote service will attempt to broadcast the result `Transaction` on behalf of the requestor.
+     * Parses a /prove or /prove/encrypted response. Returns a result object (never throws for 200/400/500/503).
+     */
+    private async handleProvingResponse(response: Response): Promise<ProvingResult> {
+        const text = await response.text();
+        let body: unknown;
+        try {
+            body = parseJSON(text);
+        } catch {
+            body = {};
+        }
+        if (response.status === 200) {
+            if (isProvingResponse(body)) {
+                return { ok: true, data: body };
+            }
+            return {
+                ok: false,
+                status: response.status,
+                error: { message: "Invalid response from proving service" },
+            };
+        }
+        if (response.status === 400 || response.status === 500 || response.status === 503) {
+            const error: ProveApiErrorBody = isProveApiErrorBody(body)
+                ? body
+                : { message: text || `${response.status} error` };
+            return { ok: false, status: response.status, error };
+        }
+        return {
+            ok: false,
+            status: response.status,
+            error: { message: text || `${response.status} error` },
+        };
+    }
+
+    /**
+     * Submit a `ProvingRequest` to a remote proving service for delegated proving. If the broadcast flag of the `ProvingRequest` is set to `true` the remote service will attempt to broadcast the result `Transaction` on behalf of the requestor. Throws on HTTP 400, 500, 503 (and retries on 500/503). Callers should {@link submitProvingRequestSafe} to handle proving request failures without throwing.
      *
      * @param {DelegatedProvingParams} options - The optional parameters required to submit a proving request.
      * @returns {Promise<ProvingResponse>} The ProvingResponse containing the transaction result and the result of the broadcast if the `broadcast` flag was set to `true`.
      */
     async submitProvingRequest(options: DelegatedProvingParams): Promise<ProvingResponse> {
+        const result = await this.submitProvingRequestSafe(options);
+        if (result.ok) {
+            return result.data;
+        }
+        const err = new Error(result.error.message) as ProvingRequestError;
+        err.status = result.status;
+        throw err;
+    }
+
+    /**
+     * Submit a proving request and return a result object instead of throwing. This method is usable when callers want to handle HTTP status (400, 500, 503) yourself. Retries on 500/503 and returns on 200 or 400.
+     *
+     * @param {DelegatedProvingParams} options - The optional parameters required to submit a proving request.
+     * @returns {Promise<ProvingResult>} `{ ok: true, data }` on success (200), or `{ ok: false, status, error }` on 400/500/503. Check `result.ok` and then either `result.data` or `result.status` / `result.error.message`.
+     */
+    async submitProvingRequestSafe(options: DelegatedProvingParams): Promise<ProvingResult> {
         const proverUri = (options.url ?? this.proverUri) ?? this.host;
 
         const provingRequestString = options.provingRequest instanceof ProvingRequest
@@ -1754,16 +1810,13 @@ class AleoNetworkClient {
             : options.provingRequest;
 
         const apiKey = options.apiKey ?? this.apiKey;
-        const consumerId = options.consumerId ?? this.consumerId;    
-        let jwtData = options.jwtData ?? this.jwtData
+        const consumerId = options.consumerId ?? this.consumerId;
+        let jwtData = options.jwtData ?? this.jwtData;
 
-        // Check if JWT is expired or missing
-        const bufferTime = FIVE_MINUTES; // 5 minutes buffer
-        const isExpired = jwtData && Date.now() >= jwtData.expiration - bufferTime;
+        const isExpired = jwtData && Date.now() >= jwtData.expiration;
         if (!jwtData || isExpired) {
             if (options.apiKey && options.consumerId) {
                 jwtData = await this.refreshJwt(apiKey!, consumerId!);
-                // Update both the class and the options with the new JWT
                 this.jwtData = jwtData;
                 options.jwtData = jwtData;
             } else {
@@ -1780,53 +1833,52 @@ class AleoNetworkClient {
             headers["Authorization"] = jwtData.jwt;
         }
 
-        // If private DPS is enabled, send an encrypted payload.
-        if (options.dpsPrivacy) {
-            try {
-                // One pubkey per request is required, so the entire flow is wrapped in a retry.
-                const response = await retryWithBackoff(async () => {
-                    // First, get the service pubkey.
-                    const pubKeyResponse = await get(proverUri + '/pubkey', {
-                        headers
-                    });
-                    // Parse the pubkey.
-                    const pubkey: CryptoBoxPubKey = parseJSON(await pubKeyResponse.text());
+        const runRequest = async (): Promise<ProvingResult> => {
+            // If DPS privacy is set, call invoke the encrypted flow.
+            if (options.dpsPrivacy) {
+                // Get an ephemeral public key from a DPS service.
+                const pubKeyResponse = await get(proverUri + '/pubkey', { headers });
 
-                    // Encrypt the proving request against the service pubkey.
-                    const ciphertext = encryptProvingRequest(pubkey.public_key, ProvingRequest.fromString(provingRequestString));
-
-                    // Create the encrypted proving request payload.
-                    const payload: EncryptedProvingRequest = { "key_id": pubkey.key_id, "ciphertext": ciphertext };
-
-                    // Stringify the key and post it.
-                    const encryptedProvingRequestString = JSON.stringify(payload);
-                    return await post(`${proverUri + '/prove/encrypted'}`, {
-                        body: encryptedProvingRequestString,
-                        headers
-                    })
+                // Encrypt the provingRequest.
+                const pubkey: CryptoBoxPubKey = parseJSON(await pubKeyResponse.text());
+                const ciphertext = encryptProvingRequest(pubkey.public_key, ProvingRequest.fromString(provingRequestString));
+                const payload: EncryptedProvingRequest = { "key_id": pubkey.key_id, "ciphertext": ciphertext };
+                const res = await fetch(`${proverUri}/prove/encrypted`, {
+                    method: "POST",
+                    body: JSON.stringify(payload),
+                    headers,
                 });
-
-                // Return the result as JSON.
-                return parseJSON(await response.text());
-            } catch (error) {
-                throw new Error(`Error sending encrypted proving request: ${error}`);
+                return this.handleProvingResponse(res);
             }
-        }
+            const proveEndpoint = (<string>proverUri).endsWith("/prove") ? proverUri : proverUri + '/prove';
+            const res = await fetch(proveEndpoint, {
+                method: "POST",
+                body: provingRequestString,
+                headers,
+            });
+            return this.handleProvingResponse(res);
+        };
 
         try {
-            // Add `/prove` if the endpoint isn't fully configured.
-            const proveEndpoint = (<string>proverUri).endsWith("/prove") ? proverUri : proverUri + '/prove';
-            const response = await retryWithBackoff(() =>
-            post(`${proveEndpoint}`, {
-                body: provingRequestString,
-                headers
-            })
-            );
-            const responseText = await response.text();
-            return parseJSON(responseText);
-        } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-            throw new Error(`Failed to submit proving request: ${errorMessage}`);
+            return await retryWithBackoff(async () => {
+                const result = await runRequest();
+                if (result.ok) {
+                    return result;
+                }
+                if (result.status === 500 || result.status === 503) {
+                    const err = new Error(result.error.message) as ProvingRequestError;
+                    err.status = result.status;
+                    throw err;
+                }
+                return result;
+            });
+        } catch (err) {
+            const e = err as ProvingRequestError;
+            return {
+                ok: false,
+                status: e.status ?? 500,
+                error: { message: e.message },
+            };
         }
     }
 

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -15,11 +15,16 @@ import {
 } from "./wasm.js";
 import { ConfirmedTransactionJSON } from "./models/confirmed_transaction.js";
 import { ProvingResponse } from "./models/provingResponse.js";
+import { CryptoBoxPubKey } from "./models/cryptoBoxPubkey.js";
+import { EncryptedProvingRequest } from "./models/encryptedProvingRequest.js";
+import { encryptProvingRequest } from "./security.js"
 
 type ProgramImports = { [key: string]: string | Program };
 
 interface AleoNetworkClientOptions {
     headers?: { [key: string]: string };
+    proverUri?: string;
+    recordScannerUri?: string;
 }
 
 /**
@@ -48,6 +53,7 @@ interface DelegatedProvingParams {
   apiKey?: string;
   consumerId?: string;
   jwtData?: JWTData;
+  dpsPrivacy?: boolean;
 }
 
 /**
@@ -75,6 +81,8 @@ class AleoNetworkClient {
     apiKey?: string;
     consumerId?: string;
     jwtData?: JWTData;
+    proverUri?: string;
+    recordScannerUri?: string;
 
     constructor(host: string, options?: AleoNetworkClientOptions) {
         this.host = host + "/%%NETWORK%%";
@@ -82,13 +90,31 @@ class AleoNetworkClient {
         this.ctx = {};
         this.verboseErrors = true;
 
-        if (options && options.headers) {
-            this.headers = options.headers;
+        if (options) {
+            if (options.headers) {
+                this.headers = options.headers;
+            } else {
+                this.headers = {
+                    // This is replaced by the actual version by a Rollup plugin
+                    "X-Aleo-SDK-Version": "%%VERSION%%",
+                    "X-Aleo-environment": environment(),
+                };
+            }
+
+            // If a prover uri was specified, set the prover uri.
+            if (options.proverUri) {
+                this.proverUri = options.proverUri + "/%%NETWORK%%";
+            }
+
+            // If a record scanner uri was specified, set the record scanner uri.
+            if (options.recordScannerUri) {
+                this.recordScannerUri = options.recordScannerUri + "/%%NETWORK%%";
+            }
         } else {
             this.headers = {
                 // This is replaced by the actual version by a Rollup plugin
                 "X-Aleo-SDK-Version": "%%VERSION%%",
-                "X-Aleo-environment" : environment(),
+                "X-Aleo-environment": environment(),
             };
         }
     }
@@ -134,6 +160,42 @@ class AleoNetworkClient {
      */
     setHost(host: string) {
         this.host = host + "/%%NETWORK%%";
+    }
+
+    /**
+     * Set a new uri for a remote prover.
+     *
+     * @param {string} proverUri The uri of the remote prover.
+     *
+     * @example
+     * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+     *
+     * // Create a networkClient that connects to the provable explorer api.
+     * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+     *
+     * // Set the prover uri.
+     * networkClient.setProverUri("https://prover.provable.prove");
+     */
+    setProverUri(proverUri: string) {
+        this.proverUri = proverUri + "/%%NETWORK%%";
+    }
+
+    /**
+     * Set a new uri for a remote record scanner.
+     *
+     * @param {string} recordScannerUri The uri of the remote record scanner.
+     *
+     * @example
+     * import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+     *
+     * // Create a networkClient that connects to the provable explorer api.
+     * const networkClient = new AleoNetworkClient("http://api.explorer.provable.com/v1", undefined);
+     *
+     * // Set the record scanner uri.
+     * networkClient.setRecordScannerUri("https://scanner.provable.scan");
+     */
+    setRecordScannerUri(recordScannerUri: string) {
+        this.recordScannerUri = recordScannerUri + "/%%NETWORK%%";
     }
 
     /**
@@ -1677,6 +1739,7 @@ class AleoNetworkClient {
         };
     }
 
+
     /**
      * Submit a `ProvingRequest` to a remote proving service for delegated proving. If the broadcast flag of the `ProvingRequest` is set to `true` the remote service will attempt to broadcast the result `Transaction` on behalf of the requestor.
      *
@@ -1684,7 +1747,13 @@ class AleoNetworkClient {
      * @returns {Promise<ProvingResponse>} The ProvingResponse containing the transaction result and the result of the broadcast if the `broadcast` flag was set to `true`.
      */
     async submitProvingRequest(options: DelegatedProvingParams): Promise<ProvingResponse> {
-        const proverUri = options.url ?? this.host;
+        const proverUri = options.url ?? this.proverUri;
+
+        // If no prover URI is provided, throw an error.
+        if (!proverUri) {
+            logAndThrow("A prover uri must be either passed in via the `url` parameter or configured on the AleoNetworkClient instance.");
+        }
+
         const provingRequestString = options.provingRequest instanceof ProvingRequest
             ? options.provingRequest.toString()
             : options.provingRequest;
@@ -1703,7 +1772,7 @@ class AleoNetworkClient {
                 this.jwtData = jwtData;
                 options.jwtData = jwtData;
             } else {
-                throw new Error('JWT or both apiKey and consumerId are required');
+                console.warn('JWT or both apiKey and consumerId are required when using the Provable API');
             }
         }
 
@@ -1716,9 +1785,40 @@ class AleoNetworkClient {
             headers["Authorization"] = jwtData.jwt;
         }
 
+        // If private DPS is enabled, send an encrypted payload.
+        if (options.dpsPrivacy) {
+            try {
+                // First, get the service pubkey.
+                const pubKeyResponse = await retryWithBackoff(() =>
+                    get(proverUri + '/pubkey', {
+                        headers
+                    })
+                );
+                const pubkey: CryptoBoxPubKey = parseJSON(await pubKeyResponse.text());
+
+                // Encrypt the proving request against the service pubkey.
+                const ciphertext = await encryptProvingRequest(pubkey.public_key, ProvingRequest.fromString(provingRequestString));
+
+                // Create the encrypted proving request payload.
+                const payload: EncryptedProvingRequest = { "key_id": pubkey.key_id, "ciphertext": ciphertext };
+                const encryptedProvingRequestString = JSON.stringify(payload);
+                const provingResponse = await post(`${proverUri + '/prove/encrypted'}`, {
+                    body: encryptedProvingRequestString,
+                    headers
+                })
+
+                // Return the result.
+                return parseJSON(await provingResponse.text());
+            } catch (error) {
+                throw new Error(`Error sending encrypted proving request: ${error}`);
+            }
+        }
+
         try {
+            // Add `/prove` if the endpoint isn't fully configured.
+            const proveEndpoint = (<string>proverUri).endsWith("/prove") ? proverUri : proverUri + '/prove';
             const response = await retryWithBackoff(() =>
-            post(`${proverUri}`, {
+            post(`${proveEndpoint}`, {
                 body: provingRequestString,
                 headers
             })

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -24,6 +24,7 @@ import {
 import { CryptoBoxPubKey } from "./models/cryptoBoxPubkey.js";
 import { EncryptedProvingRequest } from "./models/encryptedProvingRequest.js";
 import { encryptProvingRequest } from "./security.js"
+import { FIVE_MINUTES } from "./constants";
 
 type ProgramImports = { [key: string]: string | Program };
 
@@ -1813,7 +1814,7 @@ class AleoNetworkClient {
         const consumerId = options.consumerId ?? this.consumerId;
         let jwtData = options.jwtData ?? this.jwtData;
 
-        const isExpired = jwtData && Date.now() >= jwtData.expiration;
+        const isExpired = jwtData && Date.now() >= jwtData.expiration - FIVE_MINUTES;
         if (!jwtData || isExpired) {
             if (options.apiKey && options.consumerId) {
                 jwtData = await this.refreshJwt(apiKey!, consumerId!);

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -30,7 +30,7 @@ export function encryptProvingRequest(publicKey: string, provingRequest: Proving
 /**
  * Encrypt a view key with a libsodium cryptobox public key.
  *
- * @param {Uint8Array} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
+ * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
  * @param {ViewKey} viewKey the view key to encrypt.
  *
  * @returns {string} the encrypted view key in RFC 4648 standard Base64.
@@ -42,7 +42,7 @@ export function encryptViewKey(publicKey: string, viewKey: ViewKey): string {
 /**
  * Encrypt a record scanner registration request.
  *
- * @param {Uint8Array} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
+ * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
  * @param {ViewKey} viewKey the view key to encrypt.
  * @param {number} start the start height of the registration request.
  *

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -40,6 +40,34 @@ export function encryptViewKey(publicKey: string, viewKey: ViewKey): string {
 }
 
 /**
+ * Encrypt a record scanner registration request.
+ *
+ * @param {Uint8Array} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
+ * @param {ViewKey} viewKey the view key to encrypt.
+ * @param {number} start the start height of the registration request.
+ *
+ * @returns {string} the encrypted view key in RFC 4648 standard Base64.
+ */
+export function encryptRegistrationRequest(publicKey: string, viewKey: ViewKey, start: number): string {
+    // Turn the view key into a Uint8Array.
+    const vk_bytes: Uint8Array = viewKey.toBytesLe();
+    // Create a new array to hold the original bytes and the 4-byte start height.
+    const bytes = new Uint8Array(vk_bytes.length + 4);
+
+    // Copy existing bytes.
+    bytes.set(vk_bytes, 0);
+
+    // Write the 4-byte number in LE format at the end of the array.
+    const view = new DataView(bytes.buffer);
+    view.setUint32(vk_bytes.length, start, true);
+
+    // Encrypt the encoded bytes.
+    return encryptMessage(publicKey, bytes);
+}
+
+
+
+/**
  * Encrypt arbitrary bytes with a libsodium cryptobox public key.
  *
  * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -65,8 +65,6 @@ export function encryptRegistrationRequest(publicKey: string, viewKey: ViewKey, 
     return encryptMessage(publicKey, bytes);
 }
 
-
-
 /**
  * Encrypt arbitrary bytes with a libsodium cryptobox public key.
  *

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -1,0 +1,53 @@
+import sodium from "libsodium-wrappers";
+import { ViewKey, Authorization, ProvingRequest } from "@provablehq/wasm";
+await sodium.ready;
+
+/**
+ * Encrypt an authorization with a libsodium cryptobox public key.
+ *
+ * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
+ * @param {Authorization} authorization the authorization to encrypt.
+ *
+ * @returns the encrypted authorization in RFC 4648 standard Base64.
+ */
+export async function encryptAuthorization(publicKey: string, authorization: Authorization): Promise<string> {
+    // Ready the cryptobox lib.
+    return encryptMessage(publicKey, authorization.toBytesLe());
+}
+
+/**
+ * Encrypt a ProvingRequest with a libsodium cryptobox public key.
+ *
+ * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
+ * @param {Authorization} provingRequest the ProvingRequest to encrypt.
+ *
+ * @returns the encrypted ProvingRequest in RFC 4648 standard Base64.
+ */
+export async function encryptProvingRequest(publicKey: string, provingRequest: ProvingRequest): Promise<string> {
+    return encryptMessage(publicKey, provingRequest.toBytesLe());
+}
+
+/**
+ * Encrypt a view key with a libsodium cryptobox public key.
+ *
+ * @param {Uint8Array} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
+ * @param {ViewKey} viewKey the view key to encrypt.
+ *
+ * @returns the encrypted view key in RFC 4648 standard Base64.
+ */
+export async function encryptViewKey(publicKey: string, viewKey: ViewKey): Promise<string> {
+    return encryptMessage(publicKey, viewKey.toBytesLe());
+}
+
+/**
+ * Encrypt arbitrary bytes with a libsodium cryptobox public key.
+ *
+ * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
+ * @param {Uint8Array} message the bytes to encrypt.
+ *
+ * @returns the encrypted bytes in RFC 4648 standard Base64.
+ */
+async function encryptMessage(publicKey: string, message: Uint8Array) {
+    const publicKeyBytes = sodium.from_base64(publicKey, sodium.base64_variants.ORIGINAL);
+    return sodium.to_base64(sodium.crypto_box_seal(message, publicKeyBytes), sodium.base64_variants.ORIGINAL);
+}

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -8,9 +8,9 @@ await sodium.ready;
  * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
  * @param {Authorization} authorization the authorization to encrypt.
  *
- * @returns the encrypted authorization in RFC 4648 standard Base64.
+ * @returns {string} the encrypted authorization in RFC 4648 standard Base64.
  */
-export async function encryptAuthorization(publicKey: string, authorization: Authorization): Promise<string> {
+export function encryptAuthorization(publicKey: string, authorization: Authorization): string {
     // Ready the cryptobox lib.
     return encryptMessage(publicKey, authorization.toBytesLe());
 }
@@ -21,9 +21,9 @@ export async function encryptAuthorization(publicKey: string, authorization: Aut
  * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
  * @param {Authorization} provingRequest the ProvingRequest to encrypt.
  *
- * @returns the encrypted ProvingRequest in RFC 4648 standard Base64.
+ * @returns {string} the encrypted ProvingRequest in RFC 4648 standard Base64.
  */
-export async function encryptProvingRequest(publicKey: string, provingRequest: ProvingRequest): Promise<string> {
+export function encryptProvingRequest(publicKey: string, provingRequest: ProvingRequest): string {
     return encryptMessage(publicKey, provingRequest.toBytesLe());
 }
 
@@ -33,9 +33,9 @@ export async function encryptProvingRequest(publicKey: string, provingRequest: P
  * @param {Uint8Array} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
  * @param {ViewKey} viewKey the view key to encrypt.
  *
- * @returns the encrypted view key in RFC 4648 standard Base64.
+ * @returns {string} the encrypted view key in RFC 4648 standard Base64.
  */
-export async function encryptViewKey(publicKey: string, viewKey: ViewKey): Promise<string> {
+export function encryptViewKey(publicKey: string, viewKey: ViewKey): string {
     return encryptMessage(publicKey, viewKey.toBytesLe());
 }
 
@@ -45,9 +45,9 @@ export async function encryptViewKey(publicKey: string, viewKey: ViewKey): Promi
  * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
  * @param {Uint8Array} message the bytes to encrypt.
  *
- * @returns the encrypted bytes in RFC 4648 standard Base64.
+ * @returns {string} the encrypted bytes in RFC 4648 standard Base64.
  */
-async function encryptMessage(publicKey: string, message: Uint8Array) {
+function encryptMessage(publicKey: string, message: Uint8Array): string {
     const publicKeyBytes = sodium.from_base64(publicKey, sodium.base64_variants.ORIGINAL);
     return sodium.to_base64(sodium.crypto_box_seal(message, publicKeyBytes), sodium.base64_variants.ORIGINAL);
 }

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -164,37 +164,81 @@ describe('Program Manager', async () => {
             }
         });
 
-        it('Should execute an encrypted proving request', async function() {
+        it.only('Should execute an encrypted proving request', async function() {
             this.retries(3);
 
             if (network === "testnet") {
-                const pk = PrivateKey.from_string(<string>process.env["PUZZLE_PK"]);
+                const pk = PrivateKey.from_string(
+                    <string>process.env["PUZZLE_PK"],
+                );
 
-                const provingRequest = <ProvingRequest>await programManager.provingRequest({
-                    programName: "hello_hello.aleo",
-                    functionName: "hello",
-                    priorityFee: 0.0,
-                    privateFee: false,
-                    inputs: ["1u32", "1u32"],
-                    broadcast: false,
-                    privateKey: pk
-                });
+                const provingRequest = <ProvingRequest>(
+                    await programManager.provingRequest({
+                        programName: "hello_hello.aleo",
+                        functionName: "hello",
+                        priorityFee: 0.0,
+                        privateFee: false,
+                        inputs: ["1u32", "1u32"],
+                        broadcast: false,
+                        privateKey: pk,
+                    })
+                );
 
                 // Ensure an encryption roundtrip works locally.
                 await sodium.ready;
                 const keyPair = sodium.crypto_box_keypair();
-                const ciphertext = await encryptProvingRequest(sodium.to_base64(keyPair.publicKey, sodium.base64_variants.ORIGINAL), provingRequest);
-                const plaintextBytes = sodium.crypto_box_seal_open(sodium.from_base64(ciphertext, sodium.base64_variants.ORIGINAL), keyPair.publicKey, keyPair.privateKey);
-                const deserializedProvingRequest = ProvingRequest.fromBytesLe(plaintextBytes);
-                expect(deserializedProvingRequest.broadcast).equals(provingRequest.broadcast);
-
-                // Submit the proving request.
-                const provingResponse = await programManager.networkClient.submitProvingRequest({
+                const ciphertext = await encryptProvingRequest(
+                    sodium.to_base64(
+                        keyPair.publicKey,
+                        sodium.base64_variants.ORIGINAL,
+                    ),
                     provingRequest,
-                    dpsPrivacy: true
-                });
+                );
+                const plaintextBytes = sodium.crypto_box_seal_open(
+                    sodium.from_base64(
+                        ciphertext,
+                        sodium.base64_variants.ORIGINAL,
+                    ),
+                    keyPair.publicKey,
+                    keyPair.privateKey,
+                );
+                const deserializedProvingRequest =
+                    ProvingRequest.fromBytesLe(plaintextBytes);
+                expect(deserializedProvingRequest.broadcast).equals(
+                    provingRequest.broadcast,
+                );
 
-                expect(provingResponse.broadcast_result.status).equal("Skipped");
+                // Submit the proving request using the safe method.
+                const safeResult =
+                    await programManager.networkClient.submitProvingRequestSafe(
+                        {
+                            provingRequest,
+                            dpsPrivacy: true,
+                        },
+                    );
+
+                expect(safeResult.ok).to.equal(true);
+                if (safeResult.ok) {
+                    expect(safeResult.data).to.have.property("transaction");
+                    expect(safeResult.data.transaction).to.have.property("id");
+                    expect(safeResult.data).to.have.property("broadcast_result");
+                    expect(safeResult.data.broadcast_result.status).to.equal(
+                        "Skipped",
+                    );
+                }
+
+                // Submit the proving request using the regular method.
+                const result =
+                    await programManager.networkClient.submitProvingRequest(
+                        {
+                            provingRequest,
+                            dpsPrivacy: true,
+                        },
+                    );
+
+                expect(result).to.have.property("transaction");
+                expect(result).to.have.property("broadcast_result");
+                expect(result.broadcast_result.status).to.equal("Skipped");
             }
         });
     });

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -176,7 +176,7 @@ describe('Program Manager', async () => {
                     priorityFee: 0.0,
                     privateFee: false,
                     inputs: ["1u32", "1u32"],
-                    broadcast: true,
+                    broadcast: false,
                     privateKey: pk
                 });
 
@@ -187,7 +187,6 @@ describe('Program Manager', async () => {
                 const plaintextBytes = sodium.crypto_box_seal_open(sodium.from_base64(ciphertext, sodium.base64_variants.ORIGINAL), keyPair.publicKey, keyPair.privateKey);
                 const deserializedProvingRequest = ProvingRequest.fromBytesLe(plaintextBytes);
                 expect(deserializedProvingRequest.broadcast).equals(provingRequest.broadcast);
-                console.log(`Deserialized proving request: ${deserializedProvingRequest.toBytesLe()}`);
 
                 // Submit the proving request.
                 const provingResponse = <ProvingResponse>await programManager.networkClient.submitProvingRequest({
@@ -195,8 +194,8 @@ describe('Program Manager', async () => {
                     dpsPrivacy: true
                 });
 
-                console.log(`Proving response: ${provingResponse.transaction}`)
-                expect(provingResponse.broadcast).equal(true);
+                console.log("Proving response", provingResponse.broadcast_result);
+                expect(provingResponse.broadcast_result.status).equal("Skipped");
             }
         });
     });

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -36,7 +36,7 @@ import {
     PUZZLE_SPINNER_V002_INPUT_2
 } from "./data/proving.js";
 import * as process from "node:process";
-import { ProvingResponse } from "../src/models/provingResponse";
+import { BroadcastResponse, ProvingResponse } from "../src/models/provingResponse";
 import { encryptProvingRequest } from "../src/browser";
 import sodium from "libsodium-wrappers";
 
@@ -46,7 +46,7 @@ describe('Program Manager', async () => {
     const programManager = new ProgramManager("https://api.explorer.provable.com/v1", keyProvider);
     programManager.setAccount(new Account({ privateKey: statePathv0RecordOwnerPrivateKey }));
     const network = programManager.networkClient.network;
-    programManager.networkClient.setProverUri("https://accelerate-sandbox.provable.com");
+    programManager.networkClient.setProverUri("https://accelerate.provable.com");
     describe('Instantiate with AleoNetworkClientOptions', () => {
         it('should have the specified headers when instantiated', async () => {
             const newProgramManager = new ProgramManager("https://api.explorer.provable.com/v1", undefined, undefined, { headers: { 'X-Test-Header': 'programManager' } });
@@ -164,7 +164,7 @@ describe('Program Manager', async () => {
             }
         });
 
-        it('Should execute an encrypted proving request', async function() {
+        it.only('Should execute an encrypted proving request', async function() {
             this.retries(3);
 
             if (network === "testnet") {
@@ -195,7 +195,7 @@ describe('Program Manager', async () => {
                 });
 
                 console.log("Proving response", provingResponse.broadcast_result);
-                expect(provingResponse.broadcast_result.status).equal("Skipped");
+                expect((<BroadcastResponse>provingResponse.broadcast_result).status).equal("Skipped");
             }
         });
     });

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -36,6 +36,9 @@ import {
     PUZZLE_SPINNER_V002_INPUT_2
 } from "./data/proving.js";
 import * as process from "node:process";
+import { ProvingResponse } from "../src/models/provingResponse";
+import { encryptProvingRequest } from "../src/browser";
+import sodium from "libsodium-wrappers";
 
 describe('Program Manager', async () => {
     const keyProvider = new AleoKeyProvider();
@@ -43,7 +46,7 @@ describe('Program Manager', async () => {
     const programManager = new ProgramManager("https://api.explorer.provable.com/v1", keyProvider);
     programManager.setAccount(new Account({ privateKey: statePathv0RecordOwnerPrivateKey }));
     const network = programManager.networkClient.network;
-
+    programManager.networkClient.setProverUri("https://accelerate-sandbox.provable.com");
     describe('Instantiate with AleoNetworkClientOptions', () => {
         it('should have the specified headers when instantiated', async () => {
             const newProgramManager = new ProgramManager("https://api.explorer.provable.com/v1", undefined, undefined, { headers: { 'X-Test-Header': 'programManager' } });
@@ -158,6 +161,42 @@ describe('Program Manager', async () => {
                 });
 
                 expect(request.feeAuthorization()).equal(undefined);
+            }
+        });
+
+        it.only('Should execute an encrypted proving request', async function() {
+            this.retries(3);
+
+            if (network === "testnet") {
+                const pk = PrivateKey.from_string(<string>process.env["PUZZLE_PK"]);
+
+                const provingRequest = <ProvingRequest>await programManager.provingRequest({
+                    programName: "hello_hello.aleo",
+                    functionName: "hello",
+                    priorityFee: 0.0,
+                    privateFee: false,
+                    inputs: ["1u32", "1u32"],
+                    broadcast: true,
+                    privateKey: pk
+                });
+
+                // Ensure an encryption roundtrip works locally.
+                await sodium.ready;
+                const keyPair = sodium.crypto_box_keypair();
+                const ciphertext = await encryptProvingRequest(sodium.to_base64(keyPair.publicKey, sodium.base64_variants.ORIGINAL), provingRequest);
+                const plaintextBytes = sodium.crypto_box_seal_open(sodium.from_base64(ciphertext, sodium.base64_variants.ORIGINAL), keyPair.publicKey, keyPair.privateKey);
+                const deserializedProvingRequest = ProvingRequest.fromBytesLe(plaintextBytes);
+                expect(deserializedProvingRequest.broadcast).equals(provingRequest.broadcast);
+                console.log(`Deserialized proving request: ${deserializedProvingRequest.toBytesLe()}`);
+
+                // Submit the proving request.
+                const provingResponse = <ProvingResponse>await programManager.networkClient.submitProvingRequest({
+                    provingRequest,
+                    dpsPrivacy: true
+                });
+
+                console.log(`Proving response: ${provingResponse.transaction}`)
+                expect(provingResponse.broadcast).equal(true);
             }
         });
     });

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -36,7 +36,7 @@ import {
     PUZZLE_SPINNER_V002_INPUT_2
 } from "./data/proving.js";
 import * as process from "node:process";
-import { BroadcastResponse, ProvingResponse } from "../src/models/provingResponse";
+import { ProvingResponse } from "../src/models/provingResponse.js";
 import { encryptProvingRequest } from "../src/browser";
 import sodium from "libsodium-wrappers";
 
@@ -189,13 +189,12 @@ describe('Program Manager', async () => {
                 expect(deserializedProvingRequest.broadcast).equals(provingRequest.broadcast);
 
                 // Submit the proving request.
-                const provingResponse = <ProvingResponse>await programManager.networkClient.submitProvingRequest({
+                const provingResponse = await programManager.networkClient.submitProvingRequest({
                     provingRequest,
                     dpsPrivacy: true
                 });
 
-                console.log("Proving response", provingResponse.broadcast_result);
-                expect((<BroadcastResponse>provingResponse.broadcast_result).status).equal("Skipped");
+                expect(provingResponse.broadcast_result.status).equal("Skipped");
             }
         });
     });

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -164,7 +164,7 @@ describe('Program Manager', async () => {
             }
         });
 
-        it.only('Should execute an encrypted proving request', async function() {
+        it('Should execute an encrypted proving request', async function() {
             this.retries(3);
 
             if (network === "testnet") {

--- a/wasm/src/account/view_key.rs
+++ b/wasm/src/account/view_key.rs
@@ -16,7 +16,7 @@
 
 use crate::{Address, Field, PrivateKey, RecordCiphertext, Scalar, types::native::ViewKeyNative};
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
-use snarkvm_console::prelude::ToField;
+use snarkvm_console::prelude::{FromBytes, ToBytes, ToField};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -47,6 +47,25 @@ impl ViewKey {
     #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
+    }
+
+    /// Get the underlying bytes of a view key.
+    ///
+    /// @returns {Uint8Array} Left endian byte array representation of the view key.
+    #[wasm_bindgen(js_name = toBytesLe)]
+    pub fn to_bytes_le(&self) -> Result<Vec<u8>, String> {
+        self.0.to_bytes_le().map_err(|e| e.to_string())
+    }
+
+    /// Get a ViewKey from a series of bytes.
+    ///
+    /// @param {Uint8Array} bytes A left endian byte array representing the view key.
+    ///
+    /// @returns {ViewKey} The view key object.
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: Vec<u8>) -> Result<Self, String> {
+        let view_key = ViewKeyNative::read_le(&bytes[..]).map_err(|e| e.to_string())?;
+        Ok(Self(view_key))
     }
 
     /// Get the address corresponding to a view key
@@ -166,5 +185,13 @@ mod tests {
         let incorrect_view_key = ViewKey::from_string(NON_OWNER_VIEW_KEY);
         let plaintext = ciphertext.decrypt(&incorrect_view_key);
         assert!(plaintext.is_err());
+    }
+
+    #[wasm_bindgen_test]
+    pub fn test_byte_serialization_roundtrip() {
+        let vk = ViewKey::from_string(OWNER_VIEW_KEY);
+        let bytes = vk.to_bytes_le().unwrap();
+        let vk_from_bytes = ViewKey::from_bytes_le(bytes).unwrap();
+        assert_eq!(vk, vk_from_bytes);
     }
 }

--- a/wasm/src/types/native/request/bytes.rs
+++ b/wasm/src/types/native/request/bytes.rs
@@ -30,11 +30,11 @@ impl ToBytes for ProvingRequestNative {
         // Write the optional fee_authorization.
         match &self.fee_authorization {
             Some(auth) => {
-                1u8.write_le(&mut writer)?; // flag for Some
+                true.write_le(&mut writer)?; // flag for Some
                 auth.write_le(&mut writer)?;
             }
             None => {
-                0u8.write_le(&mut writer)?; // flag for None
+                false.write_le(&mut writer)?; // flag for None
             }
         }
 
@@ -51,10 +51,10 @@ impl FromBytes for ProvingRequestNative {
         let authorization = AuthorizationNative::read_le(&mut reader)?;
 
         // Read the option flag and then the fee_authorization if present.
-        let has_fee_auth = u8::read_le(&mut reader)?;
+        let has_fee_auth = bool::read_le(&mut reader)?;
         let fee_authorization = match has_fee_auth {
-            0 => None,
-            1 => Some(AuthorizationNative::read_le(&mut reader)?),
+            false => None,
+            true => Some(AuthorizationNative::read_le(&mut reader)?),
             _ => return Err(error("Invalid Option flag for fee_authorization")),
         };
 

--- a/wasm/src/types/native/request/bytes.rs
+++ b/wasm/src/types/native/request/bytes.rs
@@ -15,7 +15,7 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::types::native::{AuthorizationNative, ProvingRequestNative};
-use snarkvm_wasm::utilities::{FromBytes, ToBytes, error};
+use snarkvm_wasm::utilities::{FromBytes, ToBytes};
 
 use std::{
     io,
@@ -55,7 +55,6 @@ impl FromBytes for ProvingRequestNative {
         let fee_authorization = match has_fee_auth {
             false => None,
             true => Some(AuthorizationNative::read_le(&mut reader)?),
-            _ => return Err(error("Invalid Option flag for fee_authorization")),
         };
 
         // Read broadcast flag.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6424,6 +6424,18 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+libsodium-wrappers@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.8.2.tgz#717042fb8ad62e2e4dada53795873a08c98e658c"
+  integrity sha512-VFLmfxkxo+U9q60tjcnSomQBRx2UzlRjKWJqvB4K1pUqsMQg4cu3QXA2nrcsj9A1qRsnJBbi2Ozx1hsiDoCkhw==
+  dependencies:
+    libsodium "^0.8.0"
+
+libsodium@^0.8.0:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.8.2.tgz#eadd168d478729e8f1687da8b78a352c421fa0b1"
+  integrity sha512-TsnGYMoZtpweT+kR+lOv5TVsnJ/9U0FZOsLFzFOMWmxqOAYXjX3fsrPAW+i1LthgDKXJnI9A8dWEanT1tnJKIw==
+
 lilconfig@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"


### PR DESCRIPTION
## Motivation

This PR adds tooling to the SDK to encrypt ProvingRequests before being sent to the DPS service. It does so by encrypting the ProvingRequest with a cryptobox key and sending it to the DPS endpoint. Further tooling for encrypting view keys and individual authorizations are included as well.

## Test Plan
Tests against a staging service are included.