### PR TITLE
[Feature] Construct request from MPC outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "build:sdk-docs": "sh scripts/jsdoc.sh",
     "build:create-leo-app": "cd create-leo-app && yarn build",
     "build:all": "yarn build:wasm && yarn build:sdk && yarn build:create-leo-app",
+    "build:wasm-debug": "rustup show active-toolchain && cd wasm && CARGO_PROFILE_TEST_LTO=off BUILD_DEBUG=1 yarn build",
+    "build:all-debug": "yarn build:wasm-debug && yarn build:sdk && yarn build:create-leo-app",
     "start:website": "cd website && yarn dev",
     "test:wasm": "cd wasm && yarn test",
     "test:sdk": "cd sdk && yarn test",

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -620,6 +620,7 @@ describe('Program Manager', async () => {
             const tcm = signedRequest.tcm().toString();
             const viewKeyString = viewKey.toString();
             console.log(2);
+            console.log(signature);
             const mpcRequest = ExecutionRequest.fromMPCWithStrings(
                 "credits.aleo",
                 "transfer_private",
@@ -631,7 +632,7 @@ describe('Program Manager', async () => {
                 tvk,
                 tcm,
                 viewKeyString,
-                undefined, //recordInputIdsJson,
+                recordInputIdsJson,
             );
             console.log(3);
             expect(mpcRequest.program_id()).to.equal(signedRequest.program_id());

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -615,6 +615,11 @@ describe('Program Manager', async () => {
             if (recordId0 == null) throw new Error("Expected record input ID at index 0");
             const recordInputIdsJson = JSON.stringify([String(recordId0)]); // first input is the record
             console.log(recordInputIdsJson);
+            const signature = signedRequest.signature().toString();
+            const tvk = signedRequest.tvk().toString();
+            const tcm = signedRequest.tcm().toString();
+            const viewKeyString = viewKey.toString();
+            console.log(2);
             const mpcRequest = ExecutionRequest.fromMPCWithStrings(
                 "credits.aleo",
                 "transfer_private",
@@ -622,12 +627,13 @@ describe('Program Manager', async () => {
                 transferPrivateInputTypes,
                 true,
                 undefined,
-                signedRequest.signature().toString(),
-                signedRequest.tvk().toString(),
-                signedRequest.tcm().toString(),
-                viewKey.toString(),
-                recordInputIdsJson,
+                signature,
+                tvk,
+                tcm,
+                viewKeyString,
+                undefined, //recordInputIdsJson,
             );
+            console.log(3);
             expect(mpcRequest.program_id()).to.equal(signedRequest.program_id());
             expect(mpcRequest.function_name()).to.equal(signedRequest.function_name());
             expect(mpcRequest.inputs().length).to.equal(signedRequest.inputs().length);

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -565,11 +565,8 @@ describe('Program Manager', async () => {
                 "transfer_public",
                 transferPublicInputs,
                 transferPublicInputTypes,
-                true,
-                undefined,
                 signedRequest.signature(),
                 signedRequest.tvk(),
-                signedRequest.tcm(),
                 viewKey,
                 undefined, // no record inputs
             );
@@ -583,8 +580,8 @@ describe('Program Manager', async () => {
         it('Should match ExecutionRequest.sign for transfer_private', async () => {
             // Use beacon private key - record is owned by beacon address
             const privateKey = PrivateKey.from_string(beaconPrivateKeyString);
-            const viewKey = ViewKey.from_private_key(privateKey);
-            const viewKeyString = viewKey.to_string(); // extract before viewKey is consumed by computeMPCInputs
+            const beaconRecord = RecordPlaintext.fromString(recordBeaconOwned);
+            const gamma = beaconRecord.gamma("credits.aleo", "credits", privateKey);
             const mpcInputs = await programManager.computeMPCInputs({
                 programName: "credits.aleo",
                 functionName: "transfer_private",
@@ -592,7 +589,7 @@ describe('Program Manager', async () => {
                 inputTypes: transferPrivateInputTypes,
                 isRoot: true,
                 checksum: null,
-                viewKey,
+                viewKey: ViewKey.from_private_key(PrivateKey.from_string(beaconPrivateKeyString)),
             });
             const signedRequest = ExecutionRequest.sign(
                 privateKey,
@@ -609,28 +606,17 @@ describe('Program Manager', async () => {
             expect(signedRequest.inputs().length).to.equal(3);
             expect(mpcInputs.requestInputs.length).to.equal(signedRequest.inputs().length);
 
-            // Build the same request via fromMPCWithStrings - pass strings to avoid "null pointer passed to rust"
-            // when passing wasm objects (Signature, Field, ViewKey) across the boundary.
-            const inputIds = Array.from(signedRequest.input_ids());
-            const recordId0 = inputIds[0];
-            if (recordId0 == null) throw new Error("Expected record input ID at index 0");
-            const recordInputIdsJson = JSON.stringify([String(recordId0)]); // first input is the record
-            // console.log(recordInputIdsJson);
-            const signature = signedRequest.signature().to_string();
-            const tvk = signedRequest.tvk().toString();
-            const tcm = signedRequest.tcm().toString();
-            const mpcRequest = ExecutionRequest.fromMPCWithStrings(
+            const signature = signedRequest.signature();
+            const tvk = signedRequest.tvk();
+            const mpcRequest = ExecutionRequest.fromMPC(
                 "credits.aleo",
                 "transfer_private",
                 transferPrivateInputs,
                 transferPrivateInputTypes,
-                true,
-                undefined,
                 signature,
                 tvk,
-                tcm,
-                viewKeyString,
-                recordInputIdsJson,
+                ViewKey.from_private_key(PrivateKey.from_string(beaconPrivateKeyString)),
+                [gamma],
             );
             expect(mpcRequest.program_id()).to.equal(signedRequest.program_id());
             expect(mpcRequest.function_name()).to.equal(signedRequest.function_name());

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -615,12 +615,10 @@ describe('Program Manager', async () => {
             const recordId0 = inputIds[0];
             if (recordId0 == null) throw new Error("Expected record input ID at index 0");
             const recordInputIdsJson = JSON.stringify([String(recordId0)]); // first input is the record
-            console.log(recordInputIdsJson);
+            // console.log(recordInputIdsJson);
             const signature = signedRequest.signature().to_string();
             const tvk = signedRequest.tvk().toString();
             const tcm = signedRequest.tcm().toString();
-            console.log(2);
-            console.log(signature);
             const mpcRequest = ExecutionRequest.fromMPCWithStrings(
                 "credits.aleo",
                 "transfer_private",
@@ -634,7 +632,6 @@ describe('Program Manager', async () => {
                 viewKeyString,
                 recordInputIdsJson,
             );
-            console.log(3);
             expect(mpcRequest.program_id()).to.equal(signedRequest.program_id());
             expect(mpcRequest.function_name()).to.equal(signedRequest.function_name());
             expect(mpcRequest.inputs().length).to.equal(signedRequest.inputs().length);

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@provablehq/sdk/%%NETWORK%%.js";
 import {
     beaconAddressString,
+    beaconPrivateKeyString,
     helloProgram,
     recordStatePathv0,
     statePathRecordv0,
@@ -31,7 +32,7 @@ import {
     stateRootv0,
 } from "./data/account-data.js";
 import { IMPORT_1, IMPORT_2, MINT_VERIFYING_KEY, PROGRAM, SPEND_VERIFYING_KEY, SPIN_VERIFYING_KEY } from "./data/program.js";
-import { RECORD_PLAINTEXT_V1_STRING, CREDITS_RECORD_V1 } from "./data/records";
+import { RECORD_PLAINTEXT_V1_STRING } from "./data/records";
 import { expect } from "chai";
 import {
     PUZZLE_SPINNER_PROGRAM_ID,
@@ -473,11 +474,20 @@ describe('Program Manager', async () => {
 
     describe('Program Manager public message signing (computeMPCInputs)', () => {
         const privateKeyStr = "APrivateKey1zkp7Vc4xJt8HqW9U7VhY6h32d8Z9Xi5C6ZZX3gtXxbBSJmj";
+        const beaconAddress = "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px";
         const transferPublicInputs = [
-            "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px",
+            beaconAddress,
             "100u64",
         ];
         const transferPublicInputTypes = ["address.public", "u64.public"];
+        // Record owned by beacon address (required for ExecutionRequest.sign - record must belong to signer)
+        const recordBeaconOwned = `{ owner: ${beaconAddress}.private, microcredits: 1000000u64.private, _nonce: 3634848344765318974603121890869676775499130077229666060613233255327643175219group.public, _version: 1u8.public }`;
+        const transferPrivateInputs = [
+            recordBeaconOwned,
+            "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px",
+            "100u64",
+        ];
+        const transferPrivateInputTypes = ["credits.record", "address.private", "u64.private"];
 
         it('Should compute MPC inputs and return MPCInput shape (functionId, isRoot, requestInputs, checksum)', async () => {
             const mpcInputs = await programManager.computeMPCInputs({
@@ -522,8 +532,9 @@ describe('Program Manager', async () => {
             assertFieldsRoundTripThroughPlaintext(secondInput.data, transferPublicInputs[1]);
         });
 
-        it('Should match ExecutionRequest.sign for same program/function/inputs', async () => {
+        it('Should match ExecutionRequest.sign for transfer_public', async () => {
             const privateKey = PrivateKey.from_string(privateKeyStr);
+            const viewKey = ViewKey.from_private_key(privateKey);
             const mpcInputs = await programManager.computeMPCInputs({
                 programName: "credits.aleo",
                 functionName: "transfer_public",
@@ -547,16 +558,84 @@ describe('Program Manager', async () => {
             expect(signedRequest.function_name()).to.equal("transfer_public");
             expect(signedRequest.inputs().length).to.equal(2);
             expect(mpcInputs.requestInputs.length).to.equal(signedRequest.inputs().length);
+
+            // Build the same request via fromMPC using MPC-signed fields from the signed request.
+            const mpcRequest = ExecutionRequest.fromMPC(
+                "credits.aleo",
+                "transfer_public",
+                transferPublicInputs,
+                transferPublicInputTypes,
+                true,
+                undefined,
+                signedRequest.signature(),
+                signedRequest.tvk(),
+                signedRequest.tcm(),
+                viewKey,
+                undefined, // no record inputs
+            );
+            expect(mpcRequest.program_id()).to.equal(signedRequest.program_id());
+            expect(mpcRequest.function_name()).to.equal(signedRequest.function_name());
+            expect(mpcRequest.inputs().length).to.equal(signedRequest.inputs().length);
+            expect(mpcRequest.input_ids().length).to.equal(signedRequest.input_ids().length);
+            expect(mpcRequest.toString()).to.equal(signedRequest.toString());
+        });
+
+        it('Should match ExecutionRequest.sign for transfer_private', async () => {
+            // Use beacon private key - record is owned by beacon address
+            const privateKey = PrivateKey.from_string(beaconPrivateKeyString);
+            const viewKey = ViewKey.from_private_key(privateKey);
+            const mpcInputs = await programManager.computeMPCInputs({
+                programName: "credits.aleo",
+                functionName: "transfer_private",
+                inputs: transferPrivateInputs,
+                inputTypes: transferPrivateInputTypes,
+                isRoot: true,
+                checksum: null,
+                viewKey,
+            });
+            const signedRequest = ExecutionRequest.sign(
+                privateKey,
+                "credits.aleo",
+                "transfer_private",
+                transferPrivateInputs,
+                transferPrivateInputTypes,
+                undefined,
+                undefined,
+                true,
+            );
+            expect(signedRequest.program_id()).to.equal("credits.aleo");
+            expect(signedRequest.function_name()).to.equal("transfer_private");
+            expect(signedRequest.inputs().length).to.equal(3);
+            expect(mpcInputs.requestInputs.length).to.equal(signedRequest.inputs().length);
+
+            // Build the same request via fromMPCWithStrings - pass strings to avoid "null pointer passed to rust"
+            // when passing wasm objects (Signature, Field, ViewKey) across the boundary.
+            const inputIds = Array.from(signedRequest.input_ids());
+            const recordId0 = inputIds[0];
+            if (recordId0 == null) throw new Error("Expected record input ID at index 0");
+            const recordInputIdsJson = JSON.stringify([String(recordId0)]); // first input is the record
+            console.log(recordInputIdsJson);
+            const mpcRequest = ExecutionRequest.fromMPCWithStrings(
+                "credits.aleo",
+                "transfer_private",
+                transferPrivateInputs,
+                transferPrivateInputTypes,
+                true,
+                undefined,
+                signedRequest.signature().toString(),
+                signedRequest.tvk().toString(),
+                signedRequest.tcm().toString(),
+                viewKey.toString(),
+                recordInputIdsJson,
+            );
+            expect(mpcRequest.program_id()).to.equal(signedRequest.program_id());
+            expect(mpcRequest.function_name()).to.equal(signedRequest.function_name());
+            expect(mpcRequest.inputs().length).to.equal(signedRequest.inputs().length);
+            expect(mpcRequest.input_ids().length).to.equal(signedRequest.input_ids().length);
+            expect(mpcRequest.toString()).to.equal(signedRequest.toString());
         });
 
         it('Should compute MPC inputs and return MPCInput shape for private transfer', async () => {
-            const record = CREDITS_RECORD_V1;
-            const transferPrivateInputs = [
-            record,
-            "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px",
-            "100u64",
-            ];
-            const transferPrivateInputTypes = ["credits.record", "address.private", "u64.private"];
             const mpcInputs = await programManager.computeMPCInputs({
                 programName: "credits.aleo",
                 functionName: "transfer_private",

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -584,6 +584,7 @@ describe('Program Manager', async () => {
             // Use beacon private key - record is owned by beacon address
             const privateKey = PrivateKey.from_string(beaconPrivateKeyString);
             const viewKey = ViewKey.from_private_key(privateKey);
+            const viewKeyString = viewKey.to_string(); // extract before viewKey is consumed by computeMPCInputs
             const mpcInputs = await programManager.computeMPCInputs({
                 programName: "credits.aleo",
                 functionName: "transfer_private",
@@ -615,10 +616,9 @@ describe('Program Manager', async () => {
             if (recordId0 == null) throw new Error("Expected record input ID at index 0");
             const recordInputIdsJson = JSON.stringify([String(recordId0)]); // first input is the record
             console.log(recordInputIdsJson);
-            const signature = signedRequest.signature().toString();
+            const signature = signedRequest.signature().to_string();
             const tvk = signedRequest.tvk().toString();
             const tcm = signedRequest.tcm().toString();
-            const viewKeyString = viewKey.toString();
             console.log(2);
             console.log(signature);
             const mpcRequest = ExecutionRequest.fromMPCWithStrings(

--- a/wasm/build.js
+++ b/wasm/build.js
@@ -17,6 +17,8 @@ async function buildRollup(input, output) {
 }
 
 
+const isDebugBuild = process.env.BUILD_DEBUG === "1";
+
 async function buildWasm(network) {
     await buildRollup({
         input: {
@@ -25,6 +27,7 @@ async function buildWasm(network) {
         },
         plugins: [
             rust({
+                optimize: isDebugBuild ? { release: false, wasmOpt: false, rustc: false } : undefined,
                 extraArgs: {
                     cargo: [
                         "--no-default-features",

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -20,7 +20,7 @@ use crate::{
     Plaintext,
     account::{PrivateKey, Signature, ViewKey, compute_key::ComputeKey},
     from_js_typed_array,
-    from_wasm_object_array,
+    from_wasm_field_array,
     js_array_from_fields,
     native::{CurrentNetwork, FieldNative, LiteralNative},
     to_bits_array_le,
@@ -106,7 +106,7 @@ impl Address {
     /// @returns {Plaintext} The address object.
     #[wasm_bindgen(js_name = "fromFields")]
     pub fn from_fields(fields: Array) -> Result<Self, String> {
-        let native_fields = from_wasm_object_array!(fields, Field)?;
+        let native_fields = from_wasm_field_array!(fields, Field)?;
         let native = AddressNative::from_fields(&native_fields).map_err(|e| e.to_string())?;
         Ok(Self(native))
     }

--- a/wasm/src/algorithms/poseidon/poseidon2.rs
+++ b/wasm/src/algorithms/poseidon/poseidon2.rs
@@ -18,7 +18,7 @@ use crate::{
     Field,
     Group,
     Scalar,
-    from_wasm_object_array,
+    from_wasm_field_array,
     types::native::{FieldNative, Poseidon2Native},
 };
 use snarkvm_console::algorithms::{Hash, HashMany, HashToGroup, HashToScalar};
@@ -46,7 +46,7 @@ impl Poseidon2 {
 
     /// Returns the Poseidon hash with an input rate of 2.
     pub fn hash(&self, input: Array) -> Result<Field, String> {
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash(&input).map(Field::from).map_err(|e| e.to_string())
     }
 
@@ -54,7 +54,7 @@ impl Poseidon2 {
     #[wasm_bindgen(js_name = "hashMany")]
     pub fn hash_many(&self, input: Array, num_outputs: u16) -> Result<Array, String> {
         let array = Array::new();
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash_many(&input, num_outputs).into_iter().for_each(|field| {
             array.push(&JsValue::from(Field::from(field)));
         });
@@ -64,14 +64,14 @@ impl Poseidon2 {
     /// Returns the Poseidon hash with an input rate of 2 on the scalar field.
     #[wasm_bindgen(js_name = "hashToScalar")]
     pub fn hash_to_scalar(&self, input: Array) -> Result<Scalar, String> {
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash_to_scalar(&input).map(Scalar::from).map_err(|e| e.to_string())
     }
 
     /// Returns the Poseidon hash with an input rate of 2 on the affine curve.
     #[wasm_bindgen(js_name = "hashToGroup")]
     pub fn hash_to_group(&self, input: Array) -> Result<Group, String> {
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash_to_group(&input).map(Group::from).map_err(|e| e.to_string())
     }
 }

--- a/wasm/src/algorithms/poseidon/poseidon4.rs
+++ b/wasm/src/algorithms/poseidon/poseidon4.rs
@@ -18,7 +18,7 @@ use crate::{
     Field,
     Group,
     Scalar,
-    from_wasm_object_array,
+    from_wasm_field_array,
     types::native::{FieldNative, Poseidon4Native},
 };
 use snarkvm_console::algorithms::{Hash, HashMany, HashToGroup, HashToScalar};
@@ -46,7 +46,7 @@ impl Poseidon4 {
 
     /// Returns the Poseidon hash with an input rate of 4.
     pub fn hash(&self, input: Array) -> Result<Field, String> {
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash(&input).map(Field::from).map_err(|e| e.to_string())
     }
 
@@ -54,7 +54,7 @@ impl Poseidon4 {
     #[wasm_bindgen(js_name = "hashMany")]
     pub fn hash_many(&self, input: Array, num_outputs: u16) -> Result<Array, String> {
         let array = Array::new();
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash_many(&input, num_outputs).into_iter().for_each(|field| {
             array.push(&JsValue::from(Field::from(field)));
         });
@@ -64,14 +64,14 @@ impl Poseidon4 {
     /// Returns the Poseidon hash with an input rate of 4 on the scalar field.
     #[wasm_bindgen(js_name = "hashToScalar")]
     pub fn hash_to_scalar(&self, input: Array) -> Result<Scalar, String> {
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash_to_scalar(&input).map(Scalar::from).map_err(|e| e.to_string())
     }
 
     /// Returns the Poseidon hash with an input rate of 4 on the affine curve.
     #[wasm_bindgen(js_name = "hashToGroup")]
     pub fn hash_to_group(&self, input: Array) -> Result<Group, String> {
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash_to_group(&input).map(Group::from).map_err(|e| e.to_string())
     }
 }

--- a/wasm/src/algorithms/poseidon/poseidon8.rs
+++ b/wasm/src/algorithms/poseidon/poseidon8.rs
@@ -18,7 +18,7 @@ use crate::{
     Field,
     Group,
     Scalar,
-    from_wasm_object_array,
+    from_wasm_field_array,
     types::native::{FieldNative, Poseidon8Native},
 };
 use snarkvm_console::algorithms::{Hash, HashMany, HashToGroup, HashToScalar};
@@ -46,7 +46,7 @@ impl Poseidon8 {
 
     /// Returns the Poseidon hash with an input rate of 8.
     pub fn hash(&self, input: Array) -> Result<Field, String> {
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash(&input).map(Field::from).map_err(|e| e.to_string())
     }
 
@@ -54,7 +54,7 @@ impl Poseidon8 {
     #[wasm_bindgen(js_name = "hashMany")]
     pub fn hash_many(&self, input: Array, num_outputs: u16) -> Result<Array, String> {
         let array = Array::new();
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash_many(&input, num_outputs).into_iter().for_each(|field| {
             array.push(&JsValue::from(Field::from(field)));
         });
@@ -64,14 +64,14 @@ impl Poseidon8 {
     /// Returns the Poseidon hash with an input rate of 8 on the scalar field.
     #[wasm_bindgen(js_name = "hashToScalar")]
     pub fn hash_to_scalar(&self, input: Array) -> Result<Scalar, String> {
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash_to_scalar(&input).map(Scalar::from).map_err(|e| e.to_string())
     }
 
     /// Returns the Poseidon hash with an input rate of 8 on the affine curve.
     #[wasm_bindgen(js_name = "hashToGroup")]
     pub fn hash_to_group(&self, input: Array) -> Result<Group, String> {
-        let input = from_wasm_object_array!(input, Field)?;
+        let input = from_wasm_field_array!(input, Field)?;
         self.0.hash_to_group(&input).map(Group::from).map_err(|e| e.to_string())
     }
 }

--- a/wasm/src/programs/data/ciphertext.rs
+++ b/wasm/src/programs/data/ciphertext.rs
@@ -20,7 +20,7 @@ use crate::{
     Plaintext,
     ViewKey,
     from_js_typed_array,
-    from_wasm_object_array,
+    from_wasm_field_array,
     js_array_from_fields,
     native::{CiphertextNative, CurrentNetwork, FieldNative, IdentifierNative, ProgramIDNative},
     to_bits_array_le,
@@ -171,7 +171,7 @@ impl Ciphertext {
     /// @returns {Ciphertext} The ciphertext object.
     #[wasm_bindgen(js_name = "fromFields")]
     pub fn from_fields(fields: Array) -> Result<Ciphertext, String> {
-        let native_fields = from_wasm_object_array!(fields, Field)?;
+        let native_fields = from_wasm_field_array!(fields, Field)?;
         let native = CiphertextNative::from_fields(&native_fields).map_err(|e| e.to_string())?;
         Ok(Self(native))
     }

--- a/wasm/src/programs/data/plaintext.rs
+++ b/wasm/src/programs/data/plaintext.rs
@@ -20,7 +20,7 @@ use crate::{
     Field,
     Scalar,
     from_js_typed_array,
-    from_wasm_object_array,
+    from_wasm_field_array,
     js_array_from_fields,
     native::{FieldNative, LiteralNative, U8Native},
     plaintext_to_js_value,
@@ -204,7 +204,7 @@ impl Plaintext {
     /// @returns {Plaintext} The plaintext object.
     #[wasm_bindgen(js_name = "fromFields")]
     pub fn from_fields(fields: Array) -> Result<Plaintext, String> {
-        let native_fields = from_wasm_object_array!(fields, Field)?;
+        let native_fields = from_wasm_field_array!(fields, Field)?;
         let native = PlaintextNative::from_fields(&native_fields).map_err(|e| e.to_string())?;
         Ok(Self(native))
     }

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -22,34 +22,33 @@ use crate::{
     PrivateKey,
     Signature,
     ViewKey,
+    native_type_from_wasm_object_array,
     object,
     types::native::{
         CurrentNetwork,
         FieldNative,
         IdentifierNative,
         InputIDNative,
-        PlaintextNative,
         ProgramIDNative,
         RecordPlaintextNative,
         RequestNative,
-        SignatureNative,
         U16Native,
         ValueNative,
         ValueTypeNative,
-        ViewKeyNative,
     },
 };
 use snarkvm_console::{
     network::Network,
     prelude::{One, ToFields, Zero},
-    program::{compute_function_id, InputID},
+    program::compute_function_id,
 };
 use snarkvm_wasm::utilities::{FromBytes, ToBytes};
 
+use crate::types::native::GroupNative;
 use js_sys::{Array, Object, Reflect, Uint8Array};
 use rand::{SeedableRng, rngs::StdRng};
 use std::{ops::Deref, str::FromStr};
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{convert::TryFromJsValue, prelude::*};
 
 #[wasm_bindgen]
 pub struct ExecutionRequest(RequestNative);
@@ -234,8 +233,7 @@ impl ExecutionRequest {
     /// @param {Field} tvk The transition view key.
     /// @param {Field} tcm The transition commitment.
     /// @param {ViewKey} view_key The view key of the signer.
-    /// @param {string | undefined} record_input_ids_json JSON string of record input ID array (one per record input, in order).
-    ///        Required when inputs include records. E.g. '["{\"type\":\"record\",...}"]'. Each element is the JSON representation of InputID::Record.
+    /// @param {Group[] | undefined] gammas An array of gammas output from the MPC.
     #[wasm_bindgen(js_name = "fromMPC")]
     #[allow(clippy::too_many_arguments)]
     pub fn from_mpc(
@@ -248,57 +246,63 @@ impl ExecutionRequest {
         view_key: ViewKey,
         gammas: Option<Array>,
     ) -> Result<ExecutionRequest, String> {
+        // Parse the input and function name strings.
         let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
         let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
 
-        // Collect input_types into a Vec for record_count and length checks.
-        let input_types_vec: Vec<ValueTypeNative> = input_types
-            .iter()
-            .map(|it| ValueTypeNative::from_str(&it.as_string().unwrap()).map_err(|e| e.to_string()))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        // Collect inputs_native separately for use in RequestNative at the end.
-        let inputs_native: Vec<ValueNative> = inputs
-            .iter()
-            .map(|i| ValueNative::from_str(&i.as_string().unwrap()).map_err(|e| e.to_string()))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        if input_types_vec.len() != inputs_native.len() {
-            return Err("input_types and inputs must have the same length".to_string());
-        }
-
-        let signer = Address::from_view_key(&view_key);
-        let sk_tag = GraphKey::from_view_key(&view_key).sk_tag();
-        let root_tvk = tvk;
-        let scm = CurrentNetwork::hash_psd2(&[*signer.to_group().to_x_coordinate(), *root_tvk]).map_err(|e| e.to_string())?;
-        let tcm = CurrentNetwork::hash_psd2(&[*tvk]).map_err(|e| e.to_string())?;
-
-        let network_id = U16Native::new(CurrentNetwork::ID);
-        let function_id = compute_function_id(&network_id, &program_id, &function_name).map_err(|e| e.to_string())?;
-
-        let record_count = input_types_vec
-            .iter()
-            .filter(|t| matches!(t, ValueTypeNative::Record(_)))
-            .count();
-
-        let gamma_length = gammas.as_ref().map_or(0, |a| a.length() as usize);
-        if record_count != gamma_length {
+        // Ensure input types and inputs are the same length.
+        let input_types_length = input_types.length();
+        let inputs_length = inputs.length();
+        if input_types_length != inputs_length {
             return Err(format!(
-                "record_input_ids must have length {} for {} record input(s), got {}",
-                record_count,
-                record_count,
-                gamma_length
+                "input_types and inputs must have the same length. Input array length: {inputs_length} - input type array length: {input_types_length}"
             ));
         }
 
-        let mut record_input_idx = 0u32;
-        let mut input_ids = Vec::with_capacity(inputs_native.len());
+        // Collect input_types into a Vec for record_count and length checks.
+        let mut inputs_native = Vec::with_capacity(inputs_length as usize);
+        for (i, input) in inputs.iter().enumerate() {
+            let input_string =
+                input.as_string().ok_or(format!("Input type had invalid string encoding at index {i}"))?;
+            let input = ValueNative::from_str(&input_string).map_err(|e| e.to_string())?;
+            inputs_native.push(input);
+        }
+
+        let mut input_types_native = Vec::with_capacity(inputs_length as usize);
+        for (i, input_type) in input_types.iter().enumerate() {
+            let input_type_string =
+                input_type.as_string().ok_or(format!("Input type had invalid string encoding at index {i}"))?;
+            let input_type = ValueTypeNative::from_str(&input_type_string).map_err(|e| e.to_string())?;
+            input_types_native.push(input_type);
+        }
+
+        // Derive the signer, sk_tag, scm and tcm.
+        let signer = Address::from_view_key(&view_key);
+        let sk_tag = GraphKey::from_view_key(&view_key).sk_tag();
+        let scm =
+            CurrentNetwork::hash_psd2(&[*signer.to_group().to_x_coordinate(), *tvk]).map_err(|e| e.to_string())?;
+        let tcm = CurrentNetwork::hash_psd2(&[*tvk]).map_err(|e| e.to_string())?;
+
+        // Compute the network id and function id.
+        let network_id = U16Native::new(CurrentNetwork::ID);
+        let function_id = compute_function_id(&network_id, &program_id, &function_name).map_err(|e| e.to_string())?;
+
+        // Compute the record count.
+        let record_count = input_types_native.iter().filter(|t| matches!(t, ValueTypeNative::Record(_))).count();
+
+        // Ensure the number of gammas match the number of records.
+        let mut gammas_native =
+            native_type_from_wasm_object_array!(gammas.unwrap_or(Array::new()), Group, GroupNative)?;
+        let gamma_length = gammas_native.len();
+        if record_count != gamma_length {
+            return Err(format!(
+                "The number of gammas must match the number of record inputs. {gamma_length} gammas specified for {record_count} record input(s)",
+            ));
+        }
 
         // Iterate the raw JS arrays, parsing each input fresh so it is owned.
-        for (index, (input_js, input_type_js)) in inputs.iter().zip(input_types.iter()).enumerate() {
-            let input = ValueNative::from_str(&input_js.as_string().unwrap()).map_err(|e| e.to_string())?;
-            let input_type = ValueTypeNative::from_str(&input_type_js.as_string().unwrap()).map_err(|e| e.to_string())?;
-
+        let mut input_ids = Vec::with_capacity(inputs_native.len());
+        for (index, (input, input_type)) in inputs_native.iter().zip(input_types_native.iter()).enumerate() {
             let index_field = FieldNative::from_u16(
                 u16::try_from(index).map_err(|_| format!("Input index {index} exceeds maximum allowed value"))?,
             );
@@ -324,30 +328,30 @@ impl ExecutionRequest {
                         }
                         _ => return Err("Expected a plaintext input for private type".to_string()),
                     };
-                    let input_hash =
-                        CurrentNetwork::hash_psd8(&ciphertext.to_fields().map_err(|e| e.to_string())?)
-                            .map_err(|e| e.to_string())?;
+                    let input_hash = CurrentNetwork::hash_psd8(&ciphertext.to_fields().map_err(|e| e.to_string())?)
+                        .map_err(|e| e.to_string())?;
                     input_ids.push(InputIDNative::Private(input_hash));
                 }
                 ValueTypeNative::Record(record_name) => {
-                    // input is owned here, so destructuring works without clone.
+                    // Get the record input.
                     let record_input = match input {
                         ValueNative::Record(record) => record,
                         _ => return Err("Expected a record input for record type".to_string()),
                     };
-                    let record_view_key = (*record_input.nonce() * ***view_key).to_x_coordinate();
+                    // Compute the record's view key and commitment.
+                    let record_view_key = (*record_input.nonce() * **view_key).to_x_coordinate();
                     let commitment = record_input
                         .to_commitment(&program_id, record_name, &record_view_key)
                         .map_err(|e| e.to_string())?;
 
-                    let gamma_js = gammas.as_ref().unwrap().get(record_input_idx as u32);
-                    let gamma = Group::from_string(&gamma_js.as_string().ok_or("Invalid gamma value")?)
-                        .map_err(|e| e.to_string())?;
+                    // Get the gammas from the externally provided array of gammas.
+                    let gamma = gammas_native.pop().unwrap();
 
-                    let serial_number = RecordPlaintextNative::serial_number_from_gamma(&gamma, commitment).map_err(|e| e.to_string())?;
+                    // Compute the record nullifiers (serial number and tag).
+                    let serial_number = RecordPlaintextNative::serial_number_from_gamma(&gamma, commitment)
+                        .map_err(|e| e.to_string())?;
                     let tag = RecordPlaintextNative::tag(*sk_tag, commitment).map_err(|e| e.to_string())?;
-                    input_ids.push(InputIDNative::Record(commitment, *gamma, record_view_key, serial_number, tag));
-                    record_input_idx += 1;
+                    input_ids.push(InputIDNative::Record(commitment, gamma, record_view_key, serial_number, tag));
                 }
                 ValueTypeNative::ExternalRecord(_) => {
                     return Err("external_record inputs are not yet supported in fromMPC".to_string());
@@ -364,7 +368,7 @@ impl ExecutionRequest {
             program_id,
             function_name,
             input_ids,
-            inputs_native,  // use the separately collected Vec
+            inputs_native, // use the separately collected Vec
             *signature,
             *sk_tag,
             *tvk,
@@ -585,6 +589,7 @@ impl From<&ExecutionRequest> for RequestNative {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{RecordPlaintext, array};
     use js_sys::Reflect;
     use wasm_bindgen::JsValue;
     use wasm_bindgen_test::*;
@@ -600,9 +605,9 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_execution_request_sign_and_accessors() {
         let private_key = PrivateKey::from_string(PRIVATE_KEY_STR).unwrap();
-        let inputs = crate::array![TRANSFER_PUBLIC_INPUTS[0].to_string(), TRANSFER_PUBLIC_INPUTS[1].to_string()];
+        let inputs = array![TRANSFER_PUBLIC_INPUTS[0].to_string(), TRANSFER_PUBLIC_INPUTS[1].to_string()];
         let input_types =
-            crate::array![TRANSFER_PUBLIC_INPUT_TYPES[0].to_string(), TRANSFER_PUBLIC_INPUT_TYPES[1].to_string()];
+            array![TRANSFER_PUBLIC_INPUT_TYPES[0].to_string(), TRANSFER_PUBLIC_INPUT_TYPES[1].to_string()];
 
         let request = ExecutionRequest::sign(
             private_key,
@@ -627,9 +632,9 @@ mod tests {
     fn test_execution_request_from_mpc_matches_sign() {
         let private_key = PrivateKey::from_string(PRIVATE_KEY_STR).unwrap();
         let view_key = ViewKey::from_private_key(&private_key);
-        let inputs = crate::array![TRANSFER_PUBLIC_INPUTS[0].to_string(), TRANSFER_PUBLIC_INPUTS[1].to_string()];
+        let inputs = array![TRANSFER_PUBLIC_INPUTS[0].to_string(), TRANSFER_PUBLIC_INPUTS[1].to_string()];
         let input_types =
-            crate::array![TRANSFER_PUBLIC_INPUT_TYPES[0].to_string(), TRANSFER_PUBLIC_INPUT_TYPES[1].to_string()];
+            array![TRANSFER_PUBLIC_INPUT_TYPES[0].to_string(), TRANSFER_PUBLIC_INPUT_TYPES[1].to_string()];
 
         let signed_request = ExecutionRequest::sign(
             private_key,
@@ -648,11 +653,8 @@ mod tests {
             "transfer_public".to_string(),
             inputs,
             input_types,
-            true,
-            None,
             signed_request.signature(),
             signed_request.tvk(),
-            signed_request.tcm(),
             view_key,
             None, // no record inputs
         )
@@ -670,16 +672,16 @@ mod tests {
         let private_key = PrivateKey::from_string(BEACON_PRIVATE_KEY_STR).unwrap();
         let view_key = ViewKey::from_private_key(&private_key);
         let record_beacon_owned = "{ owner: aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px.private, microcredits: 1000000u64.private, _nonce: 3634848344765318974603121890869676775499130077229666060613233255327643175219group.public, _version: 1u8.public }";
-        let inputs = crate::array![
+        let inputs = array![
             record_beacon_owned.to_string(),
             "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px".to_string(),
             "100u64".to_string(),
         ];
-        let input_types = crate::array![
-            "credits.record".to_string(),
-            "address.private".to_string(),
-            "u64.private".to_string(),
-        ];
+        let input_types =
+            array!["credits.record".to_string(), "address.private".to_string(), "u64.private".to_string(),];
+        let record = RecordPlaintext::from_string(record_beacon_owned).unwrap();
+        let gamma = record.gamma("credits.aleo", "credits", &private_key).unwrap();
+        let gammas = array![gamma];
 
         let signed_request = ExecutionRequest::sign(
             private_key,
@@ -693,24 +695,15 @@ mod tests {
         )
         .expect("sign should succeed");
 
-        let record_input_id_0 = signed_request
-            .input_ids()
-            .get(0)
-            .as_string()
-            .expect("record input id should be string");
-        let record_input_ids_json = serde_json::to_string(&[record_input_id_0]).expect("JSON serialize");
         let mpc_request = ExecutionRequest::from_mpc(
             "credits.aleo".to_string(),
             "transfer_private".to_string(),
             inputs,
             input_types,
-            true,
-            None,
             signed_request.signature(),
             signed_request.tvk(),
-            signed_request.tcm(),
             view_key,
-            Some(record_input_ids_json),
+            Some(gammas),
         )
         .expect("from_mpc should succeed");
 
@@ -724,9 +717,9 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_execution_request_verify() {
         let private_key = PrivateKey::from_string(PRIVATE_KEY_STR).unwrap();
-        let inputs = crate::array![TRANSFER_PUBLIC_INPUTS[0].to_string(), TRANSFER_PUBLIC_INPUTS[1].to_string()];
+        let inputs = array![TRANSFER_PUBLIC_INPUTS[0].to_string(), TRANSFER_PUBLIC_INPUTS[1].to_string()];
         let input_types =
-            crate::array![TRANSFER_PUBLIC_INPUT_TYPES[0].to_string(), TRANSFER_PUBLIC_INPUT_TYPES[1].to_string()];
+            array![TRANSFER_PUBLIC_INPUT_TYPES[0].to_string(), TRANSFER_PUBLIC_INPUT_TYPES[1].to_string()];
 
         let request = ExecutionRequest::sign(
             private_key,
@@ -747,9 +740,9 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_compute_mpc_inputs_transfer_public() {
         // Build the inputs and input types.
-        let inputs = crate::array![TRANSFER_PUBLIC_INPUTS[0].to_string(), TRANSFER_PUBLIC_INPUTS[1].to_string()];
+        let inputs = array![TRANSFER_PUBLIC_INPUTS[0].to_string(), TRANSFER_PUBLIC_INPUTS[1].to_string()];
         let input_types =
-            crate::array![TRANSFER_PUBLIC_INPUT_TYPES[0].to_string(), TRANSFER_PUBLIC_INPUT_TYPES[1].to_string()];
+            array![TRANSFER_PUBLIC_INPUT_TYPES[0].to_string(), TRANSFER_PUBLIC_INPUT_TYPES[1].to_string()];
 
         // Compute the MPC inputs.
         let result = ExecutionRequest::compute_mpc_inputs(
@@ -831,8 +824,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_compute_mpc_inputs_input_types_inputs_length_mismatch() {
-        let inputs = crate::array!["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px"];
-        let input_types = crate::array!["address.public", "u64.public"];
+        let inputs = array!["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px"];
+        let input_types = array!["address.public", "u64.public"];
 
         let result = ExecutionRequest::compute_mpc_inputs(
             "credits.aleo".to_string(),

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -176,6 +176,7 @@ impl ExecutionRequest {
         program_checksum: Option<Field>,
         is_root: bool,
     ) -> Result<ExecutionRequest, String> {
+        crate::log("signing");
         // Convert the ProgramID and function name to their native objects.
         let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
         let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
@@ -249,12 +250,12 @@ impl ExecutionRequest {
         view_key: ViewKey,
         record_input_ids_json: Option<String>,
     ) -> Result<ExecutionRequest, String> {
-        println!("test1");
+        crate::log("test1");
         let signature_native = *signature;
         let tvk_native = FieldNative::from(tvk);
         let tcm_native = FieldNative::from(tcm);
         let view_key_native = *view_key;
-        println!("test2");
+        crate::log("test2");
         Self::from_mpc_impl(
             program_id,
             function_name,
@@ -287,10 +288,15 @@ impl ExecutionRequest {
         view_key_str: String,
         record_input_ids_json: Option<String>,
     ) -> Result<ExecutionRequest, String> {
+        crate::log(&format!("testa: {:?}", signature_str));
         let signature_native = SignatureNative::from_str(&signature_str).map_err(|e| e.to_string())?;
+        crate::log("testb");
         let tvk_native = FieldNative::from_str(&tvk_str).map_err(|e| e.to_string())?;
+        crate::log("testc");
         let tcm_native = FieldNative::from_str(&tcm_str).map_err(|e| e.to_string())?;
+        crate::log("testd");
         let view_key_native = ViewKeyNative::from_str(&view_key_str).map_err(|e| e.to_string())?;
+        crate::log("teste");
         Self::from_mpc_impl(
             program_id,
             function_name,
@@ -319,10 +325,10 @@ impl ExecutionRequest {
         view_key_native: ViewKeyNative,
         record_input_ids_json: Option<String>,
     ) -> Result<ExecutionRequest, String> {
-        println!("test3");
+        crate::log("test3");
         let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
         let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
-        println!("test4");
+        crate::log("test4");
 
         let inputs: Vec<ValueNative> = inputs
             .iter()

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -27,6 +27,8 @@ use crate::{
         CurrentNetwork,
         FieldNative,
         IdentifierNative,
+        InputIDNative,
+        PlaintextNative,
         ProgramIDNative,
         RecordPlaintextNative,
         RequestNative,
@@ -241,36 +243,10 @@ impl ExecutionRequest {
         function_name: String,
         inputs: Array,
         input_types: Array,
-        signature: Signature,
-        tvk: Field,
-        view_key: ViewKey,
-        gammas: Option<Array>
-    ) -> Result<ExecutionRequest, String> {
-        let signature_native = *signature;
-        let tvk_native = FieldNative::from(tvk);
-        let tcm_native = FieldNative::from(tcm);
-        let view_key_native = *view_key;
-        Self::from_mpc_impl(
-            program_id,
-            function_name,
-            inputs,
-            input_types,
-            signature,
-            tvk,
-            view_key,
-            gammas,
-        )
-    }
-
-    fn from_mpc_impl(
-        program_id: String,
-        function_name: String,
-        inputs: Array,
-        input_types: Array,
         signature_native: Signature,
         tvk: Field,
         view_key: ViewKey,
-        record_gamma: Option<Array>, // Optional array of gammas.  One gamma per input record.
+        gammas: Option<Array>, // Optional array of gammas.  One gamma per input record.
     ) -> Result<ExecutionRequest, String> {
         let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
         let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
@@ -293,12 +269,12 @@ impl ExecutionRequest {
             return Err("input_types and inputs must have the same length".to_string());
         }
 
-        let signer = Address::from_view_key(view_key.as_ref());
-        let sk_tag = GraphKey::from_view_key(view_key.as_ref()).tag();
-        let root_tvk = tvk_native;
+        let signer = Address::from_view_key(&view_key);
+        let sk_tag = GraphKey::from_view_key(&view_key).sk_tag();
+        let root_tvk = tvk;
         let signer_x = *signer.to_x_coordinate();
         let scm = CurrentNetwork::hash_psd2(&[signer_x, *root_tvk]).map_err(|e| e.to_string())?;
-        let tcm = CurrentNetwork::hash_psd2(&[*tvk])?;
+        let tcm = CurrentNetwork::hash_psd2(&[*tvk]).map_err(|e| e.to_string())?;
 
         let network_id = U16Native::new(CurrentNetwork::ID);
         let function_id = compute_function_id(&network_id, &program_id, &function_name).map_err(|e| e.to_string())?;
@@ -307,12 +283,14 @@ impl ExecutionRequest {
             .iter()
             .filter(|t| matches!(t, ValueTypeNative::Record(_)))
             .count();
-        if record_count != gammas.len() {
+        
+        let gamma_length = gammas.as_ref().map_or(0, |a| a.length() as usize);
+        if record_count != gamma_length {
             return Err(format!(
                 "record_input_ids must have length {} for {} record input(s), got {}",
                 record_count,
                 record_count,
-                gammas.len()
+                gamma_length
             ));
         }
 
@@ -327,17 +305,17 @@ impl ExecutionRequest {
                 ValueTypeNative::Constant(_) | ValueTypeNative::Public(_) => {
                     let mut preimage = vec![function_id];
                     preimage.extend(input.to_fields().map_err(|e| e.to_string())?);
-                    preimage.push(tcm_native);
+                    preimage.push(tcm);
                     preimage.push(index_field);
                     let input_hash = CurrentNetwork::hash_psd8(&preimage).map_err(|e| e.to_string())?;
                     input_ids.push(match input_type {
-                        ValueTypeNative::Constant(_) => InputID::Constant(input_hash),
-                        _ => InputID::Public(input_hash),
+                        ValueTypeNative::Constant(_) => InputIDNative::Constant(input_hash),
+                        _ => InputIDNative::Public(input_hash),
                     });
                 }
                 ValueTypeNative::Private(_) => {
                     let input_view_key =
-                        CurrentNetwork::hash_psd4(&[function_id, tvk.as_rev(), index_field]).map_err(|e| e.to_string())?;
+                        CurrentNetwork::hash_psd4(&[function_id, tvk, index_field]).map_err(|e| e.to_string())?;
                     let ciphertext = match input {
                         ValueNative::Plaintext(plaintext) => {
                             plaintext.encrypt_symmetric(input_view_key).map_err(|e| e.to_string())?
@@ -347,23 +325,23 @@ impl ExecutionRequest {
                     let input_hash =
                         CurrentNetwork::hash_psd8(&ciphertext.to_fields().map_err(|e| e.to_string())?)
                             .map_err(|e| e.to_string())?;
-                    input_ids.push(InputID::Private(input_hash));
+                    input_ids.push(InputIDNative::Private(input_hash));
                 }
                 ValueTypeNative::Record(record_name) => {
                     // Deserialize the record input
                     let ValueNative::Record(record_input) = input;
                     // Compute the record input ID from the gamma, record commitment, h, and h_r.
-                    let record_view_key = (*record_input.nonce() * ***vk).to_x_coordinate();
+                    let record_view_key = (*record_input.nonce() * ***view_key).to_x_coordinate();
                     // Compute the commitment for the record input.
                     let commitment = record_input
                         .to_commitment(&program_id, &record_name, &record_view_key)
                         .map_err(|e| e.to_string())?;
                     // Pop the gamma value and deserialize to group element.
-                    let gamma = Group::from(Array.shift());
+                    let gamma = Group::from(gammas[record_input_idx]);
                     // Compute the serial number
-                    let serial_number = RecordNative::<CurrentNetwork, PlaintextNative<CurrentNetwork>>::serial_number_from_gamma(&gamma, commitment).map_err(|e| e.to_string())?;
+                    let serial_number = RecordPlaintextNative::<CurrentNetwork, PlaintextNative<CurrentNetwork>>::serial_number_from_gamma(&gamma, commitment).map_err(|e| e.to_string())?;
                     // Compute the tag
-                    let tag = RecordNative::<CurrentNetwork, PlaintextNative<CurrentNetwork>::tag(sk_tag, commitment);
+                    let tag = RecordPlaintextNative::<CurrentNetwork, PlaintextNative<CurrentNetwork>>::tag(sk_tag, commitment);
                     // Add the input ID to the input_id vector and increment the count.
                     input_ids.push(InputIDNative::Record(commitment, gamma, record_view_key, serial_number, tag));
                     record_input_idx += 1;

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -366,7 +366,7 @@ impl ExecutionRequest {
                     let tag = RecordNative::<CurrentNetwork, PlaintextNative<CurrentNetwork>::tag(sk_tag, commitment);
                     // Add the input ID to the input_id vector and increment the count.
                     input_ids.push(InputIDNative::Record(commitment, gamma, record_view_key, serial_number, tag));
-                    record_input_ix += 1;
+                    record_input_idx += 1;
                 }
                 ValueTypeNative::ExternalRecord(_) => {
                     return Err("external_record inputs are not yet supported in fromMPC".to_string());
@@ -386,8 +386,8 @@ impl ExecutionRequest {
             inputs,
             signature_native,
             sk_tag,
-            tvk_native,
-            tcm_native,
+            tvk,
+            tcm,
             scm,
         ));
 

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -243,47 +243,44 @@ impl ExecutionRequest {
         function_name: String,
         inputs: Array,
         input_types: Array,
-        signature_native: Signature,
+        signature: Signature,
         tvk: Field,
         view_key: ViewKey,
-        gammas: Option<Array>, // Optional array of gammas.  One gamma per input record.
+        gammas: Option<Array>,
     ) -> Result<ExecutionRequest, String> {
         let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
         let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
 
-        let inputs: Vec<ValueNative> = inputs
+        // Collect input_types into a Vec for record_count and length checks.
+        let input_types_vec: Vec<ValueTypeNative> = input_types
             .iter()
-            .map(|input| {
-                ValueNative::from_str(&input.as_string().unwrap()).map_err(|e| e.to_string())
-            })
+            .map(|it| ValueTypeNative::from_str(&it.as_string().unwrap()).map_err(|e| e.to_string()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let input_types: Vec<ValueTypeNative> = input_types
+        // Collect inputs_native separately for use in RequestNative at the end.
+        let inputs_native: Vec<ValueNative> = inputs
             .iter()
-            .map(|input_type| {
-                ValueTypeNative::from_str(&input_type.as_string().unwrap()).map_err(|e| e.to_string())
-            })
+            .map(|i| ValueNative::from_str(&i.as_string().unwrap()).map_err(|e| e.to_string()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        if input_types.len() != inputs.len() {
+        if input_types_vec.len() != inputs_native.len() {
             return Err("input_types and inputs must have the same length".to_string());
         }
 
         let signer = Address::from_view_key(&view_key);
         let sk_tag = GraphKey::from_view_key(&view_key).sk_tag();
         let root_tvk = tvk;
-        let signer_x = *signer.to_x_coordinate();
-        let scm = CurrentNetwork::hash_psd2(&[signer_x, *root_tvk]).map_err(|e| e.to_string())?;
+        let scm = CurrentNetwork::hash_psd2(&[*signer.to_group().to_x_coordinate(), *root_tvk]).map_err(|e| e.to_string())?;
         let tcm = CurrentNetwork::hash_psd2(&[*tvk]).map_err(|e| e.to_string())?;
 
         let network_id = U16Native::new(CurrentNetwork::ID);
         let function_id = compute_function_id(&network_id, &program_id, &function_name).map_err(|e| e.to_string())?;
 
-        let record_count = input_types
+        let record_count = input_types_vec
             .iter()
             .filter(|t| matches!(t, ValueTypeNative::Record(_)))
             .count();
-        
+
         let gamma_length = gammas.as_ref().map_or(0, |a| a.length() as usize);
         if record_count != gamma_length {
             return Err(format!(
@@ -294,14 +291,19 @@ impl ExecutionRequest {
             ));
         }
 
-        let mut record_input_idx = 0;
-        let mut input_ids = Vec::with_capacity(inputs.len());
-        for (index, (input, input_type)) in inputs.iter().zip(&input_types).enumerate() {
+        let mut record_input_idx = 0u32;
+        let mut input_ids = Vec::with_capacity(inputs_native.len());
+
+        // Iterate the raw JS arrays, parsing each input fresh so it is owned.
+        for (index, (input_js, input_type_js)) in inputs.iter().zip(input_types.iter()).enumerate() {
+            let input = ValueNative::from_str(&input_js.as_string().unwrap()).map_err(|e| e.to_string())?;
+            let input_type = ValueTypeNative::from_str(&input_type_js.as_string().unwrap()).map_err(|e| e.to_string())?;
+
             let index_field = FieldNative::from_u16(
                 u16::try_from(index).map_err(|_| format!("Input index {index} exceeds maximum allowed value"))?,
             );
 
-            match input_type {
+            match &input_type {
                 ValueTypeNative::Constant(_) | ValueTypeNative::Public(_) => {
                     let mut preimage = vec![function_id];
                     preimage.extend(input.to_fields().map_err(|e| e.to_string())?);
@@ -328,21 +330,22 @@ impl ExecutionRequest {
                     input_ids.push(InputIDNative::Private(input_hash));
                 }
                 ValueTypeNative::Record(record_name) => {
-                    // Deserialize the record input
-                    let ValueNative::Record(record_input) = input;
-                    // Compute the record input ID from the gamma, record commitment, h, and h_r.
-                    let record_view_key = (**record_input.nonce() * ***view_key).to_x_coordinate();
-                    // Compute the commitment for the record input.
+                    // input is owned here, so destructuring works without clone.
+                    let record_input = match input {
+                        ValueNative::Record(record) => record,
+                        _ => return Err("Expected a record input for record type".to_string()),
+                    };
+                    let record_view_key = (*record_input.nonce() * ***view_key).to_x_coordinate();
                     let commitment = record_input
-                        .to_commitment(&program_id, &record_name, &record_view_key)
+                        .to_commitment(&program_id, record_name, &record_view_key)
                         .map_err(|e| e.to_string())?;
-                    // Obtain the correct gamme from the Option<Array> deserialize to group element.
-                    let gamma = Group::from(gammas.as_ref().unwrap().get(record_input_idx as u32)); // Not great to use unwrap()...even though the existence of the array is valid at this point.
-                    // Compute the serial number
+
+                    let gamma_js = gammas.as_ref().unwrap().get(record_input_idx as u32);
+                    let gamma = Group::from_string(&gamma_js.as_string().ok_or("Invalid gamma value")?)
+                        .map_err(|e| e.to_string())?;
+
                     let serial_number = RecordPlaintextNative::serial_number_from_gamma(&gamma, commitment).map_err(|e| e.to_string())?;
-                    // Compute the tag
                     let tag = RecordPlaintextNative::tag(*sk_tag, commitment).map_err(|e| e.to_string())?;
-                    // Add the input ID to the input_id vector and increment the count.
                     input_ids.push(InputIDNative::Record(commitment, *gamma, record_view_key, serial_number, tag));
                     record_input_idx += 1;
                 }
@@ -356,15 +359,15 @@ impl ExecutionRequest {
         }
 
         let request = RequestNative::from((
-            signer,
+            *signer,
             network_id,
             program_id,
             function_name,
             input_ids,
-            inputs,
-            signature_native,
-            sk_tag,
-            tvk,
+            inputs_native,  // use the separately collected Vec
+            *signature,
+            *sk_tag,
+            *tvk,
             tcm,
             scm,
         ));

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -315,7 +315,7 @@ impl ExecutionRequest {
                 }
                 ValueTypeNative::Private(_) => {
                     let input_view_key =
-                        CurrentNetwork::hash_psd4(&[function_id, tvk, index_field]).map_err(|e| e.to_string())?;
+                        CurrentNetwork::hash_psd4(&[function_id, *tvk, index_field]).map_err(|e| e.to_string())?;
                     let ciphertext = match input {
                         ValueNative::Plaintext(plaintext) => {
                             plaintext.encrypt_symmetric(input_view_key).map_err(|e| e.to_string())?
@@ -331,19 +331,19 @@ impl ExecutionRequest {
                     // Deserialize the record input
                     let ValueNative::Record(record_input) = input;
                     // Compute the record input ID from the gamma, record commitment, h, and h_r.
-                    let record_view_key = (*record_input.nonce() * ***view_key).to_x_coordinate();
+                    let record_view_key = (**record_input.nonce() * ***view_key).to_x_coordinate();
                     // Compute the commitment for the record input.
                     let commitment = record_input
                         .to_commitment(&program_id, &record_name, &record_view_key)
                         .map_err(|e| e.to_string())?;
-                    // Pop the gamma value and deserialize to group element.
-                    let gamma = Group::from(gammas[record_input_idx]);
+                    // Obtain the correct gamme from the Option<Array> deserialize to group element.
+                    let gamma = Group::from(gammas.as_ref().unwrap().get(record_input_idx as u32)); // Not great to use unwrap()...even though the existence of the array is valid at this point.
                     // Compute the serial number
-                    let serial_number = RecordPlaintextNative::<CurrentNetwork, PlaintextNative<CurrentNetwork>>::serial_number_from_gamma(&gamma, commitment).map_err(|e| e.to_string())?;
+                    let serial_number = RecordPlaintextNative::serial_number_from_gamma(&gamma, commitment).map_err(|e| e.to_string())?;
                     // Compute the tag
-                    let tag = RecordPlaintextNative::<CurrentNetwork, PlaintextNative<CurrentNetwork>>::tag(sk_tag, commitment);
+                    let tag = RecordPlaintextNative::tag(*sk_tag, commitment).map_err(|e| e.to_string())?;
                     // Add the input ID to the input_id vector and increment the count.
-                    input_ids.push(InputIDNative::Record(commitment, gamma, record_view_key, serial_number, tag));
+                    input_ids.push(InputIDNative::Record(commitment, *gamma, record_view_key, serial_number, tag));
                     record_input_idx += 1;
                 }
                 ValueTypeNative::ExternalRecord(_) => {

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -30,15 +30,17 @@ use crate::{
         ProgramIDNative,
         RecordPlaintextNative,
         RequestNative,
+        SignatureNative,
         U16Native,
         ValueNative,
         ValueTypeNative,
+        ViewKeyNative,
     },
 };
 use snarkvm_console::{
     network::Network,
     prelude::{One, ToFields, Zero},
-    program::compute_function_id,
+    program::{compute_function_id, InputID},
 };
 use snarkvm_wasm::utilities::{FromBytes, ToBytes};
 
@@ -212,6 +214,229 @@ impl ExecutionRequest {
         .map_err(|e| e.to_string())?;
 
         // Return the execution request.
+        Ok(ExecutionRequest(request))
+    }
+
+    /// Builds a request from MPC options and MPC-signed fields, computing `sk_tag` and `scm` internally.
+    ///
+    /// For record inputs, the caller must provide the record input IDs (which require `sk_sig` to compute).
+    /// These can be obtained from a signed request's `input_ids()` or from the MPC output.
+    ///
+    /// @param {string} program_id The id of the program.
+    /// @param {string} function_name The function name.
+    /// @param {string[]} inputs The inputs to the function.
+    /// @param {string[]} input_types The input types of the function.
+    /// @param {boolean} is_root Flag to indicate if this is the top level function in the call graph.
+    /// @param {Field | undefined} program_checksum The program checksum (required if the program has a constructor).
+    /// @param {Signature} signature The MPC-computed signature.
+    /// @param {Field} tvk The transition view key.
+    /// @param {Field} tcm The transition commitment.
+    /// @param {ViewKey} view_key The view key of the signer.
+    /// @param {string | undefined} record_input_ids_json JSON string of record input ID array (one per record input, in order).
+    ///        Required when inputs include records. E.g. '["{\"type\":\"record\",...}"]'. Each element is the JSON representation of InputID::Record.
+    #[wasm_bindgen(js_name = "fromMPC")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_mpc(
+        program_id: String,
+        function_name: String,
+        inputs: Array,
+        input_types: Array,
+        _is_root: bool,
+        _program_checksum: Option<Field>,
+        signature: Signature,
+        tvk: Field,
+        tcm: Field,
+        view_key: ViewKey,
+        record_input_ids_json: Option<String>,
+    ) -> Result<ExecutionRequest, String> {
+        let signature_native = *signature;
+        let tvk_native = FieldNative::from(tvk);
+        let tcm_native = FieldNative::from(tcm);
+        let view_key_native = *view_key;
+        Self::from_mpc_impl(
+            program_id,
+            function_name,
+            inputs,
+            input_types,
+            _is_root,
+            _program_checksum,
+            signature_native,
+            tvk_native,
+            tcm_native,
+            view_key_native,
+            record_input_ids_json,
+        )
+    }
+
+    /// Same as fromMPC but takes string representations for signature, tvk, tcm, and view_key.
+    /// Use this when passing wasm objects causes "null pointer passed to rust" (e.g. across worker boundaries).
+    #[wasm_bindgen(js_name = "fromMPCWithStrings")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_mpc_with_strings(
+        program_id: String,
+        function_name: String,
+        inputs: Array,
+        input_types: Array,
+        _is_root: bool,
+        _program_checksum: Option<Field>,
+        signature_str: String,
+        tvk_str: String,
+        tcm_str: String,
+        view_key_str: String,
+        record_input_ids_json: Option<String>,
+    ) -> Result<ExecutionRequest, String> {
+        let signature_native = SignatureNative::from_str(&signature_str).map_err(|e| e.to_string())?;
+        let tvk_native = FieldNative::from_str(&tvk_str).map_err(|e| e.to_string())?;
+        let tcm_native = FieldNative::from_str(&tcm_str).map_err(|e| e.to_string())?;
+        let view_key_native = ViewKeyNative::from_str(&view_key_str).map_err(|e| e.to_string())?;
+        Self::from_mpc_impl(
+            program_id,
+            function_name,
+            inputs,
+            input_types,
+            _is_root,
+            _program_checksum,
+            signature_native,
+            tvk_native,
+            tcm_native,
+            view_key_native,
+            record_input_ids_json,
+        )
+    }
+
+    fn from_mpc_impl(
+        program_id: String,
+        function_name: String,
+        inputs: Array,
+        input_types: Array,
+        _is_root: bool,
+        _program_checksum: Option<Field>,
+        signature_native: SignatureNative,
+        tvk_native: FieldNative,
+        tcm_native: FieldNative,
+        view_key_native: ViewKeyNative,
+        record_input_ids_json: Option<String>,
+    ) -> Result<ExecutionRequest, String> {
+        let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
+        let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
+
+        let inputs: Vec<ValueNative> = inputs
+            .iter()
+            .map(|input| {
+                ValueNative::from_str(&input.as_string().unwrap()).map_err(|e| e.to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let input_types: Vec<ValueTypeNative> = input_types
+            .iter()
+            .map(|input_type| {
+                ValueTypeNative::from_str(&input_type.as_string().unwrap()).map_err(|e| e.to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if input_types.len() != inputs.len() {
+            return Err("input_types and inputs must have the same length".to_string());
+        }
+
+        let signer = crate::types::native::AddressNative::try_from(&view_key_native).map_err(|e| e.to_string())?;
+        let sk_tag = crate::types::native::GraphKeyNative::try_from(view_key_native).map_err(|e| e.to_string())?.sk_tag();
+        let root_tvk = tvk_native;
+        let signer_x = signer.to_x_coordinate();
+        let scm = CurrentNetwork::hash_psd2(&[signer_x, root_tvk]).map_err(|e| e.to_string())?;
+
+        let network_id = U16Native::new(CurrentNetwork::ID);
+        let function_id = compute_function_id(&network_id, &program_id, &function_name).map_err(|e| e.to_string())?;
+
+        let record_input_id_strs: Vec<String> = record_input_ids_json
+            .as_ref()
+            .map(|json| {
+                serde_json::from_str::<Vec<String>>(json).map_err(|e| format!("record_input_ids_json must be JSON array of strings: {e}"))
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        let record_count = input_types
+            .iter()
+            .filter(|t| matches!(t, ValueTypeNative::Record(_)))
+            .count();
+        if record_count != record_input_id_strs.len() {
+            return Err(format!(
+                "record_input_ids must have length {} for {} record input(s), got {}",
+                record_count,
+                record_count,
+                record_input_id_strs.len()
+            ));
+        }
+
+        let mut record_input_idx = 0;
+        let mut input_ids = Vec::with_capacity(inputs.len());
+        for (index, (input, input_type)) in inputs.iter().zip(&input_types).enumerate() {
+            let index_field = FieldNative::from_u16(
+                u16::try_from(index).map_err(|_| format!("Input index {index} exceeds maximum allowed value"))?,
+            );
+
+            match input_type {
+                ValueTypeNative::Constant(_) | ValueTypeNative::Public(_) => {
+                    let mut preimage = vec![function_id];
+                    preimage.extend(input.to_fields().map_err(|e| e.to_string())?);
+                    preimage.push(tcm_native);
+                    preimage.push(index_field);
+                    let input_hash = CurrentNetwork::hash_psd8(&preimage).map_err(|e| e.to_string())?;
+                    input_ids.push(match input_type {
+                        ValueTypeNative::Constant(_) => InputID::Constant(input_hash),
+                        _ => InputID::Public(input_hash),
+                    });
+                }
+                ValueTypeNative::Private(_) => {
+                    let input_view_key =
+                        CurrentNetwork::hash_psd4(&[function_id, tvk_native, index_field]).map_err(|e| e.to_string())?;
+                    let ciphertext = match input {
+                        ValueNative::Plaintext(plaintext) => {
+                            plaintext.encrypt_symmetric(input_view_key).map_err(|e| e.to_string())?
+                        }
+                        _ => return Err("Expected a plaintext input for private type".to_string()),
+                    };
+                    let input_hash =
+                        CurrentNetwork::hash_psd8(&ciphertext.to_fields().map_err(|e| e.to_string())?)
+                            .map_err(|e| e.to_string())?;
+                    input_ids.push(InputID::Private(input_hash));
+                }
+                ValueTypeNative::Record(_) => {
+                    let record_input_id_str = record_input_id_strs
+                        .get(record_input_idx)
+                        .ok_or_else(|| "record_input_ids index out of bounds".to_string())?;
+                    let input_id = InputID::<CurrentNetwork>::from_str(record_input_id_str)
+                        .map_err(|e| format!("Failed to parse record input ID: {e}"))?;
+                    let input_id = match input_id {
+                        InputID::Record(..) => input_id,
+                        _ => return Err("record_input_ids must contain record-type input IDs".to_string()),
+                    };
+                    input_ids.push(input_id);
+                    record_input_idx += 1;
+                }
+                ValueTypeNative::ExternalRecord(_) => {
+                    return Err("external_record inputs are not yet supported in fromMPC".to_string());
+                }
+                ValueTypeNative::Future(_) => {
+                    return Err("Future inputs are not supported".to_string());
+                }
+            }
+        }
+
+        let request = RequestNative::from((
+            signer,
+            network_id,
+            program_id,
+            function_name,
+            input_ids,
+            inputs,
+            signature_native,
+            sk_tag,
+            tvk_native,
+            tcm_native,
+            scm,
+        ));
+
         Ok(ExecutionRequest(request))
     }
 
@@ -431,6 +656,8 @@ mod tests {
 
     /// Test vectors from program-manager.test.ts: transfer_public with address + u64.
     const PRIVATE_KEY_STR: &str = "APrivateKey1zkp7Vc4xJt8HqW9U7VhY6h32d8Z9Xi5C6ZZX3gtXxbBSJmj";
+    /// Beacon private key (produces aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px).
+    const BEACON_PRIVATE_KEY_STR: &str = "APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH";
     const TRANSFER_PUBLIC_INPUTS: [&str; 2] =
         ["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px", "100u64"];
     const TRANSFER_PUBLIC_INPUT_TYPES: [&str; 2] = ["address.public", "u64.public"];
@@ -459,6 +686,104 @@ mod tests {
         assert_eq!(request.network_id(), CurrentNetwork::ID);
         assert_eq!(request.inputs().length(), 2);
         assert_eq!(request.input_ids().length(), 2);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_execution_request_from_mpc_matches_sign() {
+        let private_key = PrivateKey::from_string(PRIVATE_KEY_STR).unwrap();
+        let view_key = ViewKey::from_private_key(&private_key);
+        let inputs = crate::array![TRANSFER_PUBLIC_INPUTS[0].to_string(), TRANSFER_PUBLIC_INPUTS[1].to_string()];
+        let input_types =
+            crate::array![TRANSFER_PUBLIC_INPUT_TYPES[0].to_string(), TRANSFER_PUBLIC_INPUT_TYPES[1].to_string()];
+
+        let signed_request = ExecutionRequest::sign(
+            private_key,
+            "credits.aleo".to_string(),
+            "transfer_public".to_string(),
+            inputs.clone(),
+            input_types.clone(),
+            None,
+            None,
+            true,
+        )
+        .expect("sign should succeed");
+
+        let mpc_request = ExecutionRequest::from_mpc(
+            "credits.aleo".to_string(),
+            "transfer_public".to_string(),
+            inputs,
+            input_types,
+            true,
+            None,
+            signed_request.signature(),
+            signed_request.tvk(),
+            signed_request.tcm(),
+            view_key,
+            None, // no record inputs
+        )
+        .expect("from_mpc should succeed");
+
+        assert_eq!(mpc_request.program_id(), signed_request.program_id());
+        assert_eq!(mpc_request.function_name(), signed_request.function_name());
+        assert_eq!(mpc_request.inputs().length(), signed_request.inputs().length());
+        assert_eq!(mpc_request.input_ids().length(), signed_request.input_ids().length());
+        assert_eq!(mpc_request.to_string(), signed_request.to_string());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_execution_request_from_mpc_matches_sign_transfer_private() {
+        let private_key = PrivateKey::from_string(BEACON_PRIVATE_KEY_STR).unwrap();
+        let view_key = ViewKey::from_private_key(&private_key);
+        let record_beacon_owned = "{ owner: aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px.private, microcredits: 1000000u64.private, _nonce: 3634848344765318974603121890869676775499130077229666060613233255327643175219group.public, _version: 1u8.public }";
+        let inputs = crate::array![
+            record_beacon_owned.to_string(),
+            "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px".to_string(),
+            "100u64".to_string(),
+        ];
+        let input_types = crate::array![
+            "credits.record".to_string(),
+            "address.private".to_string(),
+            "u64.private".to_string(),
+        ];
+
+        let signed_request = ExecutionRequest::sign(
+            private_key,
+            "credits.aleo".to_string(),
+            "transfer_private".to_string(),
+            inputs.clone(),
+            input_types.clone(),
+            None,
+            None,
+            true,
+        )
+        .expect("sign should succeed");
+
+        let record_input_id_0 = signed_request
+            .input_ids()
+            .get(0)
+            .as_string()
+            .expect("record input id should be string");
+        let record_input_ids_json = serde_json::to_string(&[record_input_id_0]).expect("JSON serialize");
+        let mpc_request = ExecutionRequest::from_mpc(
+            "credits.aleo".to_string(),
+            "transfer_private".to_string(),
+            inputs,
+            input_types,
+            true,
+            None,
+            signed_request.signature(),
+            signed_request.tvk(),
+            signed_request.tcm(),
+            view_key,
+            Some(record_input_ids_json),
+        )
+        .expect("from_mpc should succeed");
+
+        assert_eq!(mpc_request.program_id(), signed_request.program_id());
+        assert_eq!(mpc_request.function_name(), signed_request.function_name());
+        assert_eq!(mpc_request.inputs().length(), signed_request.inputs().length());
+        assert_eq!(mpc_request.input_ids().length(), signed_request.input_ids().length());
+        assert_eq!(mpc_request.to_string(), signed_request.to_string());
     }
 
     #[wasm_bindgen_test]

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -243,9 +243,8 @@ impl ExecutionRequest {
         input_types: Array,
         signature: Signature,
         tvk: Field,
-        tcm: Field,
         view_key: ViewKey,
-        record_input_ids_json: Option<String>,
+        gammas: Option<Array>
     ) -> Result<ExecutionRequest, String> {
         let signature_native = *signature;
         let tvk_native = FieldNative::from(tvk);
@@ -256,11 +255,10 @@ impl ExecutionRequest {
             function_name,
             inputs,
             input_types,
-            signature_native,
-            tvk_native,
-            tcm_native,
-            view_key_native,
-            record_input_ids_json,
+            signature,
+            tvk,
+            view_key,
+            gammas,
         )
     }
 
@@ -269,11 +267,10 @@ impl ExecutionRequest {
         function_name: String,
         inputs: Array,
         input_types: Array,
-        signature_native: SignatureNative,
-        tvk_native: FieldNative,
-        tcm_native: FieldNative,
-        view_key_native: ViewKeyNative,
-        record_input_ids_json: Option<String>,
+        signature_native: Signature,
+        tvk: Field,
+        view_key: ViewKey,
+        record_gamma: Option<Array>, // Optional array of gammas.  One gamma per input record.
     ) -> Result<ExecutionRequest, String> {
         let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
         let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
@@ -296,33 +293,26 @@ impl ExecutionRequest {
             return Err("input_types and inputs must have the same length".to_string());
         }
 
-        let signer = crate::types::native::AddressNative::try_from(&view_key_native).map_err(|e| e.to_string())?;
-        let sk_tag = crate::types::native::GraphKeyNative::try_from(view_key_native).map_err(|e| e.to_string())?.sk_tag();
+        let signer = Address::from_view_key(view_key.as_ref());
+        let sk_tag = GraphKey::from_view_key(view_key.as_ref()).tag();
         let root_tvk = tvk_native;
-        let signer_x = signer.to_x_coordinate();
-        let scm = CurrentNetwork::hash_psd2(&[signer_x, root_tvk]).map_err(|e| e.to_string())?;
+        let signer_x = *signer.to_x_coordinate();
+        let scm = CurrentNetwork::hash_psd2(&[signer_x, *root_tvk]).map_err(|e| e.to_string())?;
+        let tcm = CurrentNetwork::hash_psd2(&[*tvk])?;
 
         let network_id = U16Native::new(CurrentNetwork::ID);
         let function_id = compute_function_id(&network_id, &program_id, &function_name).map_err(|e| e.to_string())?;
-
-        let record_input_id_strs: Vec<String> = record_input_ids_json
-            .as_ref()
-            .map(|json| {
-                serde_json::from_str::<Vec<String>>(json).map_err(|e| format!("record_input_ids_json must be JSON array of strings: {e}"))
-            })
-            .transpose()?
-            .unwrap_or_default();
 
         let record_count = input_types
             .iter()
             .filter(|t| matches!(t, ValueTypeNative::Record(_)))
             .count();
-        if record_count != record_input_id_strs.len() {
+        if record_count != gammas.len() {
             return Err(format!(
                 "record_input_ids must have length {} for {} record input(s), got {}",
                 record_count,
                 record_count,
-                record_input_id_strs.len()
+                gammas.len()
             ));
         }
 
@@ -347,7 +337,7 @@ impl ExecutionRequest {
                 }
                 ValueTypeNative::Private(_) => {
                     let input_view_key =
-                        CurrentNetwork::hash_psd4(&[function_id, tvk_native, index_field]).map_err(|e| e.to_string())?;
+                        CurrentNetwork::hash_psd4(&[function_id, tvk.as_rev(), index_field]).map_err(|e| e.to_string())?;
                     let ciphertext = match input {
                         ValueNative::Plaintext(plaintext) => {
                             plaintext.encrypt_symmetric(input_view_key).map_err(|e| e.to_string())?
@@ -359,18 +349,24 @@ impl ExecutionRequest {
                             .map_err(|e| e.to_string())?;
                     input_ids.push(InputID::Private(input_hash));
                 }
-                ValueTypeNative::Record(_) => {
-                    let record_input_id_str = record_input_id_strs
-                        .get(record_input_idx)
-                        .ok_or_else(|| "record_input_ids index out of bounds".to_string())?;
-                    let input_id = InputID::<CurrentNetwork>::from_str(record_input_id_str)
-                        .map_err(|e| format!("Failed to parse record input ID: {e}"))?;
-                    let input_id = match input_id {
-                        InputID::Record(..) => input_id,
-                        _ => return Err("record_input_ids must contain record-type input IDs".to_string()),
-                    };
-                    input_ids.push(input_id);
-                    record_input_idx += 1;
+                ValueTypeNative::Record(record_name) => {
+                    // Deserialize the record input
+                    let ValueNative::Record(record_input) = input;
+                    // Compute the record input ID from the gamma, record commitment, h, and h_r.
+                    let record_view_key = (*record_input.nonce() * ***vk).to_x_coordinate();
+                    // Compute the commitment for the record input.
+                    let commitment = record_input
+                        .to_commitment(&program_id, &record_name, &record_view_key)
+                        .map_err(|e| e.to_string())?;
+                    // Pop the gamma value and deserialize to group element.
+                    let gamma = Group::from(Array.shift());
+                    // Compute the serial number
+                    let serial_number = RecordNative::<CurrentNetwork, PlaintextNative<CurrentNetwork>>::serial_number_from_gamma(&gamma, commitment).map_err(|e| e.to_string())?;
+                    // Compute the tag
+                    let tag = RecordNative::<CurrentNetwork, PlaintextNative<CurrentNetwork>::tag(sk_tag, commitment);
+                    // Add the input ID to the input_id vector and increment the count.
+                    input_ids.push(InputIDNative::Record(commitment, gamma, record_view_key, serial_number, tag));
+                    record_input_ix += 1;
                 }
                 ValueTypeNative::ExternalRecord(_) => {
                     return Err("external_record inputs are not yet supported in fromMPC".to_string());

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -249,10 +249,12 @@ impl ExecutionRequest {
         view_key: ViewKey,
         record_input_ids_json: Option<String>,
     ) -> Result<ExecutionRequest, String> {
+        println!("test1");
         let signature_native = *signature;
         let tvk_native = FieldNative::from(tvk);
         let tcm_native = FieldNative::from(tcm);
         let view_key_native = *view_key;
+        println!("test2");
         Self::from_mpc_impl(
             program_id,
             function_name,
@@ -317,8 +319,10 @@ impl ExecutionRequest {
         view_key_native: ViewKeyNative,
         record_input_ids_json: Option<String>,
     ) -> Result<ExecutionRequest, String> {
+        println!("test3");
         let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
         let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
+        println!("test4");
 
         let inputs: Vec<ValueNative> = inputs
             .iter()

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -241,8 +241,6 @@ impl ExecutionRequest {
         function_name: String,
         inputs: Array,
         input_types: Array,
-        _is_root: bool,
-        _program_checksum: Option<Field>,
         signature: Signature,
         tvk: Field,
         tcm: Field,
@@ -258,44 +256,6 @@ impl ExecutionRequest {
             function_name,
             inputs,
             input_types,
-            _is_root,
-            _program_checksum,
-            signature_native,
-            tvk_native,
-            tcm_native,
-            view_key_native,
-            record_input_ids_json,
-        )
-    }
-
-    /// Same as fromMPC but takes string representations for signature, tvk, tcm, and view_key.
-    /// Use this when passing wasm objects causes "null pointer passed to rust" (e.g. across worker boundaries).
-    #[wasm_bindgen(js_name = "fromMPCWithStrings")]
-    #[allow(clippy::too_many_arguments)]
-    pub fn from_mpc_with_strings(
-        program_id: String,
-        function_name: String,
-        inputs: Array,
-        input_types: Array,
-        _is_root: bool,
-        _program_checksum: Option<Field>,
-        signature_str: String,
-        tvk_str: String,
-        tcm_str: String,
-        view_key_str: String,
-        record_input_ids_json: Option<String>,
-    ) -> Result<ExecutionRequest, String> {
-        let signature_native = SignatureNative::from_str(&signature_str).map_err(|e| e.to_string())?;
-        let tvk_native = FieldNative::from_str(&tvk_str).map_err(|e| e.to_string())?;
-        let tcm_native = FieldNative::from_str(&tcm_str).map_err(|e| e.to_string())?;
-        let view_key_native = ViewKeyNative::from_str(&view_key_str).map_err(|e| e.to_string())?;
-        Self::from_mpc_impl(
-            program_id,
-            function_name,
-            inputs,
-            input_types,
-            _is_root,
-            _program_checksum,
             signature_native,
             tvk_native,
             tcm_native,
@@ -309,8 +269,6 @@ impl ExecutionRequest {
         function_name: String,
         inputs: Array,
         input_types: Array,
-        _is_root: bool,
-        _program_checksum: Option<Field>,
         signature_native: SignatureNative,
         tvk_native: FieldNative,
         tcm_native: FieldNative,

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -176,7 +176,6 @@ impl ExecutionRequest {
         program_checksum: Option<Field>,
         is_root: bool,
     ) -> Result<ExecutionRequest, String> {
-        crate::log("signing");
         // Convert the ProgramID and function name to their native objects.
         let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
         let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
@@ -250,12 +249,10 @@ impl ExecutionRequest {
         view_key: ViewKey,
         record_input_ids_json: Option<String>,
     ) -> Result<ExecutionRequest, String> {
-        crate::log("test1");
         let signature_native = *signature;
         let tvk_native = FieldNative::from(tvk);
         let tcm_native = FieldNative::from(tcm);
         let view_key_native = *view_key;
-        crate::log("test2");
         Self::from_mpc_impl(
             program_id,
             function_name,
@@ -288,15 +285,10 @@ impl ExecutionRequest {
         view_key_str: String,
         record_input_ids_json: Option<String>,
     ) -> Result<ExecutionRequest, String> {
-        crate::log(&format!("testa: {:?}", signature_str));
         let signature_native = SignatureNative::from_str(&signature_str).map_err(|e| e.to_string())?;
-        crate::log("testb");
         let tvk_native = FieldNative::from_str(&tvk_str).map_err(|e| e.to_string())?;
-        crate::log("testc");
         let tcm_native = FieldNative::from_str(&tcm_str).map_err(|e| e.to_string())?;
-        crate::log("testd");
         let view_key_native = ViewKeyNative::from_str(&view_key_str).map_err(|e| e.to_string())?;
-        crate::log("teste");
         Self::from_mpc_impl(
             program_id,
             function_name,
@@ -325,10 +317,8 @@ impl ExecutionRequest {
         view_key_native: ViewKeyNative,
         record_input_ids_json: Option<String>,
     ) -> Result<ExecutionRequest, String> {
-        crate::log("test3");
         let program_id = ProgramIDNative::from_str(&program_id).map_err(|e| e.to_string())?;
         let function_name = IdentifierNative::from_str(&function_name).map_err(|e| e.to_string())?;
-        crate::log("test4");
 
         let inputs: Vec<ValueNative> = inputs
             .iter()

--- a/wasm/src/record/record_plaintext.rs
+++ b/wasm/src/record/record_plaintext.rs
@@ -41,10 +41,11 @@ use crate::{
     },
 };
 use snarkvm_console::{
-    prelude::{FromBytes, ToBits, ToBytes, ToFields},
+    prelude::{FromBytes, Network, ToBits, ToBytes, ToFields},
     program::Owner,
 };
 
+use crate::types::native::ViewKeyNative;
 use anyhow::Context;
 use js_sys::{Array, Object, Uint8Array};
 use std::{ops::Deref, str::FromStr};
@@ -254,6 +255,31 @@ impl RecordPlaintext {
         let serial_number = RecordPlaintextNative::serial_number(private_key.into(), commitment.into())
             .map_err(|_| "Serial number derivation failed".to_string())?;
         Ok(serial_number.to_string())
+    }
+
+    /// Compute the record's gamma value.
+    ///
+    /// @param {string} program_id The program id that produced the record.
+    /// @param {string} record_name The name of the record within the program.
+    /// @param {PrivateKey} private_key The private key that created the record.
+    /// @returns {Group} The computed value of gamma.
+    pub fn gamma(&self, program_id: &str, record_name: &str, private_key: &PrivateKey) -> Result<Group, String> {
+        let private_key_native = **private_key;
+        let view_key = ViewKeyNative::try_from(&private_key_native).map_err(|e| e.to_string())?;
+        let program_id_native = ProgramIDNative::from_str(program_id).map_err(|e| e.to_string())?;
+        let record_name_native = IdentifierNative::from_str(record_name).map_err(|e| e.to_string())?;
+        let record_view_key = (*self.0.nonce() * *view_key).to_x_coordinate();
+        // Compute the record commitment.
+        let commitment = self
+            .0
+            .to_commitment(&program_id_native, &record_name_native, &record_view_key)
+            .map_err(|e| e.to_string())?;
+
+        // Compute the generator `H` as `HashToGroup(commitment)`.
+        let h = CurrentNetwork::hash_to_group_psd2(&[CurrentNetwork::serial_number_domain(), commitment])
+            .map_err(|e| e.to_string())?;
+        let gamma = h * private_key_native.sk_sig();
+        Ok(Group::from(gamma))
     }
 
     /// Get the tag of the record using the graph key.

--- a/wasm/src/types/native/mod.rs
+++ b/wasm/src/types/native/mod.rs
@@ -24,6 +24,7 @@ use snarkvm_console::{
         Entry,
         Future,
         Identifier,
+        InputID,
         Literal,
         Locator,
         Plaintext,
@@ -92,6 +93,7 @@ pub type CiphertextNative = Ciphertext<CurrentNetwork>;
 pub type CiphertextEntryNative = Entry<CurrentNetwork, CiphertextNative>;
 pub type FutureNative = Future<CurrentNetwork>;
 pub type IdentifierNative = Identifier<CurrentNetwork>;
+pub type InputIDNative = InputID<CurrentNetwork>;
 pub type LiteralNative = Literal<CurrentNetwork>;
 pub type LocatorNative = Locator<CurrentNetwork>;
 pub type PlaintextNative = Plaintext<CurrentNetwork>;

--- a/wasm/src/utilities/array.rs
+++ b/wasm/src/utilities/array.rs
@@ -17,7 +17,7 @@
 /// Converts a JS array of wasm-bindgen exported structs from JsValues to their native Rust type
 /// representation.
 #[macro_export]
-macro_rules! from_wasm_object_array {
+macro_rules! from_wasm_field_array {
     ($input:expr, $wasm_type:ident) => {{
         $input
             .iter()
@@ -25,6 +25,20 @@ macro_rules! from_wasm_object_array {
                 $wasm_type::try_from_js_value(x).map(|x| *x).map_err(|_| "Input must be an array of fields".to_string())
             })
             .collect::<Result<Vec<FieldNative>, String>>()
+    }};
+}
+
+/// Converts a JS array of wasm-bindgen exported structs from JsValues to their native Rust type
+/// representation.
+#[macro_export]
+macro_rules! native_type_from_wasm_object_array {
+    ($input:expr, $wasm_type:ident, $native_type:ident) => {{
+        $input
+            .iter()
+            .map(|x| {
+                $wasm_type::try_from_js_value(x).map(|x| *x).map_err(|_| "Input must be an array of fields".to_string())
+            })
+            .collect::<Result<Vec<$native_type>, String>>()
     }};
 }
 


### PR DESCRIPTION
## Motivation

This pull request introduces new functionality for constructing `ExecutionRequest`s from MPC (Multi-Party Computation) outputs, both in Rust and in the TypeScript SDK tests, and adds support for debug builds of the WASM package. The changes improve the ability to test and interoperate with MPC-generated signatures and related fields, especially for private transfers that involve record inputs.