### PR TITLE
[Test][Feature] Add retry mechanism for REST calls + add deployment tests in create-leo-app

### DIFF
--- a/create-leo-app/template-node-ts/src/index.ts
+++ b/create-leo-app/template-node-ts/src/index.ts
@@ -12,7 +12,7 @@ import {
 // Initialize the thread pool in order to prove faster.
 await initThreadPool();
 
-function generateHelloHelloSource(programName) {
+function generateHelloHelloSource(programName: string) {
     const hello_hello_program =`
 program ${programName};
 
@@ -39,8 +39,8 @@ const keyProvider = new AleoKeyProvider();
 keyProvider.useCache(true);
 programManager.setKeyProvider(keyProvider);
 
-async function localProgramExecution(program, programName, aleoFunction, inputs) {
-    // Pre-synthesize the program keys and then cache them in memory using key provider
+async function localProgramExecution(program: string, programName: string, aleoFunction: string, inputs: string[]) {
+    // Pre-synthesize the program keys and then cache them in memory using the key provider.
     try {
         const keyPair = await programManager.synthesizeKeys(program, aleoFunction, inputs);
 
@@ -76,17 +76,19 @@ async function localProgramExecution(program, programName, aleoFunction, inputs)
 
 // Run a deployment and both online and offline executions.
 async function run(online: boolean = false) {
-    // Generate the hello_hello.aleo program source code.
+    // Generate the hello_hello.aleo program source code and inputs.
     let programName = `hello_hello.aleo`;
     let hello_hello_program = generateHelloHelloSource(programName);
+    const functionName = "hello";
+    const inputs = ["5u32", "5u32"];
 
     console.log("");
     console.log("// --- STEP 1: Execute the program offline to test it gives the expected results. --- //");
     // Execute the program locally.
     console.log(`Executing ${programName}/hello offline`);
     let start = Date.now();
-    const result = await localProgramExecution(hello_hello_program, programName, "hello", ["5u32", "5u32"]);
-    console.log(`✅ Local execute finished in ${Date.now() - start}s`);
+    const result = await localProgramExecution(hello_hello_program, programName, functionName, inputs);
+    console.log(`✅ Local execute finished in ${(Date.now() - start)/1000}s`);
 
     console.log("");
     console.log("// --- STEP 2: Build the deployment transaction. --- //");
@@ -98,16 +100,18 @@ async function run(online: boolean = false) {
         0,
         false,
     )
-    console.log(`✅ Deployment transaction built in ${Date.now() - start}s`);
+    console.log(`✅ Deployment transaction built in ${(Date.now() - start)/1000}s`);
 
     // If the deployment flag is set to true, deploy the program on testnet (requires aleo credits).
-    let programDeployed = false;
     if (online) {
         const txId: string = await programManager.networkClient.submitTransaction(deploymentTx);
         const confirmedTx: ConfirmedTransactionJSON = await programManager.networkClient.waitForTransactionConfirmation(txId);
-        if (txId == confirmedTx.transaction.id) {
+        if (txId === confirmedTx.transaction.id) {
             console.log(`Program ${programName} deployed to Aleo Testnet successfully!`);
         }
+    } else {
+        programName = `hello_hello.aleo`;
+        hello_hello_program = generateHelloHelloSource(programName);
     }
 
     console.log("");
@@ -115,26 +119,28 @@ async function run(online: boolean = false) {
 
     // If the program was actually deployed, execute it online. Otherwise, execute an equivalent
     // program with the same logic.
-    const deployedProgramName = programDeployed ? programName : "hello_hello.aleo";
-    console.log(`Executing ${deployedProgramName}/hello online on the aleo network`);
+    console.log(`Executing ${programName}/hello online on the aleo network`);
     start = Date.now();
+    const keySearchParams = new AleoKeyProviderParams({cacheKey: `${programName}:${functionName}`});
     const executionTx: Transaction = await programManager.buildExecutionTransaction(
         {
-            programName: deployedProgramName,
-            functionName: "hello",
+            programName,
+            functionName,
             priorityFee: 0,
             privateFee: false,
-            inputs: ["5u32", "5u32"]
+            inputs: inputs,
+            keySearchParams,
+            program: hello_hello_program
         }
     )
-    console.log(`✅ Online execution of ${deployedProgramName} built in ${Date.now() - start}s`);
+    console.log(`✅ Online execution of ${programName} built in ${(Date.now() - start)/1000}s`);
 
     // If the online option is specified, submit the transaction to the network.
     if (online) {
         const txId: string = await programManager.networkClient.submitTransaction(executionTx);
         const confirmedTx: ConfirmedTransactionJSON = await programManager.networkClient.waitForTransactionConfirmation(txId);
-        if (txId == confirmedTx.transaction.id) {
-            console.log(`Program ${deployedProgramName}/hello executed successfully!`);
+        if (txId === confirmedTx.transaction.id) {
+            console.log(`Program ${programName}/hello executed successfully!`);
         }
     }
 }

--- a/create-leo-app/template-node-ts/src/index.ts
+++ b/create-leo-app/template-node-ts/src/index.ts
@@ -1,33 +1,48 @@
-import {Account, initThreadPool, ProgramManager, AleoKeyProvider, AleoKeyProviderParams} from "@provablehq/sdk/mainnet.js";
+import {
+    Account,
+    AleoKeyProvider,
+    AleoKeyProviderParams,
+    ConfirmedTransactionJSON,
+    initThreadPool,
+    Program,
+    ProgramManager,
+    Transaction,
+} from "@provablehq/sdk/testnet.js";
 
+// Initialize the thread pool in order to prove faster.
 await initThreadPool();
 
-const programName = "hello_hello.aleo"
-
-const hello_hello_program =`
+function generateHelloHelloSource(programName) {
+    const hello_hello_program =`
 program ${programName};
 
 function hello:
     input r0 as u32.public;
     input r1 as u32.private;
     add r0 r1 into r2;
-    output r2 as u32.private;`
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+`;
+    return hello_hello_program;
+}
+
+const programManager = new ProgramManager();
+
+// Create a temporary account for the execution of the program
+const account = new Account();
+programManager.setAccount(account);
+
+// Create a key provider in order to re-use the same key for each execution
+const keyProvider = new AleoKeyProvider();
+keyProvider.useCache(true);
+programManager.setKeyProvider(keyProvider);
 
 async function localProgramExecution(program, programName, aleoFunction, inputs) {
-    const programManager = new ProgramManager();
-
-    // Create a temporary account for the execution of the program
-    const account = new Account();
-    programManager.setAccount(account);
-
-    // Create a key provider in order to re-use the same key for each execution
-    const keyProvider = new AleoKeyProvider();
-    keyProvider.useCache(true);
-    programManager.setKeyProvider(keyProvider);
-
     // Pre-synthesize the program keys and then cache them in memory using key provider
     try {
-        const keyPair = await programManager.synthesizeKeys(hello_hello_program, aleoFunction, inputs);
+        const keyPair = await programManager.synthesizeKeys(program, aleoFunction, inputs);
 
         programManager.keyProvider.cacheKeys(`${programName}:${aleoFunction}`, keyPair);
 
@@ -59,7 +74,70 @@ async function localProgramExecution(program, programName, aleoFunction, inputs)
     }
 }
 
-const start = Date.now();
-console.log("Starting execute!");
-await localProgramExecution(hello_hello_program, programName, "hello", ["5u32", "5u32"]);
-console.log("Execute finished!", Date.now() - start);
+// Run a deployment and both online and offline executions.
+async function run(online: boolean = false) {
+    // Generate the hello_hello.aleo program source code.
+    let programName = `hello_hello.aleo`;
+    let hello_hello_program = generateHelloHelloSource(programName);
+
+    console.log("");
+    console.log("// --- STEP 1: Execute the program offline to test it gives the expected results. --- //");
+    // Execute the program locally.
+    console.log(`Executing ${programName}/hello offline`);
+    let start = Date.now();
+    const result = await localProgramExecution(hello_hello_program, programName, "hello", ["5u32", "5u32"]);
+    console.log(`✅ Local execute finished in ${Date.now() - start}s`);
+
+    console.log("");
+    console.log("// --- STEP 2: Build the deployment transaction. --- //");
+    start = Date.now();
+    programName = `hello_hello_${Math.floor(Math.random() * 65536)}.aleo`;
+    hello_hello_program = generateHelloHelloSource(programName);
+    const deploymentTx: Transaction = await programManager.buildDeploymentTransaction(
+        hello_hello_program,
+        0,
+        false,
+    )
+    console.log(`✅ Deployment transaction built in ${Date.now() - start}s`);
+
+    // If the deployment flag is set to true, deploy the program on testnet (requires aleo credits).
+    let programDeployed = false;
+    if (online) {
+        const txId: string = await programManager.networkClient.submitTransaction(deploymentTx);
+        const confirmedTx: ConfirmedTransactionJSON = await programManager.networkClient.waitForTransactionConfirmation(txId);
+        if (txId == confirmedTx.transaction.id) {
+            console.log(`Program ${programName} deployed to Aleo Testnet successfully!`);
+        }
+    }
+
+    console.log("");
+    console.log("// --- STEP 3: Execute the program ONLINE. --- //");
+
+    // If the program was actually deployed, execute it online. Otherwise, execute an equivalent
+    // program with the same logic.
+    const deployedProgramName = programDeployed ? programName : "hello_hello.aleo";
+    console.log(`Executing ${deployedProgramName}/hello online on the aleo network`);
+    start = Date.now();
+    const executionTx: Transaction = await programManager.buildExecutionTransaction(
+        {
+            programName: deployedProgramName,
+            functionName: "hello",
+            priorityFee: 0,
+            privateFee: false,
+            inputs: ["5u32", "5u32"]
+        }
+    )
+    console.log(`✅ Online execution of ${deployedProgramName} built in ${Date.now() - start}s`);
+
+    // If the online option is specified, submit the transaction to the network.
+    if (online) {
+        const txId: string = await programManager.networkClient.submitTransaction(executionTx);
+        const confirmedTx: ConfirmedTransactionJSON = await programManager.networkClient.waitForTransactionConfirmation(txId);
+        if (txId == confirmedTx.transaction.id) {
+            console.log(`Program ${deployedProgramName}/hello executed successfully!`);
+        }
+    }
+}
+
+// Run the offline execution, deployment, and online execution of hello_hello.aleo.
+await run(false);

--- a/create-leo-app/template-node-ts/src/index.ts
+++ b/create-leo-app/template-node-ts/src/index.ts
@@ -4,7 +4,6 @@ import {
     AleoKeyProviderParams,
     ConfirmedTransactionJSON,
     initThreadPool,
-    Program,
     ProgramManager,
     Transaction,
 } from "@provablehq/sdk/testnet.js";

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -78,6 +78,12 @@ version = "0.1.68"
 [dependencies.console_error_panic_hook]
 version = "0.1.7"
 
+[dependencies.gloo-timers]
+version = "0.3.0"
+features = [
+    "futures",
+]
+
 [dependencies.indexmap]
 version = "2.0.0"
 
@@ -129,12 +135,6 @@ features = [
     "Url",
     "Navigator",
     "Window",
-]
-
-[dev-dependencies.gloo-timers]
-version = "0.3.0"
-features = [
-    "futures",
 ]
 
 [dev-dependencies.wasm-bindgen-test]

--- a/wasm/src/programs/manager/mod.rs
+++ b/wasm/src/programs/manager/mod.rs
@@ -81,7 +81,7 @@ impl ProgramManager {
             program,
             function_id,
             inputs,
-            false,
+            true,
             true,
             imports,
             None,

--- a/wasm/src/utilities/rest.rs
+++ b/wasm/src/utilities/rest.rs
@@ -21,13 +21,20 @@ use crate::{
 
 use anyhow::{Result, bail};
 use gloo_timers::future::TimeoutFuture;
+use reqwest::StatusCode;
 use snarkvm_console::network::Network;
 
+/// Default number of retries for REST methods in the SDK.
 pub const DEFAULT_RETRIES: usize = 3;
+/// Default base timeout for exponential backoff in milliseconds.
 pub const DEFAULT_TIMEOUT_MS: u32 = 200;
 
-async fn sleep(ms: u32) {
-    TimeoutFuture::new(ms).await;
+// Exponential backoff helper.
+async fn backoff(attempt: u32, status: Option<StatusCode>, error: reqwest::Error, url: &str) {
+    let retry_interval = DEFAULT_TIMEOUT_MS * 2u32.pow(attempt);
+    let status = status.map(|code| format!("{code} ")).unwrap_or("".to_string());
+    log(&format!("Error - {status}response from {url}: {error}, retrying in {retry_interval}ms"));
+    TimeoutFuture::new(retry_interval).await;
 }
 
 /// Get the current network name.
@@ -91,25 +98,18 @@ where
         let request = client.get(url).send().await;
         match request {
             Ok(res) => {
-                let status = res.status().as_u16();
+                let status = res.status();
                 match res.json::<T>().await {
                     Ok(data) => return Ok(data),
                     Err(e) => {
                         // Log the error and retry.
-                        let retry_interval = DEFAULT_TIMEOUT_MS * 2u32.pow(i as u32);
-                        log(&format!(
-                            "Failed to get response from {url} with {status} code, error: {e}. retrying in {retry_interval}ms"
-                        ));
-                        sleep(retry_interval).await;
+                        backoff(i as u32, Some(status), e, url).await;
                     }
                 }
             }
             Err(e) => {
                 // Log the error and retry.
-                let retry_interval = DEFAULT_TIMEOUT_MS * 2u32.pow(i as u32);
-                log(&format!("Failed to get response from {url}: {e}, retrying in {retry_interval}ms"));
-                sleep(retry_interval).await;
-                continue;
+                backoff(i as u32, e.status(), e, url).await;
             }
         }
     }

--- a/wasm/src/utilities/rest.rs
+++ b/wasm/src/utilities/rest.rs
@@ -19,8 +19,16 @@ use crate::{
     types::native::{CurrentNetwork, FieldNative, StatePathNative},
 };
 
-use anyhow::Result;
+use anyhow::{Result, bail};
+use gloo_timers::future::TimeoutFuture;
 use snarkvm_console::network::Network;
+
+pub const DEFAULT_RETRIES: usize = 3;
+pub const DEFAULT_TIMEOUT_MS: u32 = 200;
+
+async fn sleep(ms: u32) {
+    TimeoutFuture::new(ms).await;
+}
 
 /// Get the current network name.
 pub fn get_network() -> &'static str {
@@ -79,8 +87,33 @@ where
     T: serde::de::DeserializeOwned,
 {
     let client = reqwest::Client::new();
-    let res = client.get(url).send().await?.json().await?;
-    Ok(res)
+    for i in 0..DEFAULT_RETRIES {
+        let request = client.get(url).send().await;
+        match request {
+            Ok(res) => {
+                let status = res.status().as_u16();
+                match res.json::<T>().await {
+                    Ok(data) => return Ok(data),
+                    Err(e) => {
+                        // Log the error and retry.
+                        let retry_interval = DEFAULT_TIMEOUT_MS * 2u32.pow(i as u32);
+                        log(&format!(
+                            "Failed to get response from {url} with {status} code, error: {e}. retrying in {retry_interval}ms"
+                        ));
+                        sleep(retry_interval).await;
+                    }
+                }
+            }
+            Err(e) => {
+                // Log the error and retry.
+                let retry_interval = DEFAULT_TIMEOUT_MS * 2u32.pow(i as u32);
+                log(&format!("Failed to get response from {url}: {e}, retrying in {retry_interval}ms"));
+                sleep(retry_interval).await;
+                continue;
+            }
+        }
+    }
+    bail!("Failed to get response from {url} after {DEFAULT_RETRIES} retries");
 }
 
 #[cfg(test)]
@@ -117,8 +150,7 @@ mod tests {
                 )
                 .unwrap(),
             ];
-            let state_paths =
-                get_statepaths_for_commitments("https://api.explorer.provable.com/v1", &commitments).await.unwrap();
+            let state_paths = get_statepaths_for_commitments(PROVABLE_API, &commitments).await.unwrap();
             assert_eq!(state_paths.len(), 2);
             assert_eq!(state_paths[0].global_state_root(), state_paths[1].global_state_root());
         }


### PR DESCRIPTION
## Motivation

Users of deployment flows seem to error occasionally. Part of this is likely due to the fact that some requests MUST be done within the `wasm` flows in the SDK. This PR updates the REST calls being done in the SDK to retry with expoential backoff on failure.

Further this PR adds further code to deploy and execute programs both online and offline to the `create-leo-app/node.ts` example to ensure deployment is working in CI, further PRs should add other examples which deploy programs with multiple imports.

## Test Plan

* This PR adds testing of SDK deployments via create-leo-app.