### PR TITLE
[Fix] RecordPlaintext.owner() and OwnedRecord property names for private records

### DIFF
--- a/sdk/src/record-provider.ts
+++ b/sdk/src/record-provider.ts
@@ -262,9 +262,9 @@ class NetworkRecordProvider implements RecordProvider {
         const recordsPts = await this.networkClient.findRecords(startHeight, endHeight, searchParameters.unspent, ["credits.aleo"], microcredits, maxAmount, searchParameters.nonces, this.account.privateKey());
         return recordsPts.map((record) => ({
                 owner: record.owner().toString(),
-                programName: 'credits.aleo',
-                recordName: 'credits',
-                recordPlaintext: record.toString(),
+                program_name: 'credits.aleo',
+                record_name: 'credits',
+                record_plaintext: record.toString(),
         }));
     }
 

--- a/wasm/src/record/record_plaintext.rs
+++ b/wasm/src/record/record_plaintext.rs
@@ -32,6 +32,7 @@ use crate::{
             CurrentNetwork,
             FieldNative,
             IdentifierNative,
+            LiteralNative,
             PlaintextEntryNative,
             PlaintextNative,
             ProgramIDNative,
@@ -108,7 +109,11 @@ impl RecordPlaintext {
     pub fn owner(&self) -> Result<Address, String> {
         match self.0.owner() {
             Owner::<CurrentNetwork, PlaintextNative>::Public(owner) => Ok(Address::from(*owner)),
-            _ => Err("Record is not public".to_string()),
+            // For decrypted records, extract the address from the plaintext literal
+            Owner::<CurrentNetwork, PlaintextNative>::Private(plaintext) => match plaintext {
+                PlaintextNative::Literal(LiteralNative::Address(address), _) => Ok(Address::from(*address)),
+                _ => Err("Private owner is not an address literal".to_string()),
+            },
         }
     }
 
@@ -467,6 +472,20 @@ mod tests {
             Some("The record plaintext string provided was invalid".into())
         );
         assert!(RecordPlaintext::from_string(invalid_bech32).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_owner_with_private_visibility() {
+        let record = RecordPlaintext::from_string(CREDITS_RECORD).unwrap();
+        let owner = record.owner().unwrap();
+        assert_eq!(owner.to_string(), "aleo1j7qxyunfldj2lp8hsvy7mw5k8zaqgjfyr72x2gh3x4ewgae8v5gscf5jh3");
+    }
+
+    #[wasm_bindgen_test]
+    fn test_owner_with_private_visibility_battleship() {
+        let record = RecordPlaintext::from_string(BATTLESHIP_RECORD).unwrap();
+        let owner = record.owner().unwrap();
+        assert_eq!(owner.to_string(), "aleo1kh5t7m30djl0ecdn4f5vuzp7dx0tcwh7ncquqjkm4matj2p2zqpqm6at48");
     }
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Private transfer integration tests were failing when attempting to use records created via transfer_public_to_private.

Two bugs were identified:

RecordPlaintext.owner() only handled public owner visibility: 
- Records created by `transfer_public_to_private` store the owner with private visibility. The owner() method returned "Record is not public" instead of extracting the address from the decrypted plaintext.

Property name mismatch in NetworkRecordProvider:
- findCreditsRecords() returned camelCase properties (`recordPlaintext`, `programName`) but `OwnedRecord` type and consumers expected snake_case (`record_plaintext`, `program_name`).

These issues prevented the SDK from finding and using shielded records for private transfers.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

- Added 2 unit tests for private owner extraction
- Verified tests fail without fix, pass with fix
- Ran transfer-private integration test. Confirmed transfer-private test runs completely

