### PR TITLE
[Feature] Build authorization via execution request

### DIFF
--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -20,6 +20,7 @@ import {
 import {
     Address,
     Authorization,
+    ExecutionRequest,
     ExecutionResponse,
     Execution as FunctionExecution,
     OfflineQuery,
@@ -199,6 +200,7 @@ interface ProvingRequestOptions {
     unchecked?: boolean;
     edition?: number;
     useFeeMaster?: boolean;
+    executionRequest?: ExecutionRequest,
 }
 
 /**
@@ -1353,7 +1355,7 @@ class ProgramManager {
     }
 
     /**
-     * Builds a `ProvingRequest` for submission to a prover for execution.
+     * Builds a `ProvingRequest` for submission to a prover for execution. If building a proving request with an ExecutionRequest, a private key must be explicitly provided.
      *
      * @param {ProvingRequestOptions} options - The options for building the proving request
      * @returns {Promise<ProvingRequest>} - A promise that resolves to the transaction or an error.
@@ -1439,13 +1441,10 @@ class ProgramManager {
         let executionPrivateKey = privateKey;
         if (
             typeof privateKey === "undefined" &&
-            typeof this.account !== "undefined"
+            typeof this.account !== "undefined" &&
+            typeof options.executionRequest === "undefined"
         ) {
             executionPrivateKey = this.account.privateKey();
-        }
-
-        if (typeof executionPrivateKey === "undefined") {
-            throw "No private key provided and no private key set in the ProgramManager";
         }
 
         // Resolve the program imports if they exist.
@@ -1489,21 +1488,37 @@ class ProgramManager {
             );
         }
 
-        // Build and return the `ProvingRequest`.
-        return await WasmProgramManager.buildProvingRequest(
-            executionPrivateKey,
-            program,
-            functionName,
-            inputs,
-            baseFee,
-            priorityFee,
-            feeRecord,
-            imports,
-            broadcast,
-            unchecked,
-            edition,
-            useFeeMaster
-        );
+        if (options.executionRequest instanceof ExecutionRequest) {
+            return await WasmProgramManager.buildProvingRequestFromExecutionRequest(
+                options.executionRequest,
+                program,
+                imports,
+                unchecked,
+                broadcast,
+                executionPrivateKey,
+            )
+        } else {
+            // Ensure the private key exists.
+            if (typeof executionPrivateKey === "undefined") {
+                throw "No private key provided and no private key set in the ProgramManager";
+            }
+
+            // Build and return the `ProvingRequest`.
+            return await WasmProgramManager.buildProvingRequest(
+                executionPrivateKey,
+                program,
+                functionName,
+                inputs,
+                baseFee,
+                priorityFee,
+                feeRecord,
+                imports,
+                broadcast,
+                unchecked,
+                edition,
+                useFeeMaster
+            );
+        }
     }
 
     /**

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -1463,7 +1463,7 @@ class ProgramManager {
 
         // Get the fee record from the account if it is not provided in the parameters
         try {
-            if (privateFee && !useFeeMaster) {
+            if (privateFee && !useFeeMaster && !options.executionRequest) {
                 let fee = priorityFee;
                 // If a fee record wasn't provided, estimate the fee that needs to be paid.
                 if (!feeRecord) {

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -1492,9 +1492,10 @@ class ProgramManager {
             return await WasmProgramManager.buildProvingRequestFromExecutionRequest(
                 options.executionRequest,
                 program,
-                imports,
                 unchecked,
                 broadcast,
+                edition,
+                imports,
                 executionPrivateKey,
             )
         } else {

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -3,6 +3,7 @@ import {
     AleoKeyProvider,
     Authorization,
     CREDITS_PROGRAM_KEYS,
+    ExecutionRequest,
     ExecutionResponse,
     ImportedPrograms,
     ImportedVerifyingKeys,
@@ -303,6 +304,44 @@ describe('Program Manager', async () => {
 
             const authorization = provingRequest.authorization();
             expect(authorization.transitions().length).equal(3);
+        });
+
+        it('Should build proving request from ExecutionRequest', async () => {
+            const privateKey = PrivateKey.from_string(
+                "APrivateKey1zkp7Vc4xJt8HqW9U7VhY6h32d8Z9Xi5C6ZZX3gtXxbBSJmj"
+            );
+            const inputs = [
+                "aleo1wp5f52cujua034ts029lq96ke2p505sqc0yrt7yx7x0fcel82yxqe867q9",
+                "500u64",
+            ];
+            const inputTypes = ["address.public", "u64.public"];
+            const executionRequest = ExecutionRequest.sign(
+                privateKey,
+                "credits.aleo",
+                "transfer_public",
+                inputs,
+                inputTypes,
+                undefined,
+                undefined,
+                true
+            );
+            
+            // Ensure the execution request is valid.
+            const provingRequest = await programManager.provingRequest({
+                programName: "credits.aleo",
+                functionName: "transfer_public",
+                priorityFee: 0,
+                privateFee: false,
+                inputs,
+                broadcast: false,
+                executionRequest,
+                privateKey,
+            });
+
+            const authorization = provingRequest.authorization();
+            expect(authorization.len()).equal(1);
+            expect(authorization.transitions().length).equal(1);
+            expect(provingRequest.feeAuthorization()).equal(undefined);
         });
 
         it('Should build correct authorizations', async () => {

--- a/wasm/src/programs/manager/authorize.rs
+++ b/wasm/src/programs/manager/authorize.rs
@@ -18,13 +18,25 @@ use super::*;
 
 use crate::{
     Authorization,
+    ExecutionRequest,
     PrivateKey,
     RecordPlaintext,
     authorize,
     authorize_fee,
     log,
     process_inputs,
-    types::native::{CurrentAleo, FieldNative, IdentifierNative, ProcessNative, ProgramNative, RecordPlaintextNative},
+    types::native::{
+        AuthorizationNative,
+        CallStackNative,
+        CurrentAleo,
+        FieldNative,
+        IdentifierNative,
+        PrivateKeyNative,
+        ProcessNative,
+        ProgramNative,
+        RecordPlaintextNative,
+        RequestNative,
+    },
 };
 
 use js_sys::{Array, Object};
@@ -114,6 +126,71 @@ impl ProgramManager {
             edition
         ));
         Ok(authorization)
+    }
+
+    /// Build an authorization from a `Request` object.
+    ///
+    /// @param {ExecutionRequest} request The execution request to build the authorization from.
+    /// @param {string} program The program source code containing the function to authorize.
+    /// @param {object} imports The imports to the program in the format {"programname.aleo":"aleo instructions source code"}.
+    /// @param {boolean} unchecked Whether or not to generate an unchecked authorization.
+    /// @param {PrivateKey} [private_key] Optional private key of the signer. If not provided, functions which call other programs may not succeed.
+    #[wasm_bindgen(js_name = buildAuthorizationFromExecutionRequest)]
+    pub async fn authorize_request(
+        request: &ExecutionRequest,
+        program: &str,
+        imports: Option<Object>,
+        unchecked: bool,
+        private_key: Option<PrivateKey>,
+    ) -> Result<Authorization, String> {
+        // Load the process.
+        let mut process_native = ProcessNative::load_web().map_err(|err| err.to_string())?;
+        let process = &mut process_native;
+
+        // Get the private key.
+        let private_key_native = private_key.map(|pk| PrivateKeyNative::from(pk));
+
+        // Get the request from the wasm wrapper.
+        let request_native = RequestNative::from(request);
+
+        log("Check program imports are valid and add them to the process");
+        let program_native = ProgramNative::from_str(program).map_err(|e| e.to_string())?;
+
+        log(&format!("Creating proving request for {}:{}", program_native.id(), request.function_name()));
+        ProgramManager::resolve_imports(process, &program_native, imports)?;
+        let rng = &mut StdRng::from_entropy();
+
+        // If a private key is provided, use it to authorize the request, otherwise use authorize_request method.
+        let authorization = match private_key_native {
+            Some(private_key_native) => {
+                // Initialize the authorization from the request.
+                let authorization = AuthorizationNative::new(request_native.clone());
+
+                // Get the stack.
+                let stack = process.get_stack(program_native.id()).map_err(|e| e.to_string())?;
+
+                // Construct the call stack.
+                let call_stack =
+                    CallStackNative::Authorize(vec![request_native], Some(private_key_native), authorization.clone());
+                let caller = None;
+                let root_tvk = None;
+
+                // Build unchecked or checked authorization depending on the flag.
+                if unchecked {
+                    let _response = stack
+                        .evaluate_function::<CurrentAleo, _>(call_stack, caller, root_tvk, rng)
+                        .map_err(|e| e.to_string())?;
+                } else {
+                    let _response = stack
+                        .execute_function::<CurrentAleo, _>(call_stack, caller, root_tvk, rng)
+                        .map_err(|e| e.to_string())?;
+                }
+                authorization
+            }
+            None => process.authorize_request::<CurrentAleo, _>(request_native, rng).map_err(|e| e.to_string())?,
+        };
+
+        Ok(Authorization::from(authorization))
     }
 
     /// Create an `Authorization` for `credits.aleo/fee_public` or `credits.aleo/fee_private`.

--- a/wasm/src/programs/manager/authorize.rs
+++ b/wasm/src/programs/manager/authorize.rs
@@ -132,9 +132,10 @@ impl ProgramManager {
     ///
     /// @param {ExecutionRequest} request The execution request to build the authorization from.
     /// @param {string} program The program source code containing the function to authorize.
-    /// @param {object} imports The imports to the program in the format {"programname.aleo":"aleo instructions source code"}.
     /// @param {boolean} unchecked Whether or not to generate an unchecked authorization.
-    /// @param {PrivateKey} [private_key] Optional private key of the signer. If not provided, functions which call other programs may not succeed.
+    /// @param {number | undefined} edition The edition of the program.
+    /// @param {object | undefined} imports The imports to the program in the format {"programname.aleo":"aleo instructions source code"}.
+    /// @param {PrivateKey | undefined} [private_key] Optional private key of the signer. If not provided, functions which call other programs may not succeed.
     #[wasm_bindgen(js_name = buildAuthorizationFromExecutionRequest)]
     pub async fn authorize_request(
         request: &ExecutionRequest,

--- a/wasm/src/programs/manager/authorize.rs
+++ b/wasm/src/programs/manager/authorize.rs
@@ -240,9 +240,49 @@ impl ProgramManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utilities::test::{PUZZLE_SPINNER_V002, generate_puzzle_imports, generate_puzzle_inputs, get_env};
+    use crate::{
+        ExecutionRequest,
+        PrivateKey,
+        Program,
+        array,
+        utilities::test::{PUZZLE_SPINNER_V002, generate_puzzle_imports, generate_puzzle_inputs, get_env},
+    };
 
     use wasm_bindgen_test::*;
+
+    /// Build an ExecutionRequest for credits.aleo transfer_public for use in authorize_request / proving_request_from_execution_request tests.
+    fn transfer_public_execution_request() -> ExecutionRequest {
+        let private_key =
+            PrivateKey::from_string("APrivateKey1zkp7Vc4xJt8HqW9U7VhY6h32d8Z9Xi5C6ZZX3gtXxbBSJmj").unwrap();
+        let inputs = array!["aleo1wp5f52cujua034ts029lq96ke2p505sqc0yrt7yx7x0fcel82yxqe867q9", "500u64"];
+        let input_types = array!["address.public", "u64.public"];
+        ExecutionRequest::sign(
+            private_key,
+            "credits.aleo".to_string(),
+            "transfer_public".to_string(),
+            inputs,
+            input_types,
+            None,
+            None,
+            true,
+        )
+        .unwrap()
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_authorize_request_from_execution_request() {
+        let request = transfer_public_execution_request();
+        let private_key =
+            PrivateKey::from_string("APrivateKey1zkp7Vc4xJt8HqW9U7VhY6h32d8Z9Xi5C6ZZX3gtXxbBSJmj").unwrap();
+        let program = Program::get_credits_program();
+        let program_str = program.to_string();
+
+        let authorization =
+            ProgramManager::authorize_request(&request, &program_str, None, false, Some(private_key)).await.unwrap();
+
+        assert_eq!(authorization.len(), 1, "transfer_public authorization should have 1 request");
+        assert_eq!(authorization.transitions().length(), 1, "transfer_public authorization should have 1 transition");
+    }
 
     #[wasm_bindgen_test]
     async fn test_authorization() {

--- a/wasm/src/programs/manager/authorize.rs
+++ b/wasm/src/programs/manager/authorize.rs
@@ -158,15 +158,24 @@ impl ProgramManager {
         log("Check program imports are valid and add them to the process");
         let program_native = ProgramNative::from_str(program).map_err(|e| e.to_string())?;
 
-        log(&format!("Creating proving request for {}:{}", program_native.id(), request.function_name()));
+        // Check that the program id matches the program id in the request.
+        let request_program_id = request_native.program_id();
+        if request_program_id != program_native.id() {
+            return Err(format!(
+                "ExecutionRequest program id '{}' does not match provided program source id '{}'",
+                request_program_id,
+                program_native.id()
+            ));
+        }
+
+        log(&format!("Creating proving request for {request_program_id}:{}", request.function_name()));
         ProgramManager::resolve_imports(process, &program_native, imports)?;
         let rng = &mut StdRng::from_entropy();
 
         // Add the program to the process if it is not already there.
         let edition = edition.unwrap_or(1);
-        let program_id = program_native.id();
-        if program_id.to_string() != "credits.aleo" {
-            if !process.contains_program(program_id) {
+        if request_program_id.to_string() != "credits.aleo" {
+            if !process.contains_program(request_program_id) {
                 log("Adding program to the process");
                 process.add_program_with_edition(&program_native, edition).map_err(|e| e.to_string())?;
             }

--- a/wasm/src/programs/manager/authorize.rs
+++ b/wasm/src/programs/manager/authorize.rs
@@ -139,8 +139,9 @@ impl ProgramManager {
     pub async fn authorize_request(
         request: &ExecutionRequest,
         program: &str,
-        imports: Option<Object>,
         unchecked: bool,
+        edition: Option<u16>,
+        imports: Option<Object>,
         private_key: Option<PrivateKey>,
     ) -> Result<Authorization, String> {
         // Load the process.
@@ -159,6 +160,16 @@ impl ProgramManager {
         log(&format!("Creating proving request for {}:{}", program_native.id(), request.function_name()));
         ProgramManager::resolve_imports(process, &program_native, imports)?;
         let rng = &mut StdRng::from_entropy();
+
+        // Add the program to the process if it is not already there.
+        let edition = edition.unwrap_or(1);
+        let program_id = program_native.id();
+        if program_id.to_string() != "credits.aleo" {
+            if !process.contains_program(program_id) {
+                log("Adding program to the process");
+                process.add_program_with_edition(&program_native, edition).map_err(|e| e.to_string())?;
+            }
+        }
 
         // If a private key is provided, use it to authorize the request, otherwise use authorize_request method.
         let authorization = match private_key_native {
@@ -278,7 +289,9 @@ mod tests {
         let program_str = program.to_string();
 
         let authorization =
-            ProgramManager::authorize_request(&request, &program_str, None, false, Some(private_key)).await.unwrap();
+            ProgramManager::authorize_request(&request, &program_str, false, Some(1), None, Some(private_key))
+                .await
+                .unwrap();
 
         assert_eq!(authorization.len(), 1, "transfer_public authorization should have 1 request");
         assert_eq!(authorization.transitions().length(), 1, "transfer_public authorization should have 1 transition");

--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -152,9 +152,60 @@ impl ProgramManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::{PUZZLE_SPINNER_V002, generate_puzzle_imports, generate_puzzle_inputs, get_env};
+    use crate::{
+        ExecutionRequest,
+        PrivateKey,
+        Program,
+        array,
+        test::{PUZZLE_SPINNER_V002, generate_puzzle_imports, generate_puzzle_inputs, get_env},
+    };
 
     use wasm_bindgen_test::*;
+
+    /// Build an ExecutionRequest for credits.aleo transfer_public for use in proving_request_from_execution_request test.
+    fn transfer_public_execution_request() -> ExecutionRequest {
+        let private_key =
+            PrivateKey::from_string("APrivateKey1zkp7Vc4xJt8HqW9U7VhY6h32d8Z9Xi5C6ZZX3gtXxbBSJmj").unwrap();
+        let inputs = array!["aleo1wp5f52cujua034ts029lq96ke2p505sqc0yrt7yx7x0fcel82yxqe867q9", "500u64"];
+        let input_types = array!["address.public", "u64.public"];
+        ExecutionRequest::sign(
+            private_key,
+            "credits.aleo".to_string(),
+            "transfer_public".to_string(),
+            inputs,
+            input_types,
+            None,
+            None,
+            true,
+        )
+        .unwrap()
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_proving_request_from_execution_request() {
+        let request = transfer_public_execution_request();
+        let private_key =
+            PrivateKey::from_string("APrivateKey1zkp7Vc4xJt8HqW9U7VhY6h32d8Z9Xi5C6ZZX3gtXxbBSJmj").unwrap();
+        let program = Program::get_credits_program();
+        let program_str = program.to_string();
+
+        let proving_request = ProgramManager::proving_request_from_execution_request(
+            &request,
+            &program_str,
+            None,
+            false,
+            false,
+            Some(private_key),
+        )
+        .await
+        .unwrap();
+
+        let authorization = proving_request.authorization();
+        assert_eq!(authorization.len(), 1, "transfer_public should have 1 request");
+        assert_eq!(authorization.transitions().length(), 1, "transfer_public should have 1 transition");
+        // No fee authorization when built from ExecutionRequest (fee is paid by fee master or handled separately).
+        assert!(proving_request.fee_authorization().is_none());
+    }
 
     #[wasm_bindgen_test]
     async fn test_nested_proving_request() {

--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -17,6 +17,7 @@
 use super::*;
 
 use crate::{
+    ExecutionRequest,
     PrivateKey,
     ProvingRequest,
     RecordPlaintext,
@@ -24,7 +25,14 @@ use crate::{
     authorize_fee,
     log,
     process_inputs,
-    types::native::{CurrentAleo, IdentifierNative, ProcessNative, ProgramNative, RecordPlaintextNative},
+    types::native::{
+        AuthorizationNative,
+        CurrentAleo,
+        IdentifierNative,
+        ProcessNative,
+        ProgramNative,
+        RecordPlaintextNative,
+    },
 };
 
 use js_sys::{Array, Object};
@@ -114,6 +122,30 @@ impl ProgramManager {
 
         // Return the proving request.
         Ok(ProvingRequest::from((authorization, fee_authorization, broadcast)))
+    }
+
+    /// Build a proving request from a `Request` object. By default this method currently uses the feemaster.
+    ///
+    /// @param {ExecutionRequest} request The execution request to build the authorization from.
+    /// @param {string} program The program source code containing the function to authorize.
+    /// @param {object} imports The imports to the program in the format {"programname.aleo":"aleo instructions source code"}.
+    /// @param {boolean} unchecked Whether or not to generate an unchecked authorization.
+    /// @param {PrivateKey | undefined} [private_key] Optional private key of the signer. If not provided, functions which call other programs may not succeed.
+    #[wasm_bindgen(js_name = buildProvingRequestFromExecutionRequest)]
+    pub async fn proving_request_from_execution_request(
+        request: &ExecutionRequest,
+        program: &str,
+        imports: Option<Object>,
+        unchecked: bool,
+        broadcast: bool,
+        private_key: Option<PrivateKey>,
+    ) -> Result<ProvingRequest, String> {
+        let authorization = ProgramManager::authorize_request(request, program, imports, unchecked, private_key)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Return the proving request.
+        Ok(ProvingRequest::from((AuthorizationNative::from(authorization), None, broadcast)))
     }
 }
 

--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -135,14 +135,16 @@ impl ProgramManager {
     pub async fn proving_request_from_execution_request(
         request: &ExecutionRequest,
         program: &str,
-        imports: Option<Object>,
         unchecked: bool,
         broadcast: bool,
+        edition: Option<u16>,
+        imports: Option<Object>,
         private_key: Option<PrivateKey>,
     ) -> Result<ProvingRequest, String> {
-        let authorization = ProgramManager::authorize_request(request, program, imports, unchecked, private_key)
-            .await
-            .map_err(|e| e.to_string())?;
+        let authorization =
+            ProgramManager::authorize_request(request, program, unchecked, edition, imports, private_key)
+                .await
+                .map_err(|e| e.to_string())?;
 
         // Return the proving request.
         Ok(ProvingRequest::from((AuthorizationNative::from(authorization), None, broadcast)))
@@ -192,9 +194,10 @@ mod tests {
         let proving_request = ProgramManager::proving_request_from_execution_request(
             &request,
             &program_str,
+            false,
+            false,
+            Some(1),
             None,
-            false,
-            false,
             Some(private_key),
         )
         .await

--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -128,8 +128,10 @@ impl ProgramManager {
     ///
     /// @param {ExecutionRequest} request The execution request to build the authorization from.
     /// @param {string} program The program source code containing the function to authorize.
-    /// @param {object} imports The imports to the program in the format {"programname.aleo":"aleo instructions source code"}.
     /// @param {boolean} unchecked Whether or not to generate an unchecked authorization.
+    /// @param {boolean} broadcast Whether or not to broadcast the transaction.
+    /// @param {number | undefined} edition The edition of the program.
+    /// @param {object | undefined} imports The imports to the program in the format {"programname.aleo":"aleo instructions source code"}.
     /// @param {PrivateKey | undefined} [private_key] Optional private key of the signer. If not provided, functions which call other programs may not succeed.
     #[wasm_bindgen(js_name = buildProvingRequestFromExecutionRequest)]
     pub async fn proving_request_from_execution_request(

--- a/wasm/src/types/native/mod.rs
+++ b/wasm/src/types/native/mod.rs
@@ -43,6 +43,7 @@ use snarkvm_synthesizer::{
     Authorization,
     Process,
     Program,
+    process::CallStack,
     snark::{Certificate, ProvingKey, VerifyingKey},
 };
 
@@ -115,6 +116,7 @@ pub type ValueTypeNative = ValueType<CurrentNetwork>;
 
 // Synthesizer types
 pub type AuthorizationNative = Authorization<CurrentNetwork>;
+pub type CallStackNative = CallStack<CurrentNetwork>;
 pub type ProcessNative = Process<CurrentNetwork>;
 pub type ProvingKeyNative = ProvingKey<CurrentNetwork>;
 pub type RequestNative = Request<CurrentNetwork>;


### PR DESCRIPTION
## Motivation

In some cases such as developers invoking Multi-Party-Computation, there is need to build a request and then subsequently build an authorization from that request, this PR implements this functionality.

## Test Plan
Both JS & Wasm tests surrounding this additional flow have been added.