### PR TITLE
fix: align create-leo-app scaffolding commands with templates

### DIFF
--- a/create-leo-app/src/index.ts
+++ b/create-leo-app/src/index.ts
@@ -69,6 +69,7 @@ const FRAMEWORKS: Framework[] = [
         name: 'node',
         display: 'Node.js',
         color: green,
+        customCommand: 'start',
       },
     ],
   },
@@ -94,6 +95,7 @@ async function init() {
 
   let selectedFramework: Framework | undefined;
   let selectedVariant: string | undefined;
+  let selectedVariantObj: FrameworkVariant | undefined;
 
   if (argTemplate && TEMPLATES.includes(argTemplate)) {
     for (const framework of FRAMEWORKS) {
@@ -101,6 +103,7 @@ async function init() {
       if (match) {
         selectedFramework = framework;
         selectedVariant = match.name;
+        selectedVariantObj = match;
         break;
       }
     }
@@ -197,6 +200,11 @@ async function init() {
 
   const root = path.join(cwd, targetDir);
 
+  // Find the selected variant object to get customCommand
+  if (!selectedVariantObj && framework) {
+    selectedVariantObj = framework.variants.find((v: FrameworkVariant) => v.name === variant);
+  }
+
   if (overwrite) {
     emptyDir(root);
   } else if (!fs.existsSync(root)) {
@@ -248,10 +256,11 @@ async function init() {
       }`,
     );
   }
+  const runCommand = selectedVariantObj?.customCommand || 'dev';
   switch (pkgManager) {
     default:
       console.log(`  ${pkgManager} install`);
-      console.log(`  ${pkgManager} run dev`);
+      console.log(`  ${pkgManager} ${runCommand === 'dev' ? 'run dev' : runCommand}`);
       break;
   }
   console.log();

--- a/create-leo-app/template-build-and-execute-authorization-ts/README.md
+++ b/create-leo-app/template-build-and-execute-authorization-ts/README.md
@@ -1,5 +1,5 @@
 # Aleo + Node.js + TypeScript
 
-`npm start`
+`npm run dev`
 
 Recommend Node.js 20+ for best performance.

--- a/create-leo-app/template-private-transaction-ts/README.md
+++ b/create-leo-app/template-private-transaction-ts/README.md
@@ -6,12 +6,12 @@ This example can be run with the following
 
 #### Yarn
 ```bash
-yarn dev
+yarn start
 ```
 
 #### NPM
 ```bash
-npm run dev
+npm start
 ```
 
 Recommend Node.js 20+ for best performance.


### PR DESCRIPTION


<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The create-leo-app CLI and some template READMEs were showing incorrect run commands that didn't match the actual scripts in each template's package.json. For example, the Node.js template has a `start` script but the CLI printed `npm run dev`, which would fail. This PR aligns the CLI output and README instructions with the actual available scripts so users can follow the getting-started instructions without confusion.
## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

1. Build create-leo-app:
   ```bash
   cd create-leo-app && npm install && npm run build
   ```

2. Test Node.js template:
   ```bash
   node index.js tmp/test-node -t node
   ```
   - Verify CLI prints `npm start` (not `npm run dev`)

3. Test React template:
   ```bash
   node index.js tmp/test-react -t react-ts
   ```
   - Verify CLI prints `npm run dev`

4. Run TypeScript type check:
   ```bash
   npm run typecheck
   ```
   - Passes with no errors