### PR TITLE
[Chore] SDK v0.9.1.8 release candidate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Yarn monorepo for the **Provable SDK** — a TypeScript/Rust SDK for building zero-knowledge applications on the Aleo 
 blockchain. The SDK re-exports core protocol objects from SnarkVM to allow users to perform operations related to their
-accounts and execute Aleo programs. Main published packages: `@provablehq/sdk` and `@provablehq/wasm` (both v0.9.17).
+accounts and execute Aleo programs. Main published packages: `@provablehq/sdk` and `@provablehq/wasm` (both v0.9.18).
 
 **Workspaces:** `sdk`, `wasm`, `create-leo-app`
 

--- a/.claude/commands/wrap-snarkvm.md
+++ b/.claude/commands/wrap-snarkvm.md
@@ -49,6 +49,8 @@ pub type TransactionNative = Transaction<CurrentNetwork>;
 
 Do not add a new `use` statement if the crate is already imported — extend the existing one.
 
+Ensure all imports are in alphabetical order.
+
 ---
 
 ## Step 3: Create the wrapper file at the specified destination
@@ -77,6 +79,7 @@ impl TypeName {
     // - to_string gets #[wasm_bindgen(js_name = "toString")] and #[allow(clippy::inherent_to_string)]
     // - from_str / constructors get #[wasm_bindgen(js_name = "fromString")] etc.
     // - Fallible methods return Result<T, String> — map errors with .map_err(|e| e.to_string())
+    // - Methods should have to_string(), from_string(), to_bytes_le(), from_bytes_le(), to_field(), and to_fields(), from_fields(), to_bits_le(), and from_bits_le() if the SnarkVM object implements any of those. 
 }
 
 // Always generate all four two-way conversions between TypeName and TypeNameNative.
@@ -309,14 +312,72 @@ Match the style of existing entries in that file.
 
 ---
 
-## Step 6: Verify
+## Step 6: Verify the wasm tests
 
-Run:
+Run this from the sdk base directory.
 ```bash
-cd wasm && cargo clippy --features testnet 2>&1 | head -50
+yarn test:wasm
 ```
 
 Fix any errors before declaring done. Common issues:
 - Missing imports in the wrapper file
 - Trait bounds not satisfied (check what traits the native type requires)
 - Method signatures that need adjustment for wasm-bindgen compatibility (e.g. no generic parameters, no lifetimes on return types)
