### PR TITLE
feat(wasm): add isValid static method to Address for validating addre…

### DIFF
--- a/sdk/src/account.ts
+++ b/sdk/src/account.ts
@@ -89,6 +89,24 @@ export class Account {
   }
 
   /**
+   * Validates whether the given input is a valid Aleo address.
+   * @param {string | Uint8Array} address The address to validate, either as a string or bytes
+   * @returns {boolean} True if the address is valid, false otherwise
+   *
+   * @example
+   * import { Account } from "@provablehq/sdk/testnet.js";
+   *
+   * const isValid = Account.isValidAddress("aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px");
+   * console.log(isValid); // true
+   *
+   * const isInvalid = Account.isValidAddress("invalid_address");
+   * console.log(isInvalid); // false
+   */
+  public static isValidAddress(address: string | Uint8Array): boolean {
+    return Address.isValid(address);
+  }
+
+  /**
    * Creates a PrivateKey from the provided parameters.
    * @param {AccountParam} params The parameters containing either a private key string or a seed
    * @returns {PrivateKey} A PrivateKey instance derived from the provided parameters

--- a/sdk/tests/account.test.ts
+++ b/sdk/tests/account.test.ts
@@ -105,6 +105,29 @@ describe('Account', () => {
         });
     });
 
+    describe('isValidAddress', () => {
+        it('returns true for a valid address string', () => {
+            expect(Account.isValidAddress(beaconAddressString)).equal(true);
+        });
+
+        it('returns false for invalid address strings', () => {
+            expect(Account.isValidAddress('invalid_address')).equal(false);
+            expect(Account.isValidAddress('aleo1xyz')).equal(false);
+            expect(Account.isValidAddress('')).equal(false);
+        });
+
+        it('returns true for valid address bytes', () => {
+            const address = Address.from_string(beaconAddressString);
+            const bytes = address.toBytesLe();
+            expect(Account.isValidAddress(bytes)).equal(true);
+        });
+
+        it('returns false for invalid address bytes', () => {
+            expect(Account.isValidAddress(new Uint8Array([1, 2, 3]))).equal(false);
+            expect(Account.isValidAddress(new Uint8Array([]))).equal(false);
+        });
+    });
+
     describe('View Key Record Decryption', () => {
         it('decrypts a record in ciphertext form', () => {
             const account = new Account({privateKey: "APrivateKey1zkpJkyYRGYtkeHDaFfwsKtUJzia7csiWhfBWPXWhXJzy9Ls"});

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -81,6 +81,28 @@ describe('WASM Objects', () => {
             // Ensure the signature failed to verify
             expect(result).equal(false);
         });
+
+        it('validates a correct address string with isValid', () => {
+            const result = Address.isValid(addressString);
+            expect(result).equal(true);
+        });
+
+        it('returns false for an invalid address string with isValid', () => {
+            expect(Address.isValid('invalid_address')).equal(false);
+            expect(Address.isValid('aleo1xyz')).equal(false);
+            expect(Address.isValid('')).equal(false);
+        });
+
+        it('validates correct address bytes with isValid', () => {
+            const address = Address.from_string(addressString);
+            const bytes = address.to_bytes_le();
+            expect(Address.isValid(bytes)).equal(true);
+        });
+
+        it('returns false for invalid address bytes with isValid', () => {
+            expect(Address.isValid(new Uint8Array([1, 2, 3]))).equal(false);
+            expect(Address.isValid(new Uint8Array([]))).equal(false);
+        });
     });
 
     describe('PrivateKey', () => {

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -95,7 +95,7 @@ describe('WASM Objects', () => {
 
         it('validates correct address bytes with isValid', () => {
             const address = Address.from_string(addressString);
-            const bytes = address.to_bytes_le();
+            const bytes = address.toBytesLe();
             expect(Address.isValid(bytes)).equal(true);
         });
 

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -30,7 +30,7 @@ use snarkvm_console::prelude::{FromBits, FromBytes, FromFields, Network, ToBits,
 
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
 use js_sys::{Array, Uint8Array};
-use wasm_bindgen::{convert::TryFromJsValue, prelude::*};
+use wasm_bindgen::{JsCast, convert::TryFromJsValue, prelude::*};
 
 /// Public address of an Aleo account
 #[wasm_bindgen]
@@ -185,6 +185,28 @@ impl Address {
 
         Ok(Address::from(group))
     }
+
+    /// Check if the input is a valid Aleo address.
+    ///
+    /// @param {string | Uint8Array} address - Either a string representation of an address
+    ///        or a Uint8Array of bytes in little-endian format.
+    /// @returns {boolean} True if the input is a valid address, false otherwise.
+    #[wasm_bindgen(js_name = "isValid")]
+    pub fn is_valid(address: JsValue) -> bool {
+        // Try parsing as string first
+        if let Some(address_str) = address.as_string() {
+            return AddressNative::from_str(&address_str).is_ok();
+        }
+
+        // Try parsing as Uint8Array
+        if let Some(bytes) = address.dyn_ref::<Uint8Array>() {
+            let rust_bytes = bytes.to_vec();
+            return AddressNative::from_bytes_le(rust_bytes.as_slice()).is_ok();
+        }
+
+        // Neither string nor Uint8Array
+        false
+    }
 }
 
 impl Deref for Address {
@@ -262,6 +284,8 @@ impl FromStr for Address {
 mod tests {
     use super::*;
     use crate::account::PrivateKey;
+    use js_sys::Uint8Array;
+    use wasm_bindgen::JsValue;
 
     use wasm_bindgen_test::*;
 
@@ -285,5 +309,34 @@ mod tests {
         let expected_address = "aleo1lqmly7ez2k48ajf5hs92ulphaqr05qm4n8qwzj8v0yprmasgpqgsez59gg".to_string();
         let credits_address = Address::from_program_id("credits.aleo").unwrap();
         assert_eq!(credits_address.to_string(), expected_address);
+    }
+
+    #[wasm_bindgen_test]
+    pub fn test_is_valid() {
+        // Test valid string address
+        let valid_address = "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px";
+        assert!(Address::is_valid(JsValue::from_str(valid_address)));
+
+        // Test invalid string addresses
+        assert!(!Address::is_valid(JsValue::from_str("invalid_address")));
+        assert!(!Address::is_valid(JsValue::from_str("aleo1xyz")));
+        assert!(!Address::is_valid(JsValue::from_str("")));
+
+        // Test valid bytes
+        let address = Address::from_string(valid_address);
+        let bytes = address.to_bytes_le().unwrap();
+        assert!(Address::is_valid(JsValue::from(bytes)));
+
+        // Test invalid bytes
+        let invalid_bytes = Uint8Array::new_with_length(3);
+        invalid_bytes.copy_from(&[1, 2, 3]);
+        assert!(!Address::is_valid(JsValue::from(invalid_bytes)));
+
+        // Test empty bytes
+        let empty_bytes = Uint8Array::new_with_length(0);
+        assert!(!Address::is_valid(JsValue::from(empty_bytes)));
+
+        // Test wrong type (number)
+        assert!(!Address::is_valid(JsValue::from_f64(42.0)));
     }
 }


### PR DESCRIPTION
## Motivation

Adds a dedicated method to validate addresses without throwing exceptions. Useful for input validation in forms and APIs.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

- Added Rust tests in `wasm/src/account/address.rs` - run with `yarn test` in `wasm/`
- Added TypeScript tests in `sdk/tests/wasm.test.ts` - run with `yarn test` in `sdk/`

Tests cover: valid/invalid address strings, valid/invalid byte arrays, and incorrect input types.
