### PR TITLE
[Feature] add zeroizing destructors for sensitive account objects

### DIFF
--- a/sdk/src/account.ts
+++ b/sdk/src/account.ts
@@ -11,6 +11,7 @@ import {
   RecordCiphertext,
   RecordPlaintext,
 } from "./wasm.js";
+import { zeroizeBytes } from "./security.js";
 
 interface AccountParam {
   privateKey?: string | PrivateKey;
@@ -88,7 +89,11 @@ export class Account {
     try {
       ciphertext = (typeof ciphertext === "string") ? PrivateKeyCiphertext.fromString(ciphertext) : ciphertext;
       const _privateKey = PrivateKey.fromPrivateKeyCiphertext(ciphertext, password);
-      return new Account({ privateKey: _privateKey });
+      try {
+        return new Account({ privateKey: _privateKey });
+      } finally {
+        _privateKey.free(); // Zeroize + free the temporary; Account owns its own clone
+      }
     } catch(e) {
       throw new Error("Wrong password or invalid ciphertext");
     }
@@ -128,9 +133,11 @@ export class Account {
       // Clone the PrivateKey WASM object via byte serialization to avoid
       // creating an immutable JS string of the private key.
       const bytes = params.privateKey.toBytesLe();
-      const pk = PrivateKey.fromBytesLe(bytes);
-      bytes.fill(0); // Zeroize the intermediate byte array
-      return pk;
+      try {
+        return PrivateKey.fromBytesLe(bytes);
+      } finally {
+        zeroizeBytes(bytes);
+      }
     }
     return new PrivateKey();
   }

--- a/sdk/src/account.ts
+++ b/sdk/src/account.ts
@@ -5,7 +5,6 @@ import {
   Field,
   Group,
   PrivateKey,
-  Transition,
   Signature,
   ViewKey,
   PrivateKeyCiphertext,
@@ -14,7 +13,7 @@ import {
 } from "./wasm.js";
 
 interface AccountParam {
-  privateKey?: string;
+  privateKey?: string | PrivateKey;
   seed?: Uint8Array;
 }
 
@@ -27,6 +26,9 @@ interface AccountParam {
  * of a user's activity on the blockchain. The Address is the public address to which other users of Aleo can send Aleo
  * credits and other records to. This class should only be used in environments where the safety of the underlying key
  * material can be assured.
+ *
+ * When an Account is no longer needed, call {@link destroy} to securely zeroize and free all sensitive key material
+ * from WASM memory. Alternatively, use `[Symbol.dispose]()` with the `using` declaration in ES2024+ environments.
  *
  * @example
  * import { Account } from "@provablehq/sdk/testnet.js";
@@ -47,12 +49,16 @@ interface AccountParam {
  *
  * // Verify a signature
  * assert(myRandomAccount.verify(hello_world, signature));
+ *
+ * // Securely destroy the account when done
+ * myRandomAccount.destroy();
  */
 export class Account {
   _privateKey: PrivateKey;
   _viewKey: ViewKey;
   _computeKey: ComputeKey;
   _address: Address;
+  private _destroyed = false;
 
   constructor(params: AccountParam = {}) {
     try {
@@ -82,7 +88,7 @@ export class Account {
     try {
       ciphertext = (typeof ciphertext === "string") ? PrivateKeyCiphertext.fromString(ciphertext) : ciphertext;
       const _privateKey = PrivateKey.fromPrivateKeyCiphertext(ciphertext, password);
-      return new Account({ privateKey: _privateKey.to_string() });
+      return new Account({ privateKey: _privateKey });
     } catch(e) {
       throw new Error("Wrong password or invalid ciphertext");
     }
@@ -108,7 +114,7 @@ export class Account {
 
   /**
    * Creates a PrivateKey from the provided parameters.
-   * @param {AccountParam} params The parameters containing either a private key string or a seed
+   * @param {AccountParam} params The parameters containing either a private key string, PrivateKey object, or a seed
    * @returns {PrivateKey} A PrivateKey instance derived from the provided parameters
    */
   private privateKeyFromParams(params: AccountParam): PrivateKey {
@@ -116,9 +122,26 @@ export class Account {
       return PrivateKey.from_seed_unchecked(params.seed);
     }
     if (params.privateKey) {
-      return PrivateKey.from_string(params.privateKey);
+      if (typeof params.privateKey === 'string') {
+        return PrivateKey.from_string(params.privateKey);
+      }
+      // Clone the PrivateKey WASM object via byte serialization to avoid
+      // creating an immutable JS string of the private key.
+      const bytes = params.privateKey.toBytesLe();
+      const pk = PrivateKey.fromBytesLe(bytes);
+      bytes.fill(0); // Zeroize the intermediate byte array
+      return pk;
     }
     return new PrivateKey();
+  }
+
+  /**
+   * Throws an error if this account has been destroyed.
+   */
+  private assertNotDestroyed(): void {
+    if (this._destroyed) {
+      throw new Error("Account has been destroyed. Create a new Account instance.");
+    }
   }
 
   /**
@@ -132,6 +155,7 @@ export class Account {
    * const privateKey = account.privateKey();
    */
   privateKey(): PrivateKey {
+    this.assertNotDestroyed();
     return this._privateKey;
   }
 
@@ -146,6 +170,7 @@ export class Account {
    * const viewKey = account.viewKey();
    */
   viewKey(): ViewKey {
+    this.assertNotDestroyed();
     return this._viewKey;
   }
 
@@ -160,6 +185,7 @@ export class Account {
    * const computeKey = account.computeKey();
    */
   computeKey(): ComputeKey {
+    this.assertNotDestroyed();
     return this._computeKey;
   }
 
@@ -174,11 +200,13 @@ export class Account {
    * const address = account.address();
    */
   address(): Address {
+    this.assertNotDestroyed();
     return this._address;
   }
 
   /**
-   * Deep clones the Account.
+   * Deep clones the Account via byte serialization of the private key,
+   * avoiding creation of immutable JS string representations of the private key.
    * @returns {Account} A new Account instance with the same private key
    *
    * @example
@@ -188,7 +216,8 @@ export class Account {
    * const clonedAccount = account.clone();
    */
   clone(): Account {
-    return new Account({ privateKey: this._privateKey.to_string() });
+    this.assertNotDestroyed();
+    return new Account({ privateKey: this._privateKey });
   }
 
   /**
@@ -197,6 +226,7 @@ export class Account {
    * @returns {string} The string representation of the account address
    */
   toString(): string {
+    this.assertNotDestroyed();
     return this.address().to_string()
   }
 
@@ -214,6 +244,7 @@ export class Account {
    * process.env.ciphertext = ciphertext.toString();
    */
   encryptAccount(password: string): PrivateKeyCiphertext {
+    this.assertNotDestroyed();
     return this._privateKey.toCiphertext(password);
   }
 
@@ -244,6 +275,7 @@ export class Account {
    * }
    */
   decryptRecord(ciphertext: string): RecordPlaintext {
+    this.assertNotDestroyed();
     return this._viewKey.decrypt(ciphertext);
   }
 
@@ -269,6 +301,7 @@ export class Account {
    * const decryptedRecords = account.decryptRecords(records);
    */
   decryptRecords(ciphertexts: string[]): RecordPlaintext[] {
+    this.assertNotDestroyed();
     return ciphertexts.map((ciphertext) => this._viewKey.decrypt(ciphertext));
   }
 
@@ -277,19 +310,20 @@ export class Account {
    * This key can be used to decrypt the record without revealing the account's view key.
    * @param {RecordCiphertext | string} recordCiphertext The record ciphertext to generate the view key for
    * @returns {Field} The record view key
-   * 
+   *
    * @example
    * // Import the Account class
    * import { Account } from "@provablehq/sdk/testnet.js";
-   * 
+   *
    * // Create an account object from a previously encrypted ciphertext and password.
    * const account = Account.fromCiphertext(process.env.ciphertext!, process.env.password!);
-   * 
+   *
    * // Generate a record view key from the account's view key and a record ciphertext
    * const recordCiphertext = RecordCiphertext.fromString("your_record_ciphertext_here");
    * const recordViewKey = account.generateRecordViewKey(recordCiphertext);
    */
   generateRecordViewKey(recordCiphertext: RecordCiphertext | string): Field {
+    this.assertNotDestroyed();
     if (typeof recordCiphertext === 'string') {
       recordCiphertext = RecordCiphertext.fromString(recordCiphertext);
     }
@@ -301,21 +335,22 @@ export class Account {
 
   /**
    * Generates a transition view key from the account owner's view key and the transition public key.
-   * This key can be used to decrypt the private inputs and outputs of a the transition without 
+   * This key can be used to decrypt the private inputs and outputs of a the transition without
    * revealing the account's view key.
    * @param {string | Group} tpk The transition public key
    * @returns {Field} The transition view key
-   * 
+   *
    * @example
    * // Import the Account class
    * import { Account } from "@provablehq/sdk/testnet.js";
-   * 
+   *
    * // Generate a transition view key from the account's view key and a transition public key
    * const tpk = Group.fromString("your_transition_public_key_here");
-   * 
+   *
    * const transitionViewKey = account.generateTransitionViewKey(tpk);
    */
   generateTransitionViewKey(tpk: string | Group): Field {
+    this.assertNotDestroyed();
     if (typeof tpk === 'string') {
       tpk = Group.fromString(tpk);
     }
@@ -348,6 +383,7 @@ export class Account {
    * }
    */
   ownsRecordCiphertext(ciphertext: RecordCiphertext | string): boolean {
+    this.assertNotDestroyed();
     if (typeof ciphertext === 'string') {
       try {
         const ciphertextObject = RecordCiphertext.fromString(ciphertext);
@@ -385,6 +421,7 @@ export class Account {
    * assert(account.verify(message, signature));
    */
   sign(message: Uint8Array): Signature {
+    this.assertNotDestroyed();
     return this._privateKey.sign(message);
   }
 
@@ -410,6 +447,50 @@ export class Account {
    * assert(account.verify(message, signature));
    */
   verify(message: Uint8Array, signature: Signature): boolean {
+    this.assertNotDestroyed();
     return this._address.verify(message, signature);
+  }
+
+  /**
+   * Securely destroys the account by zeroizing and freeing all sensitive key material
+   * from WASM memory. After calling this method, the account object should not be used.
+   *
+   * This triggers the Rust-level zeroizing Drop implementation which overwrites private key,
+   * view key, and compute key bytes with zeros in WASM linear memory before deallocation.
+   *
+   * Note: If destroy() is never called, the FinalizationRegistry (set up by wasm-bindgen)
+   * will eventually trigger cleanup via GC, but the timing is non-deterministic. For security-
+   * sensitive applications, always call destroy() explicitly when the account is no longer needed.
+   *
+   * @example
+   * const account = new Account();
+   * // ... use account ...
+   * account.destroy(); // Securely cleans up key material
+   */
+  destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+
+    // Free sensitive WASM objects (triggers Rust Drop -> zeroization).
+    // try/catch guards against double-free if FinalizationRegistry already ran.
+    try { this._privateKey.free(); } catch (_) { /* already freed */ }
+    try { this._viewKey.free(); } catch (_) { /* already freed */ }
+    try { this._computeKey.free(); } catch (_) { /* already freed */ }
+    // Address is public data but free it for completeness.
+    try { this._address.free(); } catch (_) { /* already freed */ }
+  }
+
+  /**
+   * Implements the Disposable interface for use with `using` declarations (ES2024+).
+   * Calls {@link destroy} to securely clean up key material.
+   *
+   * @example
+   * {
+   *   using account = new Account();
+   *   // ... use account ...
+   * } // account is automatically destroyed here
+   */
+  [Symbol.dispose](): void {
+    this.destroy();
   }
 }

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -288,4 +288,4 @@ export {
     KeyVerifier as FunctionKeyVerifier,
 } from "./keys/verifier/interface.js";
 
-export { encryptAuthorization, encryptProvingRequest, encryptViewKey, encryptRegistrationRequest } from "./security.js";
+export { encryptAuthorization, encryptProvingRequest, encryptViewKey, encryptRegistrationRequest, zeroizeBytes } from "./security.js";

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -61,14 +61,14 @@ export function encryptRegistrationRequest(publicKey: string, viewKey: ViewKey, 
     const view = new DataView(bytes.buffer);
     view.setUint32(vk_bytes.length, start, true);
 
-    // Encrypt the encoded bytes.
-    const result = encryptMessage(publicKey, bytes);
-
-    // Zeroize sensitive intermediate byte arrays.
-    vk_bytes.fill(0);
-    bytes.fill(0);
-
-    return result;
+    // Encrypt the encoded bytes, ensuring sensitive intermediate
+    // byte arrays are zeroized regardless of success or failure.
+    try {
+        return encryptMessage(publicKey, bytes);
+    } finally {
+        zeroizeBytes(vk_bytes);
+        zeroizeBytes(bytes);
+    }
 }
 
 /**
@@ -78,8 +78,10 @@ export function encryptRegistrationRequest(publicKey: string, viewKey: ViewKey, 
  *
  * This is best-effort in JavaScript — the JIT compiler could theoretically
  * elide the fill if the array is never read again (though current engines
- * do not). For cryptographic zeroization guarantees, use the Rust-side
- * zeroization via `Account.destroy()` or calling `.free()` on WASM objects.
+ * do not). For deterministic zeroization of key material, use
+ * `Account.destroy()` or call `.free()` on key objects (PrivateKey, ViewKey,
+ * ComputeKey, GraphKey) whose Rust Drop implementations zeroize memory
+ * before deallocation.
  *
  * Note: This cannot zeroize JavaScript strings, which are immutable and managed
  * by the garbage collector. Prefer using byte array representations of sensitive

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -62,7 +62,38 @@ export function encryptRegistrationRequest(publicKey: string, viewKey: ViewKey, 
     view.setUint32(vk_bytes.length, start, true);
 
     // Encrypt the encoded bytes.
-    return encryptMessage(publicKey, bytes);
+    const result = encryptMessage(publicKey, bytes);
+
+    // Zeroize sensitive intermediate byte arrays.
+    vk_bytes.fill(0);
+    bytes.fill(0);
+
+    return result;
+}
+
+/**
+ * Best-effort zeroization of a byte array by overwriting all bytes with zeros.
+ * Use this to clear sensitive data (e.g., key bytes) from memory when working
+ * with Uint8Array representations of keys or other secrets.
+ *
+ * This is best-effort in JavaScript — the JIT compiler could theoretically
+ * elide the fill if the array is never read again (though current engines
+ * do not). For cryptographic zeroization guarantees, use the Rust-side
+ * zeroization via `Account.destroy()` or calling `.free()` on WASM objects.
+ *
+ * Note: This cannot zeroize JavaScript strings, which are immutable and managed
+ * by the garbage collector. Prefer using byte array representations of sensitive
+ * data over strings whenever possible.
+ *
+ * @param {Uint8Array} bytes The byte array to zeroize
+ *
+ * @example
+ * const keyBytes = privateKey.toBytesLe();
+ * // ... use keyBytes ...
+ * zeroizeBytes(keyBytes); // Overwrite with zeros when done
+ */
+export function zeroizeBytes(bytes: Uint8Array): void {
+    bytes.fill(0);
 }
 
 /**

--- a/sdk/tests/account.test.ts
+++ b/sdk/tests/account.test.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { Account, Address, ComputeKey, PrivateKey, RecordCiphertext, ViewKey } from "../src/node.js";
+import { Account, Address, ComputeKey, PrivateKey, RecordCiphertext, ViewKey, zeroizeBytes } from "../src/node.js";
 import { seed, message, beaconPrivateKeyString, beaconViewKeyString, beaconAddressString, recordCiphertextString, foreignCiphertextString, recordPlaintextString } from "./data/account-data.js";
 
 describe('Account', () => {
@@ -209,6 +209,90 @@ describe('Account', () => {
             expect(isSigValidForMultipleMessages).equal(true);
             // Ensure a signature & message mismatch is invalid
             expect(isSigValidForWrongMessage).equal(false);
+        });
+    });
+
+    describe('Account Lifecycle & Zeroization', () => {
+        it('destroy prevents further use of the account', () => {
+            const account = new Account();
+            account.destroy();
+
+            expect(() => account.privateKey()).to.throw(/destroyed/);
+            expect(() => account.viewKey()).to.throw(/destroyed/);
+            expect(() => account.computeKey()).to.throw(/destroyed/);
+            expect(() => account.address()).to.throw(/destroyed/);
+            expect(() => account.sign(message)).to.throw(/destroyed/);
+            expect(() => account.verify(message, new Account().sign(message))).to.throw(/destroyed/);
+            expect(() => account.clone()).to.throw(/destroyed/);
+            expect(() => account.toString()).to.throw(/destroyed/);
+            expect(() => account.encryptAccount("password")).to.throw(/destroyed/);
+            expect(() => account.decryptRecord("ciphertext")).to.throw(/destroyed/);
+            expect(() => account.decryptRecords(["ciphertext"])).to.throw(/destroyed/);
+        });
+
+        it('destroy is idempotent', () => {
+            const account = new Account();
+            account.destroy();
+            expect(() => account.destroy()).to.not.throw();
+        });
+
+        it('Symbol.dispose triggers destroy', () => {
+            const account = new Account();
+            account[Symbol.dispose]();
+
+            expect(() => account.privateKey()).to.throw(/destroyed/);
+        });
+
+        it('clone produces a working independent copy', () => {
+            const account = new Account({seed: seed});
+            const cloned = account.clone();
+
+            // Verify the clone has the same keys
+            expect(cloned.privateKey().to_string()).to.equal(account.privateKey().to_string());
+            expect(cloned.viewKey().to_string()).to.equal(account.viewKey().to_string());
+            expect(cloned.address().to_string()).to.equal(account.address().to_string());
+
+            // Destroying the original should not affect the clone
+            account.destroy();
+            expect(() => cloned.privateKey()).to.not.throw();
+            expect(cloned.privateKey().to_string()).to.equal(beaconPrivateKeyString);
+
+            cloned.destroy();
+        });
+
+        it('fromCiphertext produces a working account', () => {
+            const account = new Account();
+            const ciphertext = account.encryptAccount("testpassword");
+            const recovered = Account.fromCiphertext(ciphertext, "testpassword");
+
+            expect(recovered.privateKey().to_string()).to.equal(account.privateKey().to_string());
+            expect(recovered.viewKey().to_string()).to.equal(account.viewKey().to_string());
+            expect(recovered.address().to_string()).to.equal(account.address().to_string());
+
+            account.destroy();
+            recovered.destroy();
+        });
+
+        it('accepts a PrivateKey object in AccountParam', () => {
+            const original = new Account({seed: seed});
+            const pk = original.privateKey();
+
+            // Create account from PrivateKey object (byte-serialization path, no string leak)
+            const fromPk = new Account({privateKey: pk});
+            expect(fromPk.privateKey().to_string()).to.equal(beaconPrivateKeyString);
+            expect(fromPk.viewKey().to_string()).to.equal(beaconViewKeyString);
+            expect(fromPk.address().to_string()).to.equal(beaconAddressString);
+
+            original.destroy();
+            fromPk.destroy();
+        });
+
+        it('zeroizeBytes clears a byte array', () => {
+            const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+            expect(bytes.some(b => b !== 0)).to.equal(true);
+
+            zeroizeBytes(bytes);
+            expect(bytes.every(b => b === 0)).to.equal(true);
         });
     });
 });

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "zeroize",
 ]
 
 [[package]]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -116,6 +116,10 @@ default-features = false
 [build-dependencies.walkdir]
 version = "2"
 
+[dependencies.zeroize]
+version = "1.8"
+features = [ "zeroize_derive" ]
+
 [dependencies.wasm-bindgen]
 version = "0.2.100"
 features = [ "serde-serialize" ]

--- a/wasm/src/account/compute_key.rs
+++ b/wasm/src/account/compute_key.rs
@@ -22,6 +22,7 @@ use crate::{
 
 use core::{convert::TryFrom, ops::Deref};
 use wasm_bindgen::prelude::*;
+use zeroize::Zeroize;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -64,6 +65,22 @@ impl ComputeKey {
     /// @returns {Group} pr_sig
     pub fn pr_sig(&self) -> Group {
         Group::from(self.0.pr_sig())
+    }
+}
+
+impl Drop for ComputeKey {
+    fn drop(&mut self) {
+        // Safety: ComputeKeyNative is Copy (no internal pointers or heap allocations),
+        // composed entirely of plain field elements (2x Group + Scalar), so byte-level
+        // zeroing is sound. ComputeKeyNative does not derive Zeroize, so we zero the
+        // raw bytes directly using the zeroize crate's volatile-write implementation.
+        let bytes: &mut [u8] = unsafe {
+            core::slice::from_raw_parts_mut(
+                &mut self.0 as *mut ComputeKeyNative as *mut u8,
+                core::mem::size_of::<ComputeKeyNative>(),
+            )
+        };
+        bytes.zeroize();
     }
 }
 
@@ -133,5 +150,27 @@ mod tests {
         assert_eq!(address, compute_key.address());
         assert_eq!(address, derived_address);
         assert_eq!(address, compute_key_address);
+    }
+
+    #[test]
+    fn test_zeroize_clears_compute_key_material() {
+        let private_key = PrivateKey::new();
+        let mut compute_key = ComputeKey::from_private_key(&private_key);
+
+        let ptr = &compute_key.0 as *const ComputeKeyNative as *const u8;
+        let size = core::mem::size_of::<ComputeKeyNative>();
+
+        // Verify the compute key contains non-zero data before zeroization.
+        let bytes_before: Vec<u8> = unsafe { core::slice::from_raw_parts(ptr, size).to_vec() };
+        assert!(bytes_before.iter().any(|&b| b != 0), "Compute key should contain non-zero data");
+
+        // Zeroize the raw bytes (same operation our Drop impl performs).
+        let bytes: &mut [u8] =
+            unsafe { core::slice::from_raw_parts_mut(&mut compute_key.0 as *mut ComputeKeyNative as *mut u8, size) };
+        bytes.zeroize();
+
+        // Verify all bytes are now zero.
+        let bytes_after: Vec<u8> = unsafe { core::slice::from_raw_parts(ptr, size).to_vec() };
+        assert!(bytes_after.iter().all(|&b| b == 0), "Compute key material should be zeroed");
     }
 }

--- a/wasm/src/account/compute_key.rs
+++ b/wasm/src/account/compute_key.rs
@@ -125,8 +125,9 @@ mod tests {
     };
 
     use snarkvm_console::network::Network;
+    use wasm_bindgen_test::*;
 
-    #[test]
+    #[wasm_bindgen_test]
     fn test_compute_key_conversions() {
         // Create a new private key.
         let private_key = PrivateKey::new();
@@ -152,7 +153,7 @@ mod tests {
         assert_eq!(address, compute_key_address);
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn test_zeroize_clears_compute_key_material() {
         let private_key = PrivateKey::new();
         let mut compute_key = ComputeKey::from_private_key(&private_key);

--- a/wasm/src/account/graph_key.rs
+++ b/wasm/src/account/graph_key.rs
@@ -19,6 +19,7 @@ use crate::types::{Field, native::GraphKeyNative};
 
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
+use zeroize::Zeroize;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -53,6 +54,21 @@ impl GraphKey {
     /// Get the sk_tag of the graph key. Used to determine ownership of records.
     pub fn sk_tag(&self) -> Field {
         Field::from(self.0.sk_tag())
+    }
+}
+
+impl Drop for GraphKey {
+    fn drop(&mut self) {
+        // Safety: GraphKeyNative is Copy (no internal pointers or heap allocations),
+        // composed of a single Field element, so byte-level zeroing is sound.
+        // GraphKeyNative does not derive Zeroize, so we zero the raw bytes directly.
+        let bytes: &mut [u8] = unsafe {
+            core::slice::from_raw_parts_mut(
+                &mut self.0 as *mut GraphKeyNative as *mut u8,
+                core::mem::size_of::<GraphKeyNative>(),
+            )
+        };
+        bytes.zeroize();
     }
 }
 
@@ -128,5 +144,28 @@ mod tests {
         let sk_tag_string = sk_tag.to_string();
         let sk_tag_from_string = Field::from_string(&sk_tag_string).unwrap();
         assert_eq!(sk_tag, sk_tag_from_string);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_zeroize_clears_graph_key_material() {
+        let private_key = PrivateKey::new();
+        let view_key = ViewKey::from_private_key(&private_key);
+        let mut graph_key = GraphKey::from_view_key(&view_key);
+
+        let ptr = &graph_key.0 as *const GraphKeyNative as *const u8;
+        let size = core::mem::size_of::<GraphKeyNative>();
+
+        // Verify the graph key contains non-zero data before zeroization.
+        let bytes_before: Vec<u8> = unsafe { core::slice::from_raw_parts(ptr, size).to_vec() };
+        assert!(bytes_before.iter().any(|&b| b != 0), "Graph key should contain non-zero data");
+
+        // Zeroize the raw bytes (same operation our Drop impl performs).
+        let bytes: &mut [u8] =
+            unsafe { core::slice::from_raw_parts_mut(&mut graph_key.0 as *mut GraphKeyNative as *mut u8, size) };
+        bytes.zeroize();
+
+        // Verify all bytes are now zero.
+        let bytes_after: Vec<u8> = unsafe { core::slice::from_raw_parts(ptr, size).to_vec() };
+        assert!(bytes_after.iter().all(|&b| b == 0), "Graph key material should be zeroed");
     }
 }

--- a/wasm/src/account/private_key.rs
+++ b/wasm/src/account/private_key.rs
@@ -31,6 +31,7 @@ use snarkvm_wasm::{
 use core::{convert::TryInto, fmt, ops::Deref, str::FromStr};
 use rand::{SeedableRng, rngs::StdRng};
 use wasm_bindgen::prelude::*;
+use zeroize::Zeroize;
 
 /// Private key of an Aleo account
 #[wasm_bindgen]
@@ -144,6 +145,29 @@ impl PrivateKey {
         let private_key = Encryptor::decrypt_private_key_with_secret(ciphertext, secret)
             .map_err(|_| "Decryption failed".to_string())?;
         Ok(Self::from(private_key))
+    }
+
+    /// Get the byte representation of a private key
+    ///
+    /// @returns {Uint8Array} Byte representation of a private key
+    #[wasm_bindgen(js_name = "toBytesLe")]
+    pub fn to_bytes_le(&self) -> Result<Vec<u8>, String> {
+        self.0.to_bytes_le().map_err(|e| e.to_string())
+    }
+
+    /// Get a private key from a byte representation
+    ///
+    /// @param {Uint8Array} bytes Byte representation of a private key
+    /// @returns {PrivateKey} Private key
+    #[wasm_bindgen(js_name = "fromBytesLe")]
+    pub fn from_bytes_le(bytes: Vec<u8>) -> Result<PrivateKey, String> {
+        Ok(Self(FromBytes::read_le(&bytes[..]).map_err(|e| e.to_string())?))
+    }
+}
+
+impl Drop for PrivateKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
     }
 }
 
@@ -269,6 +293,37 @@ mod tests {
             // Check the signature is valid (natively).
             assert!(signature.verify_bytes(&private_key.to_address(), &message));
         }
+    }
+
+    #[wasm_bindgen_test]
+    pub fn test_byte_serialization_roundtrip() {
+        for _ in 0..ITERATIONS {
+            let private_key = PrivateKey::new();
+            let bytes = private_key.to_bytes_le().unwrap();
+            let recovered = PrivateKey::from_bytes_le(bytes).unwrap();
+            assert_eq!(private_key, recovered);
+        }
+    }
+
+    #[wasm_bindgen_test]
+    pub fn test_zeroize_clears_key_material() {
+        use zeroize::Zeroize;
+
+        let mut private_key = PrivateKey::new();
+        // Get a raw pointer to the inner key bytes to inspect after zeroize.
+        let ptr = &private_key.0 as *const PrivateKeyNative as *const u8;
+        let size = core::mem::size_of::<PrivateKeyNative>();
+
+        // Verify the key contains non-zero data before zeroization.
+        let bytes_before: Vec<u8> = unsafe { core::slice::from_raw_parts(ptr, size).to_vec() };
+        assert!(bytes_before.iter().any(|&b| b != 0), "Key should contain non-zero data");
+
+        // Zeroize the inner key material (same operation our Drop impl performs).
+        private_key.0.zeroize();
+
+        // Verify all bytes are now zero.
+        let bytes_after: Vec<u8> = unsafe { core::slice::from_raw_parts(ptr, size).to_vec() };
+        assert!(bytes_after.iter().all(|&b| b == 0), "Key material should be zeroed after zeroize");
     }
 
     #[wasm_bindgen_test]

--- a/wasm/src/account/view_key.rs
+++ b/wasm/src/account/view_key.rs
@@ -18,6 +18,7 @@ use crate::{Address, Field, PrivateKey, RecordCiphertext, Scalar, types::native:
 use core::{convert::TryFrom, fmt, ops::Deref, str::FromStr};
 use snarkvm_console::prelude::{FromBytes, ToBytes, ToField};
 use wasm_bindgen::prelude::*;
+use zeroize::Zeroize;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -96,6 +97,12 @@ impl ViewKey {
             Ok(plaintext) => Ok(plaintext.to_string()),
             Err(error) => Err(error),
         }
+    }
+}
+
+impl Drop for ViewKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
     }
 }
 
@@ -193,5 +200,28 @@ mod tests {
         let bytes = vk.to_bytes_le().unwrap();
         let vk_from_bytes = ViewKey::from_bytes_le(bytes).unwrap();
         assert_eq!(vk, vk_from_bytes);
+    }
+
+    #[wasm_bindgen_test]
+    pub fn test_zeroize_clears_view_key_material() {
+        use zeroize::Zeroize;
+
+        let private_key =
+            PrivateKey::from_string("APrivateKey1zkp4RyQ8Utj7aRcJgPQGEok8RMzWwUZzBhhgX6rhmBT8dcP").unwrap();
+        let mut view_key = ViewKey::from_private_key(&private_key);
+
+        let ptr = &view_key.0 as *const ViewKeyNative as *const u8;
+        let size = core::mem::size_of::<ViewKeyNative>();
+
+        // Verify the view key contains non-zero data before zeroization.
+        let bytes_before: Vec<u8> = unsafe { core::slice::from_raw_parts(ptr, size).to_vec() };
+        assert!(bytes_before.iter().any(|&b| b != 0), "View key should contain non-zero data");
+
+        // Zeroize the inner view key material (same operation our Drop impl performs).
+        view_key.0.zeroize();
+
+        // Verify all bytes are now zero.
+        let bytes_after: Vec<u8> = unsafe { core::slice::from_raw_parts(ptr, size).to_vec() };
+        assert!(bytes_after.iter().all(|&b| b == 0), "View key material should be zeroed after zeroize");
     }
 }


### PR DESCRIPTION

<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

When JS code drops a reference to a WASM-backed key object (e.g., `this._viewKey = undefined`), the WASM object lingers in linear memory until GC collects it and even then, `free()` only deallocates without clearing the bytes. Sensitive key material (private key seeds, scalars, PRF secrets) remains readable in WASM memory indefinitely.

This PR ensures sensitive key material is overwritten with zeros before deallocation on the Rust side, and provides an explicit `destroy()` API on the JS `Account` class for deterministic cleanup.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

- [x] Rust/WASM: Added tests that verify key material bytes are zeroed after zeroization for PrivateKey, ViewKey, ComputeKey, and GraphKey (raw pointer inspection confirms all bytes are 0)
- [x] Rust/WASM: Added roundtrip test for new toBytesLe/fromBytesLe on PrivateKey
- [x] SDK: destroy() prevents further use — all accessor methods throw /destroyed/
- [x] SDK: destroy() is idempotent (safe to call twice)
- [x] SDK: Symbol.dispose triggers destroy (ES2024 using support)
- [x] SDK: clone() produces an independent copy that survives the original being destroyed
- [x] SDK: fromCiphertext() produces a working account without string-leaking the private key
- [x] SDK: AccountParam accepts a PrivateKey object directly (byte-serialization path, no string leak)
- [x] SDK: zeroizeBytes() clears a byte array