+
+## Step 7: Write JS tests of the wasm object and export it in `browser.ts`.
+
+
+Write JS tests of the wasm object and its methods in the JS sdk in the appropriate test file in `sdk/tests/wasm.test.ts`.
+
+An example of how to write such tests are below.
+
+```typescript
+    describe('Transition', () => {
+    const transitionStringTestnet = `{"id":"au1u62jasyx78x9hktak24awyj38fz73aseq8g9cx98u8egd9pj9uxq3u6s2z","program":"hello_hello.aleo","function":"hello","inputs":[{"type":"public","id":"3748790614260807060977840590007893602934308327222309419419577452790958781330field","value":"1u32"},{"type":"private","id":"5954208307642819953251922459490586292095132973876550778604572231610245257004field","value":"ciphertext1qyq0m5mp0d2gzh2pv9p25z70gz2avhqdt3dp8y8thzwf3aq6g35zcqcuyptz3"}],"outputs":[{"type":"private","id":"1557506318887190915592751299113729867877933642317637206076176689093854281418field","value":"ciphertext1qyqzmhw8ln9r6uuyh0n5jrsqlt25wdggqp3d9yqyttpr3g7g00k2sysdf9rmv"}],"tpk":"7532444547840484531569841377269810017844130178606467837628364672670182422388group","tcm":"7292056195970541935877520517416922164990366931599720071937561392936678536563field","scm":"8283770351301010771186520129040704279224805960417079922462917369178354050332field"}`;
+    const transitionTestnet = Transition.fromString(transitionStringTestnet);
+    const transitionDecryptedStringTestnet = `{"id":"au1mhdz6jqm973v5vfkz2pwgv63p340c9tpvydxha2zs8w03746qcpqvx3yye","program":"hello_hello.aleo","function":"hello","inputs":[{"type":"public","id":"3748790614260807060977840590007893602934308327222309419419577452790958781330field","value":"1u32"},{"type":"public","id":"5954208307642819953251922459490586292095132973876550778604572231610245257004field","value":"2u32"}],"outputs":[{"type":"public","id":"1557506318887190915592751299113729867877933642317637206076176689093854281418field","value":"3u32"}],"tpk":"7532444547840484531569841377269810017844130178606467837628364672670182422388group","tcm":"7292056195970541935877520517416922164990366931599720071937561392936678536563field","scm":"8283770351301010771186520129040704279224805960417079922462917369178354050332field"}`
+    const transitionDecryptedTestnet = Transition.fromString(transitionDecryptedStringTestnet);
+    const transitionViewKeyStringTestnet = "3975242887442171718863200089461896014344887434842278474302914755871123010247field";
+
+    const transitionStringMainnet = `{"id":"au1mguuz0dh20f78802m4z0py7n08xhl0pz60llzck63mhl8pc8l5xqxpwgtn","program":"hello_hello.aleo","function":"main","inputs":[{"type":"public","id":"6393584049543470937057043098611271993206122889317039351966319038535020834557field","value": "1u32"},{"type":"private","id":"8207446256045172951742235001162005156507562935942883128759030124682934277495field","value":"ciphertext1qyqqgz9qnupeld9vr4vuwp6yrpmhgtkvmgag5m7mmrruw0r6je666qgqdswk3"}],"outputs":[{"type":"private","id":"127469473292952941321346770257126666363371158501875622169294663492714835110field","value":"ciphertext1qyqyapkjuxm9dcslgyjf7hkr2k3dek500z40gjspnwvll0uawj23vzgggc405"}],"tpk":"7647553513996966044119163122930125808381703910407273818947266861843062002251group","tcm":"4479413938380109857414238205380483440836495997450846894155088299187217672609field","scm":"6461007226176477784737642021400489186736987671609840640950580467598882134642field"}`;
+    const transitionMainnet = Transition.fromString(transitionStringMainnet);
+    const transitionDecryptedStringMainnet = `{"id":"au1jl2ur42sj7hwe4r0alv6gnklqxj0fszrvu3q82gjcls5x6q9pyzqdgmu2k","program":"hello_hello.aleo","function":"main","inputs":[{"type":"public","id":"6393584049543470937057043098611271993206122889317039351966319038535020834557field","value":"1u32"},{"type":"public","id":"8207446256045172951742235001162005156507562935942883128759030124682934277495field","value":"2u32"}],"outputs":[{"type":"public","id":"127469473292952941321346770257126666363371158501875622169294663492714835110field","value":"3u32"}],"tpk":"7647553513996966044119163122930125808381703910407273818947266861843062002251group","tcm":"4479413938380109857414238205380483440836495997450846894155088299187217672609field","scm":"6461007226176477784737642021400489186736987671609840640950580467598882134642field"}`;
+    const transitionDecryptedMainnet = Transition.fromString(transitionDecryptedStringMainnet);
+    const transitionViewKeyStringMainnet = "8161419549946991944867064830365679191883723972221767444308198038592561311302field";
+
+    const invalidTransitionViewKeyString = "5089075468761042335883809641276568724119791331127957254389204093712358605127field"
+    const invalidTransitionViewKey = Field.fromString(invalidTransitionViewKeyString);
+    const privateKey = PrivateKey.from_string("APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH");
+    const viewKey = privateKey.to_view_key();
+
+    let connection = new AleoNetworkClient("https://api.provable.com/v2");
+
+    if (connection.network === "testnet") {
+        it('can be decrypted with a valid transition view key', () => {
+            const tvk = transitionTestnet.tvk(viewKey);
+            const transitionDecryptedWithTVK = transitionTestnet.decryptTransition(tvk);
+            // Ensure the transition is valid
+            expect(transitionDecryptedWithTVK.toString()).equal(transitionDecryptedTestnet.toString());
+        });
+
+        it('cannot be decrypted with an invalid transition view key', () => {
+            expect(() => transitionTestnet.decryptTransition(invalidTransitionViewKey).toThrow());
+        });
+
+        it('can generate a transition view key from a valid view key', () => {
+            const generatedTransitionViewKey = transitionTestnet.tvk(viewKey);
+
+            // Ensure the generated transition view key is the same as the one used to decrypt
+            expect(generatedTransitionViewKey.toString()).equal(transitionViewKeyStringTestnet);
+        });
+    };
+```
+
+Verify these tests work by running `yarn build:wasm && yarn build:sdk && yarn test:sdk` from the root of the sdk directory.
+
+## Step 8: Cleanup Run cargo fmt --all
+
+run the following in the `wasm` directory
+```bash
+cargo fmt --all
+```

--- a/create-leo-app/package.json
+++ b/create-leo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-leo-app",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "type": "module",
   "license": "GPL-3.0",
   "collaborators": [

--- a/create-leo-app/template-build-and-execute-authorization-ts/package.json
+++ b/create-leo-app/template-build-and-execute-authorization-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17"
+    "@provablehq/sdk": "^0.9.18"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-devnode-js/index.js
+++ b/create-leo-app/template-devnode-js/index.js
@@ -32,7 +32,7 @@ constructor:
 async function main() {
     // Initialize multi-threading to allow WASM execution.
     await initThreadPool();
-    const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11");
+    const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
 
     const privateKey = "APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH";
     const account = new Account({privateKey});

--- a/create-leo-app/template-devnode-js/package.json
+++ b/create-leo-app/template-devnode-js/package.json
@@ -7,6 +7,6 @@
     "dev": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17"
+    "@provablehq/sdk": "^0.9.18"
   }
 }

--- a/create-leo-app/template-extension/package.json
+++ b/create-leo-app/template-extension/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf static/js && rollup --config"
   },
   "devDependencies": {
-    "@provablehq/sdk": "^0.9.17",
+    "@provablehq/sdk": "^0.9.18",
     "@web/rollup-plugin-import-meta-assets": "^2.2.1",
     "rimraf": "^6.0.1",
     "rollup": "^4.59.0"

--- a/create-leo-app/template-nextjs-ts/package.json
+++ b/create-leo-app/template-nextjs-ts/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17",
+    "@provablehq/sdk": "^0.9.18",
     "next": "15.5.10",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/create-leo-app/template-node-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-node-credits-aleo-functions-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.9.17"
+        "@provablehq/sdk": "^0.9.18"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-ts/package.json
+++ b/create-leo-app/template-node-ts/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17"
+    "@provablehq/sdk": "^0.9.18"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-node/package.json
+++ b/create-leo-app/template-node/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17"
+    "@provablehq/sdk": "^0.9.18"
   }
 }

--- a/create-leo-app/template-offline-public-transaction-ts/package.json
+++ b/create-leo-app/template-offline-public-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node --trace-uncaught dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17"
+    "@provablehq/sdk": "^0.9.18"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-private-transaction-ts/package.json
+++ b/create-leo-app/template-private-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17"
+    "@provablehq/sdk": "^0.9.18"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-react-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-react-credits-aleo-functions-ts/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.9.17",
+        "@provablehq/sdk": "^0.9.18",
         "comlink": "^4.4.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-leo/package.json
