### PR TITLE
[Feature] Add KeyStore implementation to AleoKeyProvider

### DIFF
--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -8,6 +8,7 @@ export interface Key {
     prover: string,
     verifier: string,
     verifyingKey: () => VerifyingKey,
+    fileLocator: string,
 }
 
 function convert(metadata: Metadata): Key {
@@ -24,6 +25,7 @@ function convert(metadata: Metadata): Key {
         prover: metadata.prover,
         verifier: metadata.verifier,
         verifyingKey,
+        fileLocator: metadata.locator.replace("/", "."),
     };
 }
 

--- a/sdk/src/keys/provider/memory.ts
+++ b/sdk/src/keys/provider/memory.ts
@@ -35,10 +35,10 @@ type AleoKeyProviderInitParams = {
  * verifierUri to fetch keys via HTTP from a remote resource as well as a unique cacheKey to store the keys in memory.
  */
 class AleoKeyProviderParams implements KeySearchParams {
-    name: string | undefined;
+    functionName: string | undefined;
     proverUri: string | undefined;
     verifierUri: string | undefined;
-    program: string | undefined;
+    programName: string | undefined;
     cacheKey: string | undefined;
 
     /**
@@ -49,12 +49,12 @@ class AleoKeyProviderParams implements KeySearchParams {
      *
      * @param { AleoKeyProviderInitParams } params - Optional search parameters
      */
-    constructor(params: {proverUri?: string, verifierUri?: string, cacheKey?: string, name?: string, program?: string}) {
+    constructor(params: {proverUri?: string, verifierUri?: string, cacheKey?: string, name?: string, programName?: string}) {
         this.proverUri = params.proverUri;
         this.verifierUri = params.verifierUri;
         this.cacheKey = params.cacheKey;
-        this.name = params.name;
-        this.program = params.program;
+        this.functionName = params.name;
+        this.programName = params.programName;
     }
 }
 
@@ -138,14 +138,16 @@ class AleoKeyProvider implements FunctionKeyProvider {
     /**
      * Cache a set of keys. This will overwrite any existing keys with the same keyId. The user can check if a keyId
      * exists in the cache using the containsKeys method prior to calling this method if overwriting is not desired.
-     * If a KeyStore is set, keys are stored there first, then in the in-memory cache.
+     * This stores the keys in the in-memory cache first if the cache option is enabled, and then in the KeyStore if it is set.
      *
      * @param {string} keyId access key for the cache (and base locator for KeyStore: keyId.prover / keyId.verifier)
      * @param {FunctionKeyPair} keys keys to cache
      */
     async cacheKeys(keyId: string, keys: FunctionKeyPair): Promise<void> {
         const [provingKey, verifyingKey] = keys;
-        this.cache.set(keyId, [provingKey.toBytes(), verifyingKey.toBytes()]);
+        if (this.cacheOption) {
+            this.cache.set(keyId, [provingKey.toBytes(), verifyingKey.toBytes()]);
+        }
         if (this._keyStore) {
             await this._keyStore.setKeys(
                 { locator: keyId + PROVER_LOCATOR_SUFFIX },
@@ -226,6 +228,8 @@ class AleoKeyProvider implements FunctionKeyProvider {
             // Check to see if a cache key is provided.
             if ("cacheKey" in params && typeof params["cacheKey"] == "string") {
                 cacheKey = params["cacheKey"];
+            } else if ("programName" in params && "functionName" in params) {
+                cacheKey = `${params["programName"]}.${params["functionName"]}`;
             }
 
             // If the cache key is provided attempt to do a cache and keystorelookup first.
@@ -252,14 +256,14 @@ class AleoKeyProvider implements FunctionKeyProvider {
                         }
                     }
                     catch (error: any) {
-                        console.error(`Error fetching keys from configured keystore for cache key: ${cacheKey}, attempting to fetch from remote source.`);
+                        console.error(`Error fetching keys from configured keystore for cache key: ${cacheKey}. Error: ${error.message}. Attempting to fetch from remote source.`);
                     }
                 }
             }
 
             // If the name of the key is a credits.aleo function, attempt to fetch the keys from the credits.aleo program.
-            if ("name" in params && typeof params["name"] == "string" && "program" in params && params["program"] == "credits.aleo") {
-                const key = CREDITS_PROGRAM_KEYS.getKey(params["name"]);
+            if ("functionName" in params && typeof params["functionName"] == "string" && "programName" in params && params["programName"] == "credits.aleo") {
+                const key = CREDITS_PROGRAM_KEYS.getKey(params["functionName"]);
                 return this.fetchCreditsKeys(key);
             }
 
@@ -287,7 +291,7 @@ class AleoKeyProvider implements FunctionKeyProvider {
 
         }
         throw new Error(
-            "Invalid parameters provided, must provide either a cacheKey and/or a proverUrl and a verifierUrl",
+            "Invalid parameters provided to the KeyProvider, must provide either a cacheKey, `programName` & `name` keys to identify program/function pair, and/or a proverUrl and a verifierUrl",
         );
     }
 
@@ -323,12 +327,9 @@ class AleoKeyProvider implements FunctionKeyProvider {
     ): Promise<FunctionKeyPair> {
         try {
             // If cache is enabled, check if the keys have already been fetched and return them if they have
-            if (this.cacheOption) {
-                if (!cacheKey) {
-                    cacheKey = proverUrl;
-                }
+            if (this.cacheOption && cacheKey) {
                 const value = this.cache.get(cacheKey);
-                if (typeof value !== "undefined") {
+                if (Array.isArray(value) && value.length === 2) {
                     return [
                         ProvingKey.fromBytes(value[0]),
                         VerifyingKey.fromBytes(value[1]),
@@ -343,11 +344,16 @@ class AleoKeyProvider implements FunctionKeyProvider {
                     );
                     const pair: FunctionKeyPair = [provingKey, verifyingKey];
                     if (this._keyStore) {
-                        await this._keyStore.setKeys(
-                            { locator: cacheKey + PROVER_LOCATOR_SUFFIX },
-                            { locator: cacheKey + VERIFIER_LOCATOR_SUFFIX },
-                            pair,
-                        );
+                        try {
+                            await this._keyStore.setKeys(
+                                { locator: cacheKey + PROVER_LOCATOR_SUFFIX },
+                                { locator: cacheKey + VERIFIER_LOCATOR_SUFFIX },
+                                pair,
+                            );
+                        }
+                        catch (error: any) {
+                            console.error(`Error storing keys in keystore for cache key: ${cacheKey}. Error: ${error.message}.`);
+                        }
                     }
                     this.cache.set(cacheKey, [
                         provingKey.toBytes(),
@@ -363,12 +369,17 @@ class AleoKeyProvider implements FunctionKeyProvider {
                 const verifyingKey = <VerifyingKey>(
                     await this.getVerifyingKey(verifierUrl)
                 );
-                if (this._keyStore) {
-                    await this._keyStore.setKeys(
-                        { locator: cacheKey + PROVER_LOCATOR_SUFFIX },
-                        { locator: cacheKey + VERIFIER_LOCATOR_SUFFIX },
-                        [provingKey.clone(), verifyingKey.clone()],
-                    );
+                if (this._keyStore && cacheKey) {
+                    try {
+                        await this._keyStore.setKeys(
+                            { locator: cacheKey + PROVER_LOCATOR_SUFFIX },
+                            { locator: cacheKey + VERIFIER_LOCATOR_SUFFIX },
+                            [provingKey.clone(), verifyingKey.clone()],
+                        );
+                    }
+                    catch (error: any) {
+                        console.error(`Error storing keys in keystore for cache key: ${cacheKey}. Error: ${error.message}.`);
+                    }
                 }
                 return [provingKey, verifyingKey];
             }
@@ -394,18 +405,23 @@ class AleoKeyProvider implements FunctionKeyProvider {
     ): Promise<ProvingKey> {
         try {
             // If cache is enabled, check cache then KeyStore before fetching
-            if (this.cacheOption) {
-                if (!cacheKey) {
-                    cacheKey = proverUrl;
-                }
+            if (this.cacheOption && cacheKey) {
                 // If the key is in the cache, return it.
                 const value = this.cache.get(cacheKey);
                 if (typeof value !== "undefined") {
                     return ProvingKey.fromBytes(value[0]);
                 }
                 // If the keystore is configured and the key is already in the keystore, return it.
-                if (this._keyStore && (await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
-                    await this._keyStore.getKeyBytes({ locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                if (this._keyStore && cacheKey && (await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
+                    try {
+                        const keyBytes = await this._keyStore.getKeyBytes({ locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                        if (keyBytes !== null) {
+                            return ProvingKey.fromBytes(keyBytes);
+                        }
+                    }
+                    catch (error: any) {
+                        console.error(`Error fetching proving key from keystore for cache key: ${cacheKey}. Error: ${error.message}. Attempting to fetch from remote source.`);
+                    }
                 }
                 console.debug(
                     "Fetching proving keys from url " + proverUrl,
@@ -414,22 +430,41 @@ class AleoKeyProvider implements FunctionKeyProvider {
                     ProvingKey.fromBytes(await this.fetchBytes(proverUrl))
                 );
                 // If they keystore is configured and the key is not already in the keystore, store it.
-                if (this._keyStore && !(await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
+                if (cacheKey && this._keyStore && !(await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
+                    try {
+                        await this._keyStore.setKeyBytes(provingKey.toBytes(), { locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                    }
+                    catch (error: any) {
+                        console.error(`Error storing proving key in keystore for cache key: ${cacheKey}. Error: ${error.message}.`);
+                    }
                     await this._keyStore.setKeyBytes(provingKey.toBytes(), { locator: cacheKey + PROVER_LOCATOR_SUFFIX });
                 }
                 return provingKey;
             } else {
                 // If the keystore is configured and the key is already in the keystore, return it.
-                if (this._keyStore && (await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
-                    await this._keyStore.getKeyBytes({ locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                if (cacheKey && this._keyStore && (await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
+                    try {
+                        const keyBytes = await this._keyStore.getKeyBytes({ locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                        if (keyBytes !== null) {
+                            return ProvingKey.fromBytes(keyBytes);
+                        }
+                    }
+                    catch (error: any) {
+                        console.error(`Error fetching proving key from keystore for cache key: ${cacheKey}. Error: ${error.message}. Attempting to fetch from remote source.`);
+                    }
                 }
                 // If not fetch the bytes.
                 const provingKey = <ProvingKey>(
                     ProvingKey.fromBytes(await this.fetchBytes(proverUrl))
                 );
                 // If they keystore is configured and the key is not already in the keystore, store it.
-                if (this._keyStore && !(await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
-                    await this._keyStore.setKeyBytes(provingKey.toBytes(), { locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                if (cacheKey && this._keyStore && !(await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
+                    try {
+                        await this._keyStore.setKeyBytes(provingKey.toBytes(), { locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                    }
+                    catch (error: any) {
+                        console.error(`Error storing proving key in keystore for cache key: ${cacheKey}. Error: ${error.message}.`);
+                    }
                 }
                 return provingKey;
             }

--- a/sdk/src/keys/provider/memory.ts
+++ b/sdk/src/keys/provider/memory.ts
@@ -38,6 +38,7 @@ class AleoKeyProviderParams implements KeySearchParams {
     name: string | undefined;
     proverUri: string | undefined;
     verifierUri: string | undefined;
+    program: string | undefined;
     cacheKey: string | undefined;
 
     /**
@@ -48,24 +49,33 @@ class AleoKeyProviderParams implements KeySearchParams {
      *
      * @param { AleoKeyProviderInitParams } params - Optional search parameters
      */
-    constructor(params: {proverUri?: string, verifierUri?: string, cacheKey?: string, name?: string}) {
+    constructor(params: {proverUri?: string, verifierUri?: string, cacheKey?: string, name?: string, program?: string}) {
         this.proverUri = params.proverUri;
         this.verifierUri = params.verifierUri;
         this.cacheKey = params.cacheKey;
         this.name = params.name;
+        this.program = params.program;
     }
 }
 
 
+/** Locator suffix for the proving key when storing a pair under a single cache key. */
+const PROVER_LOCATOR_SUFFIX = ".prover";
+/** Locator suffix for the verifying key when storing a pair under a single cache key. */
+const VERIFIER_LOCATOR_SUFFIX = ".verifier";
+
 /**
  * AleoKeyProvider class. Implements the FunctionKeyProvider interface. Enables the retrieval of Aleo program proving and
  * verifying keys for the credits.aleo program over HTTP from official Aleo sources and storing and retrieving function
- * keys from a local memory cache.
+ * keys from a local memory cache. Optionally uses a {@link KeyStore} for persistence; lookups check the in-memory cache
+ * first, then the KeyStore (if set), then remote fetch.
  */
 class AleoKeyProvider implements FunctionKeyProvider {
     cache: Map<string, CachedKeyPair>;
     cacheOption: boolean;
     keyUris: string;
+    /** Optional KeyStore for persistent key storage; used after the in-memory cache when resolving keys. */
+    private _keyStore: KeyStore | undefined;
 
     async fetchBytes(url = "/"): Promise<Uint8Array> {
         try {
@@ -83,8 +93,30 @@ class AleoKeyProvider implements FunctionKeyProvider {
         this.cacheOption = false;
     }
 
+    /**
+     * Create a new AleoKeyProvider from a KeyStore.
+     * 
+     * @param keyStore - The KeyStore to use for persistent key storage.
+     * @returns A new AleoKeyProvider instance.
+     */
+    static fromKeyStore(keyStore: KeyStore): AleoKeyProvider {
+        const provider = new AleoKeyProvider();
+        provider.setKeyStore(keyStore);
+        return provider;
+    }
+
+    /**
+     * Sets the optional KeyStore used for persistent key storage. When set, {@link functionKeys} checks the KeyStore
+     * after the in-memory cache, and {@link cacheKeys} writes to the KeyStore before updating the cache.
+     *
+     * @param {KeyStore | undefined} keyStore - KeyStore instance, or undefined to disable.
+     */
+    setKeyStore(keyStore: KeyStore | undefined) {
+        this._keyStore = keyStore;
+    }
+
     async keyStore(): Promise<KeyStore | undefined> {
-        return undefined;
+        return this._keyStore;
     }
 
     /**
@@ -106,13 +138,21 @@ class AleoKeyProvider implements FunctionKeyProvider {
     /**
      * Cache a set of keys. This will overwrite any existing keys with the same keyId. The user can check if a keyId
      * exists in the cache using the containsKeys method prior to calling this method if overwriting is not desired.
+     * If a KeyStore is set, keys are stored there first, then in the in-memory cache.
      *
-     * @param {string} keyId access key for the cache
+     * @param {string} keyId access key for the cache (and base locator for KeyStore: keyId.prover / keyId.verifier)
      * @param {FunctionKeyPair} keys keys to cache
      */
-    cacheKeys(keyId: string, keys: FunctionKeyPair) {
+    async cacheKeys(keyId: string, keys: FunctionKeyPair): Promise<void> {
         const [provingKey, verifyingKey] = keys;
         this.cache.set(keyId, [provingKey.toBytes(), verifyingKey.toBytes()]);
+        if (this._keyStore) {
+            await this._keyStore.setKeys(
+                { locator: keyId + PROVER_LOCATOR_SUFFIX },
+                { locator: keyId + VERIFIER_LOCATOR_SUFFIX },
+                keys,
+            );
+        }
     }
 
     /**
@@ -157,7 +197,8 @@ class AleoKeyProvider implements FunctionKeyProvider {
     }
 
     /**
-     * Get arbitrary function keys from a provider
+     * Get arbitrary function keys from a provider. Resolves keys in order: in-memory cache, then KeyStore (if set),
+     * then remote fetch (proverUri/verifierUri) or credits keys by name.
      *
      * @param {KeySearchParams} params parameters for the key search in form of: {proverUri: string, verifierUri: string, cacheKey: string}
      * @returns {Promise<FunctionKeyPair>} Proving and verifying keys for the specified program
@@ -178,10 +219,46 @@ class AleoKeyProvider implements FunctionKeyProvider {
      */
     async functionKeys(params?: KeySearchParams): Promise<FunctionKeyPair> {
         if (params) {
-            let proverUrl;
-            let verifierUrl;
-            let cacheKey;
-            if ("name" in params && typeof params["name"] == "string") {
+            let proverUrl: string | undefined;
+            let verifierUrl: string | undefined;
+            let cacheKey: string | undefined;
+
+            // Check to see if a cache key is provided.
+            if ("cacheKey" in params && typeof params["cacheKey"] == "string") {
+                cacheKey = params["cacheKey"];
+            }
+
+            // If the cache key is provided attempt to do a cache and keystorelookup first.
+            if (cacheKey) {
+                // First check the cache.
+                if (this.cache.has(cacheKey)) {
+                    return this.getKeys(cacheKey);
+                }
+                // If the keystore is configured, check it for the keys.
+                if (this._keyStore) {
+                    // Configure the locators.
+                    const proverLocator = { locator: cacheKey + PROVER_LOCATOR_SUFFIX };
+                    const verifierLocator = { locator: cacheKey + VERIFIER_LOCATOR_SUFFIX };
+                    // Attempt to fetch the keys from the keystore.
+                    try {
+                        const [provingKey, verifyingKey] = await Promise.all([
+                            this._keyStore.getProvingKey(proverLocator),
+                            this._keyStore.getVerifyingKey(verifierLocator),
+                        ]);
+                        if (provingKey !== null && verifyingKey !== null) {
+                            const pair: FunctionKeyPair = [provingKey, verifyingKey];
+                            this.cache.set(cacheKey, [provingKey.toBytes(), verifyingKey.toBytes()]);
+                            return pair;
+                        }
+                    }
+                    catch (error: any) {
+                        console.error(`Error fetching keys from configured keystore for cache key: ${cacheKey}, attempting to fetch from remote source.`);
+                    }
+                }
+            }
+
+            // If the name of the key is a credits.aleo function, attempt to fetch the keys from the credits.aleo program.
+            if ("name" in params && typeof params["name"] == "string" && "program" in params && params["program"] == "credits.aleo") {
                 const key = CREDITS_PROGRAM_KEYS.getKey(params["name"]);
                 return this.fetchCreditsKeys(key);
             }
@@ -200,10 +277,6 @@ class AleoKeyProvider implements FunctionKeyProvider {
                 verifierUrl = params["verifierUri"];
             }
 
-            if ("cacheKey" in params && typeof params["cacheKey"] == "string") {
-                cacheKey = params["cacheKey"];
-            }
-
             if (proverUrl && verifierUrl) {
                 return await this.fetchRemoteKeys(
                     proverUrl,
@@ -212,9 +285,6 @@ class AleoKeyProvider implements FunctionKeyProvider {
                 );
             }
 
-            if (cacheKey) {
-                return this.getKeys(cacheKey);
-            }
         }
         throw new Error(
             "Invalid parameters provided, must provide either a cacheKey and/or a proverUrl and a verifierUrl",
@@ -264,9 +334,6 @@ class AleoKeyProvider implements FunctionKeyProvider {
                         VerifyingKey.fromBytes(value[1]),
                     ];
                 } else {
-                    console.debug(
-                        "Fetching proving keys from url " + proverUrl,
-                    );
                     const provingKey = <ProvingKey>(
                         ProvingKey.fromBytes(await this.fetchBytes(proverUrl))
                     );
@@ -274,11 +341,19 @@ class AleoKeyProvider implements FunctionKeyProvider {
                     const verifyingKey = <VerifyingKey>(
                         await this.getVerifyingKey(verifierUrl)
                     );
+                    const pair: FunctionKeyPair = [provingKey, verifyingKey];
+                    if (this._keyStore) {
+                        await this._keyStore.setKeys(
+                            { locator: cacheKey + PROVER_LOCATOR_SUFFIX },
+                            { locator: cacheKey + VERIFIER_LOCATOR_SUFFIX },
+                            pair,
+                        );
+                    }
                     this.cache.set(cacheKey, [
                         provingKey.toBytes(),
                         verifyingKey.toBytes(),
                     ]);
-                    return [provingKey, verifyingKey];
+                    return pair;
                 }
             } else {
                 // If cache is disabled, fetch the keys and return them
@@ -288,6 +363,13 @@ class AleoKeyProvider implements FunctionKeyProvider {
                 const verifyingKey = <VerifyingKey>(
                     await this.getVerifyingKey(verifierUrl)
                 );
+                if (this._keyStore) {
+                    await this._keyStore.setKeys(
+                        { locator: cacheKey + PROVER_LOCATOR_SUFFIX },
+                        { locator: cacheKey + VERIFIER_LOCATOR_SUFFIX },
+                        [provingKey.clone(), verifyingKey.clone()],
+                    );
+                }
                 return [provingKey, verifyingKey];
             }
         } catch (error: any) {
@@ -298,7 +380,8 @@ class AleoKeyProvider implements FunctionKeyProvider {
     }
 
     /***
-     * Fetches the proving key from a remote source.
+     * Fetches the proving key from a remote source. When cache is enabled, resolves in order: in-memory cache,
+     * then KeyStore (if set), then network.
      *
      * @param proverUrl
      * @param cacheKey
@@ -310,27 +393,44 @@ class AleoKeyProvider implements FunctionKeyProvider {
         cacheKey?: string,
     ): Promise<ProvingKey> {
         try {
-            // If cache is enabled, check if the keys have already been fetched and return them if they have
+            // If cache is enabled, check cache then KeyStore before fetching
             if (this.cacheOption) {
                 if (!cacheKey) {
                     cacheKey = proverUrl;
                 }
+                // If the key is in the cache, return it.
                 const value = this.cache.get(cacheKey);
                 if (typeof value !== "undefined") {
                     return ProvingKey.fromBytes(value[0]);
-                } else {
-                    console.debug(
-                        "Fetching proving keys from url " + proverUrl,
-                    );
-                    const provingKey = <ProvingKey>(
-                        ProvingKey.fromBytes(await this.fetchBytes(proverUrl))
-                    );
-                    return provingKey;
                 }
-            } else {
+                // If the keystore is configured and the key is already in the keystore, return it.
+                if (this._keyStore && (await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
+                    await this._keyStore.getKeyBytes({ locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                }
+                console.debug(
+                    "Fetching proving keys from url " + proverUrl,
+                );
                 const provingKey = <ProvingKey>(
                     ProvingKey.fromBytes(await this.fetchBytes(proverUrl))
                 );
+                // If they keystore is configured and the key is not already in the keystore, store it.
+                if (this._keyStore && !(await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
+                    await this._keyStore.setKeyBytes(provingKey.toBytes(), { locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                }
+                return provingKey;
+            } else {
+                // If the keystore is configured and the key is already in the keystore, return it.
+                if (this._keyStore && (await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
+                    await this._keyStore.getKeyBytes({ locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                }
+                // If not fetch the bytes.
+                const provingKey = <ProvingKey>(
+                    ProvingKey.fromBytes(await this.fetchBytes(proverUrl))
+                );
+                // If they keystore is configured and the key is not already in the keystore, store it.
+                if (this._keyStore && !(await this._keyStore.has(cacheKey + PROVER_LOCATOR_SUFFIX))) {
+                    await this._keyStore.setKeyBytes(provingKey.toBytes(), { locator: cacheKey + PROVER_LOCATOR_SUFFIX });
+                }
                 return provingKey;
             }
         } catch (error: any) {
@@ -342,25 +442,42 @@ class AleoKeyProvider implements FunctionKeyProvider {
 
     async fetchCreditsKeys(key: Key): Promise<FunctionKeyPair> {
         try {
-            if (!this.cache.has(key.locator) || !this.cacheOption) {
-                const verifying_key = key.verifyingKey();
-                const proving_key = <ProvingKey>(
-                    await this.fetchProvingKey(key.prover, key.locator)
-                );
-                if (this.cacheOption) {
-                    this.cache.set(
-                        CREDITS_PROGRAM_KEYS.getKey(key.name).locator,
-                        [proving_key.toBytes(), verifying_key.toBytes()],
-                    );
-                }
-                return [proving_key, verifying_key];
-            } else {
-                const keyPair = <CachedKeyPair>this.cache.get(key.locator);
+            // First check the cache.
+            if (this.cache.has(key.locator)) {
+                const keyPair = this.cache.get(key.locator)!;
                 return [
                     ProvingKey.fromBytes(keyPair[0]),
                     VerifyingKey.fromBytes(keyPair[1]),
                 ];
             }
+            // If the key is not in the cache, check the keystore.
+            if (this._keyStore) {
+                const verifyingKey = key.verifyingKey();
+                const provingKey = await this._keyStore.getProvingKey({ locator: key.locator });
+                if (provingKey !== null && verifyingKey !== null) {
+                    const pair: FunctionKeyPair = [provingKey, verifyingKey];
+                    if (this.cacheOption && !this.cache.has(key.locator)) {
+                        this.cache.set(key.locator, [
+                            provingKey.toBytes(),
+                            verifyingKey.toBytes(),
+                        ]);
+                    }
+                    return pair;
+                }
+            }
+            // Otherwise fetch the proving key from the network.
+            const verifying_key = key.verifyingKey();
+            const proving_key = <ProvingKey>(
+                await this.fetchProvingKey(key.prover, key.locator)
+            );
+            if (this.cacheOption) {
+                const locator = CREDITS_PROGRAM_KEYS.getKey(key.name).locator;
+                this.cache.set(locator, [
+                    proving_key.toBytes(),
+                    verifying_key.toBytes(),
+                ]);
+            }
+            return [proving_key, verifying_key];
         } catch (error: any) {
             throw new Error(
                 `Error: fetching credits.aleo keys: ${error.message}`,

--- a/sdk/src/keys/provider/memory.ts
+++ b/sdk/src/keys/provider/memory.ts
@@ -443,8 +443,8 @@ class AleoKeyProvider implements FunctionKeyProvider {
     async fetchCreditsKeys(key: Key): Promise<FunctionKeyPair> {
         try {
             // First check the cache.
-            if (this.cache.has(key.locator)) {
-                const keyPair = this.cache.get(key.locator)!;
+            if (this.cache.has(key.fileLocator)) {
+                const keyPair = this.cache.get(key.fileLocator)!;
                 return [
                     ProvingKey.fromBytes(keyPair[0]),
                     VerifyingKey.fromBytes(keyPair[1]),
@@ -453,11 +453,11 @@ class AleoKeyProvider implements FunctionKeyProvider {
             // If the key is not in the cache, check the keystore.
             if (this._keyStore) {
                 const verifyingKey = key.verifyingKey();
-                const provingKey = await this._keyStore.getProvingKey({ locator: key.locator });
+                const provingKey = await this._keyStore.getProvingKey({ locator: key.fileLocator + PROVER_LOCATOR_SUFFIX });
                 if (provingKey !== null && verifyingKey !== null) {
                     const pair: FunctionKeyPair = [provingKey, verifyingKey];
-                    if (this.cacheOption && !this.cache.has(key.locator)) {
-                        this.cache.set(key.locator, [
+                    if (this.cacheOption && !this.cache.has(key.fileLocator)) {
+                        this.cache.set(key.fileLocator, [
                             provingKey.toBytes(),
                             verifyingKey.toBytes(),
                         ]);
@@ -468,10 +468,10 @@ class AleoKeyProvider implements FunctionKeyProvider {
             // Otherwise fetch the proving key from the network.
             const verifying_key = key.verifyingKey();
             const proving_key = <ProvingKey>(
-                await this.fetchProvingKey(key.prover, key.locator)
+                await this.fetchProvingKey(key.prover, key.fileLocator)
             );
             if (this.cacheOption) {
-                const locator = CREDITS_PROGRAM_KEYS.getKey(key.name).locator;
+                const locator = CREDITS_PROGRAM_KEYS.getKey(key.name).fileLocator;
                 this.cache.set(locator, [
                     proving_key.toBytes(),
                     verifying_key.toBytes(),

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -282,6 +282,16 @@ class ProgramManager {
     }
 
     /**
+     * Add the programName to the key search params.
+     */
+    private identifyProgram(programName: string, functionName: string, keySearchParams?: KeySearchParams): KeySearchParams {
+        if (keySearchParams === undefined) {
+            return { programName, functionName };
+        }
+        return { ...keySearchParams, programName, functionName };
+    }
+
+    /**
      * Set the host peer to use for transaction submission to the Aleo network
      *
      * @param host {string} Peer url to use for transaction submission
@@ -879,7 +889,7 @@ class ProgramManager {
         if (!provingKey || !verifyingKey) {
             try {
                 [provingKey, verifyingKey] = <FunctionKeyPair>(
-                    await this.keyProvider.functionKeys(keySearchParams)
+                    await this.keyProvider.functionKeys(this.identifyProgram(programName, functionName, keySearchParams))
                 );
             } catch (e) {
                 console.log(
@@ -1079,7 +1089,7 @@ class ProgramManager {
         if (!provingKey || !verifyingKey) {
             try {
                 [provingKey, verifyingKey] = <FunctionKeyPair>(
-                    await this.keyProvider.functionKeys(keySearchParams)
+                    await this.keyProvider.functionKeys(this.identifyProgram(programName, authorization.functionName(), keySearchParams))
                 );
             } catch (e) {
                 console.log(
@@ -1634,7 +1644,7 @@ class ProgramManager {
      * Run an Aleo program in offline mode
      *
      * @param {string} program Program source code containing the function to be executed
-     * @param {string} function_name Function name to execute
+     * @param {string} functionName Function name to execute
      * @param {string[]} inputs Inputs to the function
      * @param {number} proveExecution Whether to prove the execution of the function and return an execution transcript that contains the proof.
      * @param {string[] | undefined} imports Optional imports to the program
@@ -1664,7 +1674,7 @@ class ProgramManager {
      */
     async run(
         program: string,
-        function_name: string,
+        functionName: string,
         inputs: string[],
         proveExecution: boolean,
         imports?: ProgramImports,
@@ -1688,11 +1698,12 @@ class ProgramManager {
             throw "No private key provided and no private key set in the ProgramManager";
         }
 
+        const programName = Program.fromString(program).id();
         // If the function proving and verifying keys are not provided, attempt to find them using the key provider
         if (!provingKey || !verifyingKey) {
             try {
                 [provingKey, verifyingKey] = <FunctionKeyPair>(
-                    await this.keyProvider.functionKeys(keySearchParams)
+                    await this.keyProvider.functionKeys(this.identifyProgram(programName, functionName, keySearchParams))
                 );
             } catch (e) {
                 console.log(
@@ -1708,7 +1719,7 @@ class ProgramManager {
         return WasmProgramManager.executeFunctionOffline(
             executionPrivateKey,
             program,
-            function_name,
+            functionName,
             inputs,
             proveExecution,
             false,

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -2406,7 +2406,7 @@ class ProgramManager {
             keySearchParams = new AleoKeyProviderParams({
                 proverUri: CREDITS_PROGRAM_KEYS.bond_public.prover,
                 verifierUri: CREDITS_PROGRAM_KEYS.bond_public.verifier,
-                cacheKey: "credits.aleo/bond_public",
+                cacheKey: CREDITS_PROGRAM_KEYS.bond_public.fileLocator,
             }),
             program = this.creditsProgram(),
             ...additionalOptions
@@ -2549,7 +2549,7 @@ class ProgramManager {
             keySearchParams = new AleoKeyProviderParams({
                 proverUri: CREDITS_PROGRAM_KEYS.bond_validator.prover,
                 verifierUri: CREDITS_PROGRAM_KEYS.bond_validator.verifier,
-                cacheKey: "credits.aleo/bond_validator",
+                cacheKey: CREDITS_PROGRAM_KEYS.bond_validator.fileLocator,
             }),
             program = this.creditsProgram(),
             ...additionalOptions
@@ -2682,7 +2682,7 @@ class ProgramManager {
             keySearchParams = new AleoKeyProviderParams({
                 proverUri: CREDITS_PROGRAM_KEYS.unbond_public.prover,
                 verifierUri: CREDITS_PROGRAM_KEYS.unbond_public.verifier,
-                cacheKey: "credits.aleo/unbond_public",
+                cacheKey: CREDITS_PROGRAM_KEYS.unbond_public.fileLocator,
             }),
             program = this.creditsProgram(),
             ...additionalOptions
@@ -2812,7 +2812,7 @@ class ProgramManager {
             keySearchParams = new AleoKeyProviderParams({
                 proverUri: CREDITS_PROGRAM_KEYS.claim_unbond_public.prover,
                 verifierUri: CREDITS_PROGRAM_KEYS.claim_unbond_public.verifier,
-                cacheKey: "credits.aleo/claim_unbond_public",
+                cacheKey: CREDITS_PROGRAM_KEYS.claim_unbond_public.fileLocator,
             }),
             program = this.creditsProgram(),
             ...additionalOptions
@@ -2944,7 +2944,7 @@ class ProgramManager {
             keySearchParams = new AleoKeyProviderParams({
                 proverUri: CREDITS_PROGRAM_KEYS.set_validator_state.prover,
                 verifierUri: CREDITS_PROGRAM_KEYS.set_validator_state.verifier,
-                cacheKey: "credits.aleo/set_validator_state",
+                cacheKey: CREDITS_PROGRAM_KEYS.set_validator_state.fileLocator,
             }),
             program = this.creditsProgram(),
             ...additionalOptions

--- a/sdk/tests/key-provider.test.ts
+++ b/sdk/tests/key-provider.test.ts
@@ -159,6 +159,88 @@ describe("KeyProvider", () => {
     });
 });
 
+describe("AleoKeyProvider with LocalFileKeyStore", () => {
+    const tempDir = `${process.cwd()}/.keystore-provider-test-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+    afterEach(async () => {
+        await $fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    });
+
+    it("keyStore() returns the configured LocalFileKeyStore", async () => {
+        const keystore = new LocalFileKeyStore(tempDir);
+        const provider = AleoKeyProvider.fromKeyStore(keystore);
+        const resolved = await provider.keyStore();
+        expect(resolved).equal(keystore);
+    });
+
+    it("setKeyStore configures keystore and keyStore() returns it", async () => {
+        const provider = new AleoKeyProvider();
+        expect(await provider.keyStore()).equal(undefined);
+        const keystore = new LocalFileKeyStore(tempDir);
+        provider.setKeyStore(keystore);
+        expect(await provider.keyStore()).equal(keystore);
+    });
+
+    it("cacheKeys persists keys to LocalFileKeyStore; functionKeys resolves from keystore after clearCache", async () => {
+        const keystore = new LocalFileKeyStore(tempDir);
+        const provider = AleoKeyProvider.fromKeyStore(keystore);
+        provider.useCache(true);
+
+        const [provingKey, verifyingKey] = <FunctionKeyPair>await provider.feePublicKeys();
+        const cacheKey = "credits.aleo.fee_public.persisted";
+        await provider.cacheKeys(cacheKey, [provingKey, verifyingKey]);
+
+        expect(await keystore.has(cacheKey + ".prover")).equal(true);
+        expect(await keystore.has(cacheKey + ".verifier")).equal(true);
+
+        provider.clearCache();
+        expect(provider.cache.size).equal(0);
+
+        const [fromStoreProving, fromStoreVerifier] = <FunctionKeyPair>await provider.functionKeys({
+            cacheKey,
+        });
+        expect(fromStoreProving.checksum()).equal(provingKey.checksum());
+        expect(fromStoreVerifier.checksum()).equal(verifyingKey.checksum());
+    });
+
+    it("second provider instance with same LocalFileKeyStore directory resolves keys without network", async () => {
+        const keystore1 = new LocalFileKeyStore(tempDir);
+        const provider1 = AleoKeyProvider.fromKeyStore(keystore1);
+        provider1.useCache(true);
+
+        const [provingKey, verifyingKey] = <FunctionKeyPair>await provider1.feePublicKeys();
+        const cacheKey = "credits.aleo.fee_public.shared";
+        await provider1.cacheKeys(cacheKey, [provingKey, verifyingKey]);
+
+        const keystore2 = new LocalFileKeyStore(tempDir);
+        const provider2 = AleoKeyProvider.fromKeyStore(keystore2);
+        provider2.useCache(false);
+
+        const [p2, v2] = <FunctionKeyPair>await provider2.functionKeys({ cacheKey });
+        expect(p2.checksum()).equal(provingKey.checksum());
+        expect(v2.checksum()).equal(verifyingKey.checksum());
+    });
+
+    it("fetchCreditsKeys returns keys from LocalFileKeyStore when present and cache empty", async () => {
+        const kp = new AleoKeyProvider();
+        const [prov, ver] = <FunctionKeyPair>await kp.feePublicKeys();
+        const key = CREDITS_PROGRAM_KEYS.fee_public;
+        const keystore = new LocalFileKeyStore(tempDir);
+        await keystore.setKeys(
+            locator(key.locator),
+            locator(key.locator + ".verifier"),
+            [prov, ver]
+        );
+
+        const provider = AleoKeyProvider.fromKeyStore(keystore);
+        provider.useCache(false);
+
+        const [fromStoreProving, fromStoreVerifier] = <FunctionKeyPair>await provider.fetchCreditsKeys(key);
+        expect(fromStoreProving.checksum()).equal(prov.checksum());
+        expect(fromStoreVerifier.checksum()).equal(ver.checksum());
+    });
+});
+
 describe("KeyStore (file) – LocalFileKeyStore", () => {
     it("getProvingKey and getVerifyingKey return null when key does not exist", async () => {
         const tempDir = `${process.cwd()}/.keystore-test-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;

--- a/sdk/tests/key-provider.test.ts
+++ b/sdk/tests/key-provider.test.ts
@@ -227,8 +227,8 @@ describe("AleoKeyProvider with LocalFileKeyStore", () => {
         const key = CREDITS_PROGRAM_KEYS.fee_public;
         const keystore = new LocalFileKeyStore(tempDir);
         await keystore.setKeys(
-            locator(key.locator),
-            locator(key.locator + ".verifier"),
+            locator(key.fileLocator),
+            locator(key.fileLocator + ".verifier"),
             [prov, ver]
         );
 

--- a/wasm/src/programs/proving_key/mod.rs
+++ b/wasm/src/programs/proving_key/mod.rs
@@ -79,6 +79,14 @@ impl ProvingKey {
     pub fn to_string(&self) -> String {
         self.0.to_string()
     }
+
+    /// Clone the ProvingKey object.
+    ///
+    /// @returns {ProvingKey}
+    #[wasm_bindgen(js_name = "clone")]
+    pub fn clone(&self) -> ProvingKey {
+        ProvingKey::from(self.0.clone())
+    }
 }
 
 impl Deref for ProvingKey {

--- a/wasm/src/programs/verifying_key/mod.rs
+++ b/wasm/src/programs/verifying_key/mod.rs
@@ -91,6 +91,14 @@ impl VerifyingKey {
     pub fn num_constraints(&self) -> u32 {
         self.0.circuit_info.num_constraints as u32
     }
+
+    /// Clone the VerifyingKey object.
+    ///
+    /// @returns {VerifyingKey}
+    #[wasm_bindgen(js_name = "clone")]
+    pub fn clone(&self) -> VerifyingKey {
+        VerifyingKey::from(self.0.clone())
+    }
 }
 
 impl Deref for VerifyingKey {


### PR DESCRIPTION
## Motivation

Currently the `AleoKeyProvider` implements the `KeyProvider` interface but has no way of storing keys in persistent storage. 

This PR adds flows to store Keys via the KeyStore interface if the user configures it. Future work should remove the KeyProvider interface in favor of the KeyStore interface, but this is currently maintained in favor of backwards compatibilidy.

## Test Plan

Tests that test a filesystem based persistent storage in Node.js have been added and existing tests have been kept unmodified to ensure they KeyProvider works as expected.
