### PR TITLE
fix: use dot-delimited type strings for dynamic record and future

### DIFF
--- a/wasm/src/programs/program.rs
+++ b/wasm/src/programs/program.rs
@@ -184,14 +184,14 @@ impl Program {
                 }
                 ValueType::DynamicRecord => {
                     let input = Object::new();
-                    let value_type = JsValue::from_str("dynamic_record");
+                    let value_type = JsValue::from_str("dynamic.record");
                     Reflect::set(&input, &"type".into(), &value_type).map_err(|_| "Failed to set property")?;
                     Reflect::set(&input, &"register".into(), &register).map_err(|_| "Failed to set property")?;
                     function_inputs.set(index as u32, input.into());
                 }
                 ValueType::DynamicFuture => {
                     let input = Object::new();
-                    let value_type = JsValue::from_str("dynamic_future");
+                    let value_type = JsValue::from_str("dynamic.future");
                     Reflect::set(&input, &"type".into(), &value_type).map_err(|_| "Failed to set property")?;
                     Reflect::set(&input, &"register".into(), &register).map_err(|_| "Failed to set property")?;
                     function_inputs.set(index as u32, input.into());


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The `ValueType::DynamicRecord` and `ValueType::DynamicFuture` variants in `get_inputs()` serialize their type strings with underscores (`dynamic_record`, `dynamic_future`) instead of dots (`dynamic.record`, `dynamic.future`). This is inconsistent with snarkVM's Display implementation for these types ([value_type/parse.rs:71-72](https://github.com/ProvableHQ/snarkVM/blob/feat/dynamic-dispatch/console/program/src/data_types/value_type/parse.rs#L71-L72)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the serialized `type` strings returned by `Program.getFunctionInputs()` for `DynamicRecord`/`DynamicFuture`, which may break consumers relying on the previous underscore format.
> 
> **Overview**
> Fixes `Program.getFunctionInputs()` to serialize `ValueType::DynamicRecord` and `ValueType::DynamicFuture` using dot-delimited `type` strings (`dynamic.record`, `dynamic.future`) instead of underscore-delimited variants.
> 
> This brings the WASM program-introspection output in line with snarkVM’s type string conventions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7e79a91fd6f3f554847469fdb98bcd24371592a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->