+++ b/create-leo-app/template-react-leo/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17",
+    "@provablehq/sdk": "^0.9.18",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-managed-worker/package.json
+++ b/create-leo-app/template-react-managed-worker/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17",
+    "@provablehq/sdk": "^0.9.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/create-leo-app/template-react-ts/package.json
+++ b/create-leo-app/template-react-ts/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17",
+    "@provablehq/sdk": "^0.9.18",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-vanilla/package.json
+++ b/create-leo-app/template-vanilla/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@provablehq/sdk": "^0.9.17",
+        "@provablehq/sdk": "^0.9.18",
         "tslib": "^2.8.1",
         "vite": "^6.3.6"
     }

--- a/docs/api_reference/sdk-src_program-manager.md
+++ b/docs/api_reference/sdk-src_program-manager.md
@@ -1556,7 +1556,7 @@ __*return*__ | `Promise.<Transaction>` | *- A promise that resolves to the trans
 import { AleoKeyProvider, getOrInitConsensusVersionTestHeights, ProgramManager, NetworkRecordProvider } from "@provablehq/sdk/mainnet.js";
 
 // Initialize the development consensus heights in order to work with devnode.
-getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11");
+getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
 
 // Create a new NetworkClient and RecordProvider.
 const recordProvider = new NetworkRecordProvider(account, networkClient);
@@ -1606,7 +1606,7 @@ __*return*__ | `string` | *The transaction id of the deployed program or a failu
 import { ProgramManager, NetworkRecordProvider, getOrInitConsensusVersionTestHeights } from "@provablehq/sdk/mainnet.js";
 
 // Initialize the development consensus heights in order to work with a local devnode.
-getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11");
+getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
 
 // Create a new NetworkClient, and RecordProvider
 const recordProvider = new NetworkRecordProvider(account, networkClient);
@@ -3213,7 +3213,7 @@ __*return*__ | `Promise.<Transaction>` | *- A promise that resolves to the trans
 import { AleoKeyProvider, getOrInitConsensusVersionTestHeights, ProgramManager, NetworkRecordProvider } from "@provablehq/sdk/mainnet.js";
 
 // Initialize the development consensus heights in order to work with devnode.
-getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11");
+getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
 
 // Create a new NetworkClient and RecordProvider.
 const recordProvider = new NetworkRecordProvider(account, networkClient);
@@ -3263,7 +3263,7 @@ __*return*__ | `string` | *The transaction id of the deployed program or a failu
 import { ProgramManager, NetworkRecordProvider, getOrInitConsensusVersionTestHeights } from "@provablehq/sdk/mainnet.js";
 
 // Initialize the development consensus heights in order to work with a local devnode.
-getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11");
+getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
 
 // Create a new NetworkClient, and RecordProvider
 const recordProvider = new NetworkRecordProvider(account, networkClient);

--- a/e2e/dynamic/package.json
+++ b/e2e/dynamic/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17"
+    "@provablehq/sdk": "^0.9.18"
   }
 }

--- a/e2e/mainnet/package.json
+++ b/e2e/mainnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17"
+    "@provablehq/sdk": "^0.9.18"
   }
 }

--- a/e2e/nodenext/package.json
+++ b/e2e/nodenext/package.json
@@ -2,7 +2,7 @@
     "name": "nodenext",
     "type": "module",
     "dependencies": {
-        "@provablehq/sdk": "^0.9.17",
+        "@provablehq/sdk": "^0.9.18",
         "typescript": "^5.7.3"
     },
     "scripts": {

--- a/e2e/testnet/package.json
+++ b/e2e/testnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.9.17"
+    "@provablehq/sdk": "^0.9.18"
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/sdk",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Provable Team"
@@ -51,7 +51,7 @@
   },
   "homepage": "https://github.com/ProvableHQ/sdk#readme",
   "dependencies": {
-    "@provablehq/wasm": "^0.9.17",
+    "@provablehq/wasm": "^0.9.18",
     "@scure/base": "^2.0.0",
     "comlink": "^4.4.2",
     "core-js": "^3.40.0",

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -3291,7 +3291,7 @@ class ProgramManager {
      * import { AleoKeyProvider, getOrInitConsensusVersionTestHeights, ProgramManager, NetworkRecordProvider } from "@provablehq/sdk/mainnet.js";
      * 
      * // Initialize the development consensus heights in order to work with devnode.
-     * getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11");
+     * getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
      *
      * // Create a new NetworkClient and RecordProvider.
      * const recordProvider = new NetworkRecordProvider(account, networkClient);
@@ -3461,7 +3461,7 @@ class ProgramManager {
      * import { ProgramManager, NetworkRecordProvider, getOrInitConsensusVersionTestHeights } from "@provablehq/sdk/mainnet.js";
      * 
      * // Initialize the development consensus heights in order to work with a local devnode.
-     * getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11");
+     * getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
      *
      * // Create a new NetworkClient, and RecordProvider
      * const recordProvider = new NetworkRecordProvider(account, networkClient);

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -564,9 +564,9 @@ describe('WASM Objects', () => {
     describe('Set development consensus version heights', () => {
         it('Consensus version heights can be set externally', async () => {
             if (process.env["RUN_SKIPPED"]) {
-                const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11");
+                const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
                 console.log(heights);
-                expect(heights).to.deep.equal([0,1,2,3,4,5,6,7,8,9,10,11]);
+                expect(heights).to.deep.equal([0,1,2,3,4,5,6,7,8,9,10,11,12]);
             }
         });
     });

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2228,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2255,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2269,7 +2269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2289,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2299,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2317,12 +2317,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2362,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2375,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2384,7 +2384,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2406,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2441,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2481,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2493,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2531,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2578,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2596,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "anyhow",
  "rand",
@@ -2682,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2729,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2751,7 +2751,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2766,7 +2766,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2858,7 +2858,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2939,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "proc-macro2",
  "quote 1.0.44",
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-wasm"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
 dependencies = [
  "getrandom 0.2.17",
  "snarkvm-console",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,7 +51,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ebd144c81671193ed85aa2db9bb5e183421843e0485de8fffc07e5cf50e18a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.44",
  "syn 1.0.109",
 ]
 
@@ -71,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f6ff9e4c36858fa2c29e5284b77527b5a7466743976e1ba1f5824e16683545"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.44",
  "syn 1.0.109",
 ]
 
@@ -126,12 +117,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-dependencies = [
- "backtrace",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayref"
@@ -152,8 +140,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -167,21 +155,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
 
 [[package]]
 name = "base16ct"
@@ -224,9 +197,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake2"
@@ -239,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
+checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -268,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -285,10 +258,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cc"
-version = "1.2.47"
+name = "cast"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -302,11 +281,11 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -327,9 +306,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cookie"
@@ -344,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie",
  "document-features",
@@ -365,6 +344,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -455,18 +444,18 @@ checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
 dependencies = [
  "curl-sys",
  "libc",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
+version = "0.4.85+curl-8.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
+checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
 dependencies = [
  "cc",
  "libc",
@@ -489,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -535,8 +524,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -674,8 +663,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -728,15 +717,15 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -786,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -801,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -811,15 +800,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -828,38 +817,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -869,7 +858,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -895,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -908,21 +896,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "wasip2",
+ "wasip3",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gloo-timers"
@@ -968,16 +951,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1006,6 +989,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1041,12 +1030,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1068,7 +1056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1079,7 +1067,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1130,8 +1118,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
- "http 1.3.1",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -1148,7 +1136,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
  "rustls",
@@ -1189,24 +1177,23 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
- "system-configuration 0.6.1",
+ "socket2 0.6.2",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1261,9 +1248,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1275,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -1293,6 +1280,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -1317,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1336,9 +1329,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -1355,15 +1348,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1388,18 +1381,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.177"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -1417,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1444,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -1459,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1471,9 +1476,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -1497,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -1508,14 +1513,14 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -1531,6 +1536,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1556,8 +1570,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1576,6 +1590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1589,19 +1604,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
@@ -1609,7 +1621,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1625,8 +1637,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1634,6 +1646,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -1725,10 +1743,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.103"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1741,9 +1769,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1781,7 +1809,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1819,7 +1847,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1828,7 +1856,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -1875,16 +1903,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.12",
- "http 1.3.1",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -1931,17 +1959,11 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc_version"
@@ -1954,11 +1976,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1967,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
@@ -1991,18 +2013,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2017,9 +2039,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2060,12 +2082,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2073,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2119,22 +2141,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2178,15 +2200,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2227,7 +2249,7 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-parameters",
  "snarkvm-utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2625,7 +2647,7 @@ dependencies = [
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2641,7 +2663,7 @@ dependencies = [
  "rayon",
  "serde",
  "snarkvm-utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -2798,7 +2820,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c01
 dependencies = [
  "anyhow",
  "async-trait",
- "reqwest 0.12.24",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "snarkvm-console",
@@ -2854,7 +2876,7 @@ dependencies = [
  "sha2",
  "snarkvm-curves",
  "snarkvm-utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "web-sys",
 ]
 
@@ -2964,7 +2986,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "snarkvm-utilities-derives",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -2975,8 +2997,8 @@ version = "4.4.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2984,7 +3006,7 @@ name = "snarkvm-wasm"
 version = "4.4.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "snarkvm-console",
  "snarkvm-curves",
  "snarkvm-fields",
@@ -3007,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -3041,7 +3063,7 @@ checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 dependencies = [
  "quote 0.3.15",
  "synom",
- "unicode-xid",
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -3051,18 +3073,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.44",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.44",
  "unicode-ident",
 ]
 
@@ -3087,7 +3109,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -3097,8 +3119,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3108,18 +3130,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -3145,12 +3167,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3167,11 +3189,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3181,19 +3203,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3263,15 +3285,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "windows-sys 0.61.2",
 ]
 
@@ -3297,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3310,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3325,14 +3347,14 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
@@ -3355,9 +3377,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3366,20 +3388,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -3398,15 +3420,21 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3416,9 +3444,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
@@ -3441,16 +3469,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64 0.22.1",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3509,18 +3537,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3533,11 +3570,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -3546,65 +3584,114 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
 dependencies = [
- "quote 1.0.42",
+ "quote 1.0.44",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
 dependencies = [
  "bumpalo",
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.55"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+checksum = "6f9483e929b4ae6889bc7c62b314abda7d0bd286a8d82b21235855d5327e4eb4"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.55"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+checksum = "30f8b972c5c33f97917c9f418535f3175e464d48db15f5226d124c648a1b4036"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0000397743a3b549ddba01befd1a26020eff98a028429630281c4203b4cc538d"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3612,9 +3699,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3928,9 +4015,91 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote 1.0.44",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid 0.2.6",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -3956,29 +4125,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.28"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.28"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3997,8 +4166,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4013,13 +4182,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4051,6 +4220,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2206,8 +2206,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc064d3ad09ca7a22e9659212d4fddf28e4bbc9c96d4aa2288aa17933498117"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2234,8 +2233,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13621a445caf8ee1958e835e14a0f8974bd0b757ebd4de4fe22b9063e45aad40"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2249,8 +2247,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df5d6cb0579ec9e9f473d85ee985cb6cf021d35541262dc770438164f60a328"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2260,8 +2257,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75f80d1dd05e4f5daaee601240c0bec20fafdafa5246cc2c48382940ce08b6d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2271,8 +2267,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c70bfd65cf988f1546b5f7b3751b62977a1937ffebad090850a784ebb0a96a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2282,8 +2277,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901cc5c67082b0df337ee26f2bfb3b70a2ca51d64e6f200cf11f7a1708bfc1d9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2301,14 +2295,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884964c0c167823e6ee76fc1ae1e647880f07b4a04415371c81de0f0cb5a2e6d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eab9d33e9eb389d7187a67327ba48482e64ab66924dd934367f4cd4775f6b0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2319,8 +2311,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b137592dd746c7eb4f56f63ecfa9947e62257f9b3b14e335aa8afacd5354217"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2334,8 +2325,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc98725fbd1fc34be94198f8271f534d1c9049c822a26eaa26432a7edcf6e81a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2350,8 +2340,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550c5271f41cb15316f7a09a5d1faa0411fcef3031a4a23ac51751d9dd9e0b6c"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2364,8 +2353,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bfbc7c607653fd523ef25fccec2fa7084d869468ff49ee58c6069a628786fe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2374,8 +2362,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8db5a8888734da5ee5598fe80a70ec251a679fad2c72aaccb039ec8c09836fa"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2385,8 +2372,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76791b4f4c960b5c8a89c6caa2953315eb70fe8ca0e7734c6354b8206089cce"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2398,8 +2384,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3607d81e417bf23dde768575ae16072537e66ed19f8bbd1b96066c66b207f8bb"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2411,8 +2396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe08c39cb7ce71d947da1fd36c0a677ed9d361edadb42c14f83b9652cf34d6a5"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2423,8 +2407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf54a2995c69c4e0f770bbd5352204151736f35128190f6361a58b762ae5210"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2436,8 +2419,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78da46f40feec9078410c2415d36489256b282abf3c1dec85945874115e8803"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2450,8 +2432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd345486bab3fbe54a5800a1dfee37e05b0dee06710b4f389fea98645e8f58b6"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2462,12 +2443,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ba6389587cd3bd7431ff3280619ae8a5761a46722ae53edcd98172ce027ae3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "blake2s_simd",
  "hex",
  "k256",
+ "serde",
  "smallvec",
  "snarkvm-console-types",
  "snarkvm-fields",
@@ -2478,11 +2459,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a72b0ca52f5e4059b4159758aac8395155c081953abfddd2c196d43ba9743b5"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std",
  "rayon",
+ "serde",
  "snarkvm-console-algorithms",
  "snarkvm-console-types",
 ]
@@ -2490,8 +2471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c92880c09b37d5bdff2ced22e0911cce75e3e425f51783628481d478aa2a80d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2511,8 +2491,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1aeabebbda7b45b66196cdd9db456d154625b6b3233c477536b82e46024688"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2530,8 +2509,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a0ff48530b8392268dec61f9231b2eb290624d6f58246ada83eaca7bcde99"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2552,8 +2530,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047f4712e7de64699e401c08d80aa11aefbda4bb5a3b97cfe0181b31cb482c8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2568,8 +2545,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc581d795614ffa23dbf737c44413caf7b25a62845f38649ba00a61be6f124ec"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2580,8 +2556,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740afa0e3018eb8048f1d2351b92c163214a6d16b73513f9f4fe0de53d8d977c"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2589,8 +2564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d92c4e9dddcdf25942903959d0402cad5baba3d56f0d09d22f4ee95fc24cb5"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2600,8 +2574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ea02928ed85ea863cac8eb429ba92232d8e0aba7f111473b42665eedcc794f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2612,8 +2585,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7cfb62960c945521065a04cabf5b25cb9925027455c4f428d7613afc22a77d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2624,8 +2596,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "593c61497ce4658e43d0829b6dd7ee57a01fe5069333f36bd14bcfa1cdeef680"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2636,8 +2607,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8eb1d2a1275202adb50f1abae4d6afc1059950435f01bb884da435205bff96b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2648,11 +2618,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b8f4f8477fdd9fbab7bde40b5fd104993b6199227cd219af968384a8e8d657"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "rand",
- "rayon",
  "rustc_version",
  "serde",
  "snarkvm-fields",
@@ -2663,8 +2631,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78912e74b5de1807326eb175e75331a9f5c195944746c362e9092dda6b54db8d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2681,8 +2648,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a20386597ffd5550e536265c0a24d823db995df8d555ab59d55b335d823cd2"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "anyhow",
  "rand",
@@ -2694,8 +2660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d4687d54811d18d6922e167e432c2f78be2fc31ff849098d90b5a08f56a741"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2717,8 +2682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678d6e0bc202ea821638836c36d129df1f4aec86c19681edffbf0d7ce14bb04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2730,8 +2694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a87acbd36d5851fc746550fc190d37ce56660a48be9659bcc4c0de08ba4ea7f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2744,8 +2707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c94988348c23db830c3431528af45a6c876a2bf1142fcd15f42d128a496762b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2757,8 +2719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c37c79d6a7f934ed19a7f32391ea1c77567991f3a29b1dfe138b4b8ef27b41"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2768,8 +2729,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fe2242ed6a26b4fe3d52888b392b4560e3ec466ea97e7d06d4083068d9113f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2784,8 +2744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850f880f898929b3ad24b6e403c6edeec8c35f40040c5f89c1ae2ef539bf0293"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2794,8 +2753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94e53be712268f4d0994899fa2d5143606da62e1946265607abe58fa7a6723c"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2814,8 +2772,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c2b866424dba58368d47e85e4529e4dbae68cf346ab1f9b7e2dd08631c5697"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2837,8 +2794,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b9a6594198d17477adc72a8fbffa495e0c0193dd8fc36e632f787d5b98c694"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2855,8 +2811,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c125333fa216ae69b3f90563a2d06f47511d553bc0f951771709177cfaa1638"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2875,13 +2830,13 @@ dependencies = [
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
+ "tracing",
 ]
 
 [[package]]
 name = "snarkvm-parameters"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1f5f415330dbb5c5921ef6d05962b5d18f239c12d4f1a12795a592ecde6038"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2906,8 +2861,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0092bc65216609a180c01e8a03b2a527d6b527e8776ce71785b932f901893e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2932,14 +2886,14 @@ dependencies = [
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ceadf64062805b4a48b298c206a9f5a4bb12032a9a60465ef1e0a5766cdf77"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2963,8 +2917,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc32136ef3ac69aaeab040e11e4a0bdc8c00dbae778c0d3b65120d179e44eb9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -2983,8 +2936,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175dbc6a6d7cbf188397b81c545323bed27dab554a40e3a6261988f0b1fdca0a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2997,12 +2949,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b062dc2351b888db6ea293e2ee294b4069c5b9eda242f8d336f08f2ea95150d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
+ "colored",
  "num-bigint",
  "num_cpus",
  "rand",
@@ -3020,8 +2972,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a60e21b9d249446399f4c67bf2ca12e1e10bb2539a1812df3202d235213d5b3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -3031,8 +2982,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-wasm"
 version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e790de363e10fbbc6b3496f895a318717b569281e1d1ffc9b8d43c098e7daa"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.4#745c018fcb22f5a252f36ab3a4a807b26eff9e26"
 dependencies = [
  "getrandom 0.2.16",
  "snarkvm-console",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "12aca1021aef2c476bad30d2f681e891b2be4f07dbc230a96df09cb693bfb3cb"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2227,8 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8ac1b6a6f09d6563f0c2b8907d4f604e30dd734615d74d047fffd69d515d82"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2254,8 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "789ebaac0b333ff0bc67c080321b485b8f83341f608e2c0f7789ffda09f26bb1"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2268,8 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e386197b4b8b9da94935cae1f7c8de5a48080846a99b89d48a37bdda19a41274"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2278,8 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61dfe1df8b9f1dab0437c7077fd849f9c6c175c2d2bc6a4a21777abee9fcec7"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2288,8 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc59afd654098930527c9240eb34d48cb9b66f1b14aceaf9d9383cfca0be936d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2298,8 +2303,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dee5ea35b2fcd22572c6a2f9bf5665b99239880aa27b1e8c859066006d56e66"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2316,13 +2322,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0722b642ba183bb9d8ee819555ffaf3f6517fb135e6ab7ba04d3397e39bac67"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0ad7521a67f3115eacdde833ad21c96caf5ed490067ab0a3f22b7fdfe16f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2332,8 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c4e7b786afeeff9b2668a28290c05ac1cac2c7553bf2bab46629d9a54d12b8"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2346,8 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "863535b214170279b4458819e6e36ad88dfdf47998f83dd15d8e3dca2038f014"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2361,8 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ab1004c1033eea2a0b63e0cf3dae135dc3f4ef643ecafa68140bee610b9928"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2374,8 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf15f8adcd01eb17b9f1f6351f12d7f12c31dd872515a5e316cf1b1950252867"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2383,8 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fd90969d0f5f7bb3568b8f3c46be0411767e3a6bc3c61eda8bcdec95ce6b0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2393,8 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60fad82bb36772a0d5d5aed64023b30632a7d7feea1b2a9a5f115beb807292b6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2405,8 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faefa15a1aa2a85066f0c36ae840d5760a27166efba1564b60f6e39e08e15ed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2417,8 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98982adf5e0667d8764613417c6e64c8ad954efcdd3c345cfcabd4c3a1ce46"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2428,8 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e2ad5b31dd261c741646e2b4c06d82e842a2508def775f87807afca1b671d9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2440,8 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eedd50cc76dbd958e54128ab3c91bd6c8b99bca0a3fdace1db6a9575a18cd0c"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2453,8 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5294eb812914aa4e0d453a7a5c72bb744dd43fe2411422296f4cb65405e69a93"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2464,8 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efad39f931761918c4014ecca58dfe3118ebfb5f0b361baa86dcc9ef348597fe"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2480,8 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb86ad2603ffd541a18ea524de0333b55b2c45fc44e38e891962e15ad2e2c28"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2492,8 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63ede70a074cce404e121b569e8765e127cd1b9f87730ce7944518d2bd45d22"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2512,8 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fac3b4b95c381a9537102ee84e20335df1598557f06d5e1138e74b98741d988"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2530,8 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffd370083d4396a7c4c7b89e38be0923cd8ce283caf20e54f729c3f4008dd74"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2551,8 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c51363e05726d4aa1c8e73fb8aaadbb1a3895a2a0838ee1a50f4e2af111e295"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2566,8 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4572a1aa0593f89ee7d338f496794dca57251a7dc43b2e4631d9f41b1db3cb9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2577,16 +2603,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0255c235e2fe2d61652357ddbcc032a5c34c21e2e1f575f6a0cce8b741dd1870"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc1fc0bcaf8d66dad69469b9331279577402e3bb6e8744728ea3f19305d05dd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2595,8 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b4fb849c1dc4016cb449d15e7e5fb096bc23872422c03f12e180e16ba6accf"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2606,8 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea1dd3fb2575a7c9ed8e3797ae27759a94fe85d41004fa2f50ce4f35864825e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2617,8 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c300ee4c5a71033ae492b15a2b3270bb8fff1ed7bbfb4caaf8311f73230c0479"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2628,8 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b842c747b5df818aa01cdd668ec1af51934d22ef73005d7b3c110af3f3bf563"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2639,8 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eef241fc007b4d15eb3bc704dd17734e005babf075f843b2ab4f6603a255a63d"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2652,8 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf420b40e671f6982e436d7356c75e008b04a8a2631e30bbe5789b1b72c9417"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2669,8 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5747f7656153c24fbcbe38031d0936ce4ccf8fc00a28e724fedcacc5d2356814"
 dependencies = [
  "anyhow",
  "rand",
@@ -2681,8 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8280e3c51a6220d04be7f5a09fcb6c6ce9384492ae23b40f4537842b2f6d86b5"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2703,8 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436fba11c005b91c8cf03671a8c6791750ba5c5dce2e5b28d02ab2829fc68ef0"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2715,8 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a36980e0d857135083f9887e4cf66827735cbfd8b65ee4c627e197159c3c2b"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2728,8 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e02c6b118935828771b13d8d85880a00364d4487d9e2b2822af64301dce5a5"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2740,8 +2779,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e49a698596a3adc0491b57521e9ebbb6a8b2f07eb7fa5283fa0b87b0c9db24da"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2750,8 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e8640d272eea7842fb4f6a85bf5214908bcf294edcba8161a3fe852b5319b8"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2765,8 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecf18739f9594fe5494b628cd8d2f72b53c50a28773bf7940fea848fc26a6f17"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2774,8 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60576c33e4417f347a41d6f6dceeb38895af1ec4b7ef49eef467c5956ea8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2793,8 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb9278a74ef96adecd302979d43f01bb1fda9dab01af8586426eab0be916f07"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2815,8 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f55770a9b2aabc103b658e681346f62eb4e00b98293d185e04d654edf1ab31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2832,8 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f71a9d7badda594dc9dd75f6dd31a08b282d4e5cc2cb679d3802d396506387"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -2857,8 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0969bee3d4c8b033bde17d35df2db9fbc92d2e7d2aceb01af6a59ebf32e455be"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2882,8 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9a1805635e7e2d85d7b7e51d1234bd87a6a7be8b2eef7be19617261a488f4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2914,8 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2a61297295cd9a8ed0e509c14170bd1e4338eeefba1224302e7a6aea451d7"
 dependencies = [
  "aleo-std",
  "colored",
@@ -2938,8 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70af04be0ae7bd5f2ab9a9fb37cbc8c57a74a54838f2b5fceaae3de342586014"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -2957,8 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f62babd345a3cb305e88946f5781040591ad6351dec4dd3cbca23d46c2a4ec88"
 dependencies = [
  "bincode",
  "serde_json",
@@ -2970,8 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eed8688602a2468ad1833a3cd2fbf902517d53b519ebd05c9e5cb6431e3c96"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2993,8 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b14dca149fde666bdd9ea91395ff4d48a442e83a75de9ff4b4224efc379fdbc"
 dependencies = [
  "proc-macro2",
  "quote 1.0.44",
@@ -3003,8 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=9a76d30158dbd70e30b538154eb982058b603570#9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899545f032a9e518752d76ee35f601a765833b25c6717f10c78cb7cebc4fe4c7"
 dependencies = [
  "getrandom 0.2.17",
  "snarkvm-console",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -22,14 +22,17 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 
 [dependencies.snarkvm-circuit-network]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 default-features = false
 features = [
     "account",
@@ -42,31 +45,38 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 
 [dependencies.snarkvm-parameters]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+tag = "canary-v4.5.4"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-wasm"
-version = "0.9.17"
+version = "0.9.18"
 authors = [ "The Provable Team" ]
 description = "WebAssembly based toolkit for developing zero-knowledge applications with Aleo"
 homepage = "https://provable.com"
@@ -22,17 +22,14 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 
 [dependencies.snarkvm-circuit-network]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 default-features = false
 features = [
     "account",
@@ -45,38 +42,31 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 
 [dependencies.snarkvm-parameters]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "9a76d30158dbd70e30b538154eb982058b603570"
+version = "4.5.0"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -22,14 +22,17 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 
 [dependencies.snarkvm-circuit-network]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 default-features = false
 features = [
     "account",
@@ -42,31 +45,38 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 
 [dependencies.snarkvm-parameters]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-version = "4.4.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "9a76d30158dbd70e30b538154eb982058b603570"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]
@@ -161,58 +171,3 @@ strip = true
 opt-level = 3
 lto = "thin"
 incremental = true
-
-[patch.crates-io]
-snarkvm-algorithms = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-account = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-algorithms = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-collections = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-environment = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-environment-witness = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-network = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-program = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-types = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-types-address = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-types-boolean = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-types-field = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-types-group = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-types-integers = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-types-scalar = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-circuit-types-string = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-account = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-algorithms = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-collections = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-network = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-network-environment = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-program = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-types = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-types-address = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-types-boolean = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-types-field = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-types-group = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-types-integers = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-types-scalar = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-console-types-string = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-curves = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-fields = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-authority = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-block = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-committee = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-narwhal-batch-certificate = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-narwhal-batch-header = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-narwhal-data = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-narwhal-subdag = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-narwhal-transmission-id = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-puzzle = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-puzzle-epoch = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-query = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-ledger-store = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-parameters = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-synthesizer = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-synthesizer-process = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-synthesizer-program = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-synthesizer-snark = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-utilities = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
-snarkvm-wasm = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -22,17 +22,14 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 
 [dependencies.snarkvm-circuit-network]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 default-features = false
 features = [
     "account",
@@ -45,38 +42,31 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 
 [dependencies.snarkvm-parameters]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.4"
+version = "4.4.0"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]
@@ -171,3 +161,58 @@ strip = true
 opt-level = 3
 lto = "thin"
 incremental = true
+
+[patch.crates-io]
+snarkvm-algorithms = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-account = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-algorithms = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-collections = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-environment = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-environment-witness = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-network = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-program = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-types = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-types-address = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-types-boolean = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-types-field = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-types-group = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-types-integers = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-types-scalar = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-circuit-types-string = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-account = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-algorithms = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-collections = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-network = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-network-environment = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-program = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-types = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-types-address = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-types-boolean = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-types-field = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-types-group = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-types-integers = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-types-scalar = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-console-types-string = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-curves = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-fields = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-authority = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-block = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-committee = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-narwhal-batch-certificate = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-narwhal-batch-header = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-narwhal-data = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-narwhal-subdag = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-narwhal-transmission-id = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-puzzle = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-puzzle-epoch = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-query = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-ledger-store = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-parameters = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-synthesizer = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-synthesizer-process = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-synthesizer-program = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-synthesizer-snark = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-utilities = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }
+snarkvm-wasm = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.4" }

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/wasm",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [

--- a/wasm/src/programs/program.rs
+++ b/wasm/src/programs/program.rs
@@ -263,6 +263,16 @@ impl Program {
                 let inputs = self.get_struct_members(struct_name)?;
                 Reflect::set(&input, &"members".into(), &inputs.into()).map_err(|_| "Failed to set property")?;
             }
+            PlaintextType::ExternalStruct(struct_locator) => {
+                let struct_name = struct_locator.name();
+                if let Some(name) = name {
+                    Reflect::set(&input, &"name".into(), &name.into()).map_err(|_| "Failed to set property")?;
+                }
+                Reflect::set(&input, &"type".into(), &"struct".into()).map_err(|_| "Failed to set property")?;
+                Reflect::set(&input, &"struct_id".into(), &struct_name.to_string().into()).map_err(|_| "Failed to set property")?;
+                let inputs = self.get_struct_members(struct_name.to_string())?;
+                Reflect::set(&input, &"members".into(), &inputs.into()).map_err(|_| "Failed to set property")?;
+            }
         }
         if let Some(visibility) = visibility {
             Reflect::set(&input, &"visibility".into(), &visibility.into()).map_err(|_| "Failed to set property")?;

--- a/wasm/src/programs/program.rs
+++ b/wasm/src/programs/program.rs
@@ -269,7 +269,8 @@ impl Program {
                     Reflect::set(&input, &"name".into(), &name.into()).map_err(|_| "Failed to set property")?;
                 }
                 Reflect::set(&input, &"type".into(), &"struct".into()).map_err(|_| "Failed to set property")?;
-                Reflect::set(&input, &"struct_id".into(), &struct_name.to_string().into()).map_err(|_| "Failed to set property")?;
+                Reflect::set(&input, &"struct_id".into(), &struct_name.to_string().into())
+                    .map_err(|_| "Failed to set property")?;
                 let inputs = self.get_struct_members(struct_name.to_string())?;
                 Reflect::set(&input, &"members".into(), &inputs.into()).map_err(|_| "Failed to set property")?;
             }

--- a/wasm/src/utilities/mod.rs
+++ b/wasm/src/utilities/mod.rs
@@ -43,7 +43,7 @@ pub mod test;
 /// import { getOrInitConsensusVersionHeights } from @provablehq/sdk;
 ///
 /// Set the consensus version heights.
-/// getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10");
+/// getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
 #[wasm_bindgen::prelude::wasm_bindgen(js_name = getOrInitConsensusVersionTestHeights)]
 pub fn get_or_init_consensus_version_heights(heights: Option<String>) -> js_sys::Array {
     // Call the underlying Rust function that returns [(ConsensusVersion, u32); N]
@@ -61,6 +61,6 @@ mod tests {
     #[wasm_bindgen_test]
     #[should_panic]
     fn test_set_genesis_block_non_zero_fails() {
-        get_or_init_consensus_version_heights(Some("10,9,8,7,6,5,4,3,2,1,0".to_string()));
+        get_or_init_consensus_version_heights(Some("10,9,8,7,6,5,4,3,2,1,0,1,2".to_string()));
     }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
         "@codemirror/language": "^6.10.8",
         "@codemirror/legacy-modes": "^6.4.2",
         "@codemirror/stream-parser": "^0.19.9",
-        "@provablehq/sdk": "^0.9.17",
+        "@provablehq/sdk": "^0.9.18",
         "@uiw/codemirror-theme-noctis-lilac": "^4.23.7",
         "@uiw/codemirror-theme-okaidia": "^4.23.7",
         "@uiw/react-codemirror": "^4.23.7",


### PR DESCRIPTION
## Motivation

This PR creates the SDK `v0.9.18` release candidate. Changes include.
- Formal package version bump from `v0.9.17` --> `v0.9.18`
- Update snarkVM version from `4.4.0` -> `4.5.0`
- Addition of ExternalStruct support
- Minor updates to claude wasm export skill.