### PR TITLE
[Feature] Add toString methods for account objects

### DIFF
--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -153,6 +153,15 @@ impl Address {
         self.0.to_string()
     }
 
+    /// Get a string representation of an Aleo address object
+    ///
+    /// @returns {string} String representation of the address
+    #[wasm_bindgen(js_name = "toString")]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string_js(&self) -> String {
+        self.0.to_string()
+    }
+
     /// Get the plaintext representation of the address.
     #[wasm_bindgen(js_name = "toPlaintext")]
     pub fn to_plaintext(&self) -> Plaintext {

--- a/wasm/src/account/graph_key.rs
+++ b/wasm/src/account/graph_key.rs
@@ -50,6 +50,15 @@ impl GraphKey {
         self.0.to_string()
     }
 
+    /// Get a string representation of a graph key
+    ///
+    /// @returns {string} String representation of a graph key
+    #[wasm_bindgen(js_name = "toString")]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string_js(&self) -> String {
+        self.0.to_string()
+    }
+
     /// Get the sk_tag of the graph key. Used to determine ownership of records.
     pub fn sk_tag(&self) -> Field {
         Field::from(self.0.sk_tag())

--- a/wasm/src/account/private_key.rs
+++ b/wasm/src/account/private_key.rs
@@ -78,6 +78,16 @@ impl PrivateKey {
         self.0.to_string()
     }
 
+    /// Get a string representation of the private key. This function should be used very carefully
+    /// as it exposes the private key plaintext
+    ///
+    /// @returns {string} String representation of a private key
+    #[wasm_bindgen(js_name = "toString")]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string_js(&self) -> String {
+        self.0.to_string()
+    }
+
     /// Get the view key corresponding to the private key
     ///
     /// @returns {ViewKey}

--- a/wasm/src/account/signature.rs
+++ b/wasm/src/account/signature.rs
@@ -160,6 +160,15 @@ impl Signature {
         self.0.to_string()
     }
 
+    /// Get a string representation of a signature
+    ///
+    /// @returns {string} String representation of a signature
+    #[wasm_bindgen(js_name = "toString")]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string_js(&self) -> String {
+        self.0.to_string()
+    }
+
     /// Get the plaintext representation of the signature.
     #[wasm_bindgen(js_name = "toPlaintext")]
     pub fn to_plaintext(&self) -> Plaintext {

--- a/wasm/src/account/view_key.rs
+++ b/wasm/src/account/view_key.rs
@@ -49,6 +49,15 @@ impl ViewKey {
         self.0.to_string()
     }
 
+    /// Get a string representation of a view key
+    ///
+    /// @returns {string} String representation of a view key
+    #[wasm_bindgen(js_name = "toString")]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string_js(&self) -> String {
+        self.0.to_string()
+    }
+
     /// Get the underlying bytes of a view key.
     ///
     /// @returns {Uint8Array} Left endian byte array representation of the view key.


### PR DESCRIPTION
## Motivation

When the SDK was first developed, the `to_string` method for account objects was not appropriately named `toString` in the JS bindings to the `wasm` method. This has caused significant confusion for developers who expect a camelCase toString method.

Unfortunately this `to_string` method must be maintained so as not to break any implementations using it. This PR adds `toString` methods in JS for account objects in addition to the `to_string` bindings in order to provide the expected camelCase syntax while preserving backwards compatibility. 

The to_string methods will eventually be deprecated.