### PR TITLE
[Feature] Add prepareInputs to auto-convert bare strings to field elements

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -128,10 +128,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        template:
-          - node
-          - node-credits-aleo-functions-ts
-          - node-ts
+        include:
+          - template: node
+            command: start
+          - template: node-credits-aleo-functions-ts
+            command: start
+          - template: node-ts
+            command: test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-yarn
@@ -139,7 +142,7 @@ jobs:
 
       - working-directory: create-leo-app/template-${{ matrix.template }}
         run: |
-          yarn start
+          yarn ${{ matrix.command }}
 
 
   create-leo-app-loyalty-program-local:

--- a/create-leo-app/template-node-ts/package.json
+++ b/create-leo-app/template-node-ts/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "build": "rimraf dist/js && rollup --config",
-    "start": "npm run build && node dist/index.js"
+    "start": "npm run build && node dist/index.js",
+    "start:dynamic-dispatch": "npm run build && node dist/dynamic-dispatch.js",
+    "test": "npm run build && node dist/index.js && node dist/dynamic-dispatch.js"
   },
   "dependencies": {
     "@provablehq/sdk": "^0.10.1"

--- a/create-leo-app/template-node-ts/rollup.config.js
+++ b/create-leo-app/template-node-ts/rollup.config.js
@@ -3,6 +3,7 @@ import typescript from "rollup-plugin-typescript2";
 export default {
     input: {
         index: "./src/index.ts",
+        "dynamic-dispatch": "./src/dynamic-dispatch.ts",
     },
     output: {
         dir: `dist`,

--- a/create-leo-app/template-node-ts/src/dynamic-dispatch.ts
+++ b/create-leo-app/template-node-ts/src/dynamic-dispatch.ts
@@ -1,0 +1,159 @@
+import {
+    Account,
+    DynamicRecord,
+    initThreadPool,
+    ProgramManager,
+    RecordPlaintext,
+} from "@provablehq/sdk/testnet.js";
+
+await initThreadPool();
+
+// --- Programs --- //
+
+const DD_CONSTANTS_PROGRAM = `program dd_constants.aleo;
+
+function get_value:
+    output 42u128 as u128.private;
+
+constructor:
+    assert.eq true true;
+`;
+
+const DD_CALLER_PROGRAM = `program dd_caller.aleo;
+
+function call_and_increment:
+    input r0 as field.public;
+    input r1 as field.public;
+    input r2 as field.public;
+    call.dynamic r0 r1 r2 into r3 (as u128.private);
+    add r3 1u128 into r4;
+    output r4 as u128.public;
+
+constructor:
+    assert.eq true true;
+`;
+
+// --- Setup --- //
+
+const programManager = new ProgramManager();
+const account = new Account();
+programManager.setAccount(account);
+
+// --- Test 1: Dynamic dispatch with plain string inputs --- //
+// The SDK's prepareInputs() should auto-convert bare strings to field elements
+// when the function signature expects `field` type. Users should NOT need to
+// call stringToField() manually.
+
+console.log("");
+console.log("// --- Dynamic dispatch: plain string inputs (auto-converted by SDK) --- //");
+
+const programInput = "dd_constants";
+const networkInput = "aleo";
+const functionInput = "get_value";
+
+console.log(`Inputs: program="${programInput}", network="${networkInput}", function="${functionInput}"`);
+
+const start = Date.now();
+const executionResponse = await programManager.run(
+    DD_CALLER_PROGRAM,
+    "call_and_increment",
+    [programInput, networkInput, functionInput],
+    true,
+    { "dd_constants.aleo": DD_CONSTANTS_PROGRAM },
+);
+const elapsed = Date.now() - start;
+
+const outputs = executionResponse.getOutputs();
+console.log(`Execution completed in ${elapsed / 1000}s — outputs: ${outputs}`);
+
+// dd_constants/get_value returns 42u128, caller adds 1 -> expect 43u128
+const expected = "43u128";
+if (outputs[0] !== expected) {
+    throw new Error(`Expected output ${expected}, got ${outputs[0]}`);
+}
+console.log("PASS: Plain strings auto-converted — users do NOT need stringToField()");
+
+// --- Test 2: Dynamic dispatch with dynamic.record input --- //
+// Tests whether a user can pass a RecordPlaintext string as input
+// to a program that expects `dynamic.record`.
+
+console.log("");
+console.log("// --- Dynamic dispatch: dynamic.record input (plaintext string) --- //");
+
+// A target program that accepts a dynamic.record and returns it.
+const DD_RECORD_READER_PROGRAM = `program dd_record_reader.aleo;
+
+function read_owner:
+    input r0 as dynamic.record;
+    output r0 as dynamic.record;
+
+constructor:
+    assert.eq true true;
+`;
+
+// A caller that dynamically dispatches to dd_record_reader/read_owner with a dynamic.record.
+// The first three field inputs will be auto-converted by prepareInputs().
+const DD_RECORD_CALLER_PROGRAM = `program dd_record_caller.aleo;
+
+function call_read_owner:
+    input r0 as field.public;
+    input r1 as field.public;
+    input r2 as field.public;
+    input r3 as dynamic.record;
+    call.dynamic r0 r1 r2 with r3 (as dynamic.record) into r4 (as dynamic.record);
+    output r4 as dynamic.record;
+
+constructor:
+    assert.eq true true;
+`;
+
+// Construct a credits record plaintext.
+const creditsRecord = `{ owner: ${account.address().toString()}.private, microcredits: 1000000u64.private, _nonce: 3634848344765318974603121890869676775499130077229666060613233255327643175219group.public, _version: 1u8.public }`;
+
+// Test 2a: Pass raw RecordPlaintext string with bare string field inputs (auto-converted).
+console.log("");
+console.log("Test 2a: Raw RecordPlaintext string + bare string field inputs...");
+const start2a = Date.now();
+const executionResponse2a = await programManager.run(
+    DD_RECORD_CALLER_PROGRAM,
+    "call_read_owner",
+    ["dd_record_reader", "aleo", "read_owner", creditsRecord],
+    true,
+    { "dd_record_reader.aleo": DD_RECORD_READER_PROGRAM },
+);
+const elapsed2a = Date.now() - start2a;
+const outputs2a = executionResponse2a.getOutputs();
+console.log(`Execution completed in ${elapsed2a / 1000}s — outputs: ${outputs2a}`);
+// Verify the output is a parseable dynamic record.
+const returnedRecord2a = DynamicRecord.fromString(outputs2a[0]);
+if (!returnedRecord2a.owner()) {
+    throw new Error("Test 2a: returned dynamic record has no owner");
+}
+console.log("PASS: Raw RecordPlaintext + bare strings accepted");
+
+// Test 2b: Pass DynamicRecord.fromRecord().toString() (explicit conversion still works).
+console.log("");
+console.log("Test 2b: DynamicRecord.fromRecord().toString() as dynamic.record input...");
+const recordPlaintext = RecordPlaintext.fromString(creditsRecord);
+const dynamicRecord = DynamicRecord.fromRecord(recordPlaintext);
+const dynamicRecordStr = dynamicRecord.toString();
+const start2b = Date.now();
+const executionResponse2b = await programManager.run(
+    DD_RECORD_CALLER_PROGRAM,
+    "call_read_owner",
+    ["dd_record_reader", "aleo", "read_owner", dynamicRecordStr],
+    true,
+    { "dd_record_reader.aleo": DD_RECORD_READER_PROGRAM },
+);
+const elapsed2b = Date.now() - start2b;
+const outputs2b = executionResponse2b.getOutputs();
+console.log(`Execution completed in ${elapsed2b / 1000}s — outputs: ${outputs2b}`);
+// Verify the output is a parseable dynamic record.
+const returnedRecord2b = DynamicRecord.fromString(outputs2b[0]);
+if (!returnedRecord2b.owner()) {
+    throw new Error("Test 2b: returned dynamic record has no owner");
+}
+console.log("PASS: DynamicRecord plaintext string accepted as input");
+
+console.log("");
+console.log("All dynamic dispatch tests passed!");

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -36,6 +36,7 @@ import {
     Proof,
     ProgramManager as WasmProgramManager,
     verifyFunctionExecution,
+    stringToField,
 } from "./wasm.js";
 
 import {
@@ -972,12 +973,15 @@ class ProgramManager {
             }
         }
 
+        // Auto-convert bare string inputs to field elements where the function expects field type.
+        const preparedInputs = this.prepareInputs(program, functionName, inputs);
+
         // Build an execution transaction
         return await WasmProgramManager.buildExecutionTransaction(
             executionPrivateKey,
             program,
             functionName,
-            inputs,
+            preparedInputs,
             priorityFee,
             feeRecord,
             this.host,
@@ -1263,12 +1267,15 @@ class ProgramManager {
             }
         }
 
+        // Auto-convert bare string inputs to field elements where the function expects field type.
+        const preparedInputs = this.prepareInputs(program, functionName, inputs);
+
         // Build and return an `Authorization` for the desired function.
         return await WasmProgramManager.authorize(
             executionPrivateKey,
             program,
             functionName,
-            inputs,
+            preparedInputs,
             imports,
             edition
         );
@@ -1373,12 +1380,15 @@ class ProgramManager {
             }
         }
 
+        // Auto-convert bare string inputs to field elements where the function expects field type.
+        const preparedInputs = this.prepareInputs(program, functionName, inputs);
+
         // Build and return an `Authorization` for the desired function.
         return await WasmProgramManager.buildAuthorizationUnchecked(
             executionPrivateKey,
             program,
             functionName,
-            inputs,
+            preparedInputs,
             imports,
             edition
         );
@@ -1543,12 +1553,15 @@ class ProgramManager {
                 throw new Error("No inputs provided to build a proving request");
             }
 
+            // Auto-convert bare string inputs to field elements where the function expects field type.
+            const preparedInputs = this.prepareInputs(program, functionName, inputs);
+
             // Build and return the `ProvingRequest`.
             return await WasmProgramManager.buildProvingRequest(
                 executionPrivateKey,
                 program,
                 functionName,
-                inputs,
+                preparedInputs,
                 baseFee,
                 priorityFee,
                 feeRecord,
@@ -1686,6 +1699,45 @@ class ProgramManager {
     }
 
     /**
+     * Prepares user-provided inputs for a function call by auto-converting bare
+     * string identifiers to field elements where the function signature expects
+     * a `field` type. This lets callers of dynamic-dispatch programs pass
+     * human-readable strings (e.g. `"my_program"`) instead of requiring
+     * `stringToField("my_program").toString()`.
+     *
+     * Inputs that already look like a field literal (ending in `"field"`) are
+     * left untouched. Non-field inputs are returned as-is. If introspection
+     * fails for any reason the original inputs are returned unchanged.
+     *
+     * @param {string} programSource - The program source code
+     * @param {string} functionName - The function to inspect
+     * @param {string[]} inputs - The raw user-provided inputs
+     * @returns {string[]} The (possibly converted) inputs
+     */
+    prepareInputs(
+        programSource: string,
+        functionName: string,
+        inputs: string[],
+    ): string[] {
+        try {
+            const programObj = Program.fromString(programSource);
+            const functionInputs = programObj.getFunctionInputs(functionName);
+            if (functionInputs.length !== inputs.length) {
+                return inputs;
+            }
+            return inputs.map((input, i) => {
+                const spec = functionInputs[i] as { type?: string };
+                if (spec?.type === "field" && !input.endsWith("field")) {
+                    return stringToField(input).toString();
+                }
+                return input;
+            });
+        } catch {
+            return inputs;
+        }
+    }
+
+    /**
      * Run an Aleo program in offline mode
      *
      * @param {string} program Program source code containing the function to be executed
@@ -1756,6 +1808,9 @@ class ProgramManager {
             }
         }
 
+        // Auto-convert bare string inputs to field elements where the function expects field type.
+        const preparedInputs = this.prepareInputs(program, function_name, inputs);
+
         // Run the program offline and return the result
         console.log("Running program offline");
         console.log("Proving key: ", provingKey);
@@ -1764,7 +1819,7 @@ class ProgramManager {
             executionPrivateKey,
             program,
             function_name,
-            inputs,
+            preparedInputs,
             proveExecution,
             false,
             imports,

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -1705,29 +1705,32 @@ class ProgramManager {
      * human-readable strings (e.g. `"my_program"`) instead of requiring
      * `stringToField("my_program").toString()`.
      *
-     * Inputs that already look like a field literal (ending in `"field"`) are
-     * left untouched. Non-field inputs are returned as-is. If introspection
-     * fails for any reason the original inputs are returned unchanged.
+     * Inputs that already look like a numeric field literal (matching
+     * `/^\d+field$/` after trimming whitespace) are left untouched. Non-field
+     * inputs are returned as-is. If introspection fails for any reason the
+     * original inputs are returned unchanged.
      *
-     * @param {string} programSource - The program source code
+     * @param {string | Program} programSource - The program source code or Program object
      * @param {string} functionName - The function to inspect
      * @param {string[]} inputs - The raw user-provided inputs
      * @returns {string[]} The (possibly converted) inputs
      */
     prepareInputs(
-        programSource: string,
+        programSource: string | Program,
         functionName: string,
         inputs: string[],
     ): string[] {
         try {
-            const programObj = Program.fromString(programSource);
+            const source = typeof programSource === "string" ? programSource : programSource.toString();
+            const programObj = Program.fromString(source);
             const functionInputs = programObj.getFunctionInputs(functionName);
             if (functionInputs.length !== inputs.length) {
                 return inputs;
             }
             return inputs.map((input, i) => {
                 const spec = functionInputs[i] as { type?: string };
-                if (spec?.type === "field" && !input.endsWith("field")) {
+                const isFieldLiteral = /^\d+field$/.test(input.trim());
+                if (spec?.type === "field" && !isFieldLiteral) {
                     return stringToField(input).toString();
                 }
                 return input;
@@ -2111,6 +2114,9 @@ class ProgramManager {
             }
         }
 
+        // Auto-convert bare string inputs to field elements where the function expects field type.
+        const preparedInputs = this.prepareInputs(program, function_id, inputs);
+
         // Attempt to run an offline execution of the program and extract the proving and verifying keys
         try {
             imports = await this.networkClient.getProgramImports(program);
@@ -2118,7 +2124,7 @@ class ProgramManager {
                 executionPrivateKey,
                 program,
                 function_id,
-                inputs,
+                preparedInputs,
                 imports,
             );
             return [
@@ -3544,12 +3550,15 @@ class ProgramManager {
             }
         }
         
+        // Auto-convert bare string inputs to field elements where the function expects field type.
+        const preparedInputs = this.prepareInputs(program, functionName, inputs);
+
         // Build a transaction without a proof
         return await WasmProgramManager.buildDevnodeExecutionTransaction(
             executionPrivateKey,
             program,
             functionName,
-            inputs,
+            preparedInputs,
             priorityFee,
             feeRecord,
             this.host,

--- a/sdk/tests/prepare-inputs.test.ts
+++ b/sdk/tests/prepare-inputs.test.ts
@@ -31,15 +31,43 @@ describe("ProgramManager.prepareInputs", () => {
         expect(result[2]).to.equal(stringToField("get_value").toString());
     });
 
-    it("should leave inputs that already end with 'field' untouched", () => {
+    it("should leave numeric field literals (e.g. '123field') untouched", () => {
         const manager = new ProgramManager();
-        const alreadyField = stringToField("dd_constants").toString();
+        const alreadyFieldLiteral = "123field";
         const result = manager.prepareInputs(DD_CALLER_PROGRAM, "call_and_increment", [
-            alreadyField,
+            alreadyFieldLiteral,
+            "456field",
+            "789field",
+        ]);
+        expect(result[0]).to.equal(alreadyFieldLiteral);
+        expect(result[1]).to.equal("456field");
+        expect(result[2]).to.equal("789field");
+    });
+
+    it("should convert identifiers ending with 'field' when a field is expected", () => {
+        const manager = new ProgramManager();
+        const result = manager.prepareInputs(DD_CALLER_PROGRAM, "call_and_increment", [
+            "battlefield",
+            "my_field",
+            "outfield",
+        ]);
+        // These are NOT numeric field literals — they must be converted
+        expect(result[0]).to.equal(stringToField("battlefield").toString());
+        expect(result[1]).to.equal(stringToField("my_field").toString());
+        expect(result[2]).to.equal(stringToField("outfield").toString());
+    });
+
+    it("should leave stringToField output untouched since it is a numeric field literal", () => {
+        const manager = new ProgramManager();
+        const encoded = stringToField("dd_constants").toString();
+        const result = manager.prepareInputs(DD_CALLER_PROGRAM, "call_and_increment", [
+            encoded,
             stringToField("aleo").toString(),
             stringToField("get_value").toString(),
         ]);
-        expect(result[0]).to.equal(alreadyField);
+        expect(result[0]).to.equal(encoded);
+        expect(result[1]).to.equal(stringToField("aleo").toString());
+        expect(result[2]).to.equal(stringToField("get_value").toString());
     });
 
     it("should not convert non-field inputs", () => {

--- a/sdk/tests/prepare-inputs.test.ts
+++ b/sdk/tests/prepare-inputs.test.ts
@@ -1,0 +1,79 @@
+import { expect } from "chai";
+import {
+    ProgramManager,
+    stringToField,
+} from "@provablehq/sdk/%%NETWORK%%.js";
+
+const DD_CALLER_PROGRAM = `program dd_caller.aleo;
+
+function call_and_increment:
+    input r0 as field.public;
+    input r1 as field.public;
+    input r2 as field.public;
+    call.dynamic r0 r1 r2 into r3 (as u128.private);
+    add r3 1u128 into r4;
+    output r4 as u128.public;
+
+constructor:
+    assert.eq true true;
+`;
+
+describe("ProgramManager.prepareInputs", () => {
+    it("should convert bare strings to field elements for field-typed inputs", () => {
+        const manager = new ProgramManager();
+        const result = manager.prepareInputs(DD_CALLER_PROGRAM, "call_and_increment", [
+            "dd_constants",
+            "aleo",
+            "get_value",
+        ]);
+        expect(result[0]).to.equal(stringToField("dd_constants").toString());
+        expect(result[1]).to.equal(stringToField("aleo").toString());
+        expect(result[2]).to.equal(stringToField("get_value").toString());
+    });
+
+    it("should leave inputs that already end with 'field' untouched", () => {
+        const manager = new ProgramManager();
+        const alreadyField = stringToField("dd_constants").toString();
+        const result = manager.prepareInputs(DD_CALLER_PROGRAM, "call_and_increment", [
+            alreadyField,
+            stringToField("aleo").toString(),
+            stringToField("get_value").toString(),
+        ]);
+        expect(result[0]).to.equal(alreadyField);
+    });
+
+    it("should not convert non-field inputs", () => {
+        const program = `program test_non_field.aleo;\n\nfunction add:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n`;
+        const manager = new ProgramManager();
+        const result = manager.prepareInputs(program, "add", ["5u32", "10u32"]);
+        expect(result[0]).to.equal("5u32");
+        expect(result[1]).to.equal("10u32");
+    });
+
+    it("should return original inputs when input count mismatches", () => {
+        const manager = new ProgramManager();
+        const result = manager.prepareInputs(DD_CALLER_PROGRAM, "call_and_increment", [
+            "dd_constants",
+            "aleo",
+        ]);
+        expect(result[0]).to.equal("dd_constants");
+        expect(result[1]).to.equal("aleo");
+        expect(result.length).to.equal(2);
+    });
+
+    it("should return original inputs for invalid program source", () => {
+        const manager = new ProgramManager();
+        const inputs = ["a", "b", "c"];
+        const result = manager.prepareInputs("not a valid program", "foo", inputs);
+        expect(result).to.deep.equal(inputs);
+    });
+
+    it("should handle mixed field and non-field inputs", () => {
+        const program = `program mixed.aleo;\n\nfunction mix:\n    input r0 as field.public;\n    input r1 as u64.private;\n    input r2 as field.private;\n    output r0 as field.public;\n`;
+        const manager = new ProgramManager();
+        const result = manager.prepareInputs(program, "mix", ["hello", "42u64", "world"]);
+        expect(result[0]).to.equal(stringToField("hello").toString());
+        expect(result[1]).to.equal("42u64");
+        expect(result[2]).to.equal(stringToField("world").toString());
+    });
+});


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Dynamic dispatch programs expect field encoded identifiers (program name, network, function name) as inputs. Currently, users must manually call `stringToField("my_program").toString()` for each field input, a non obvious requirement that produces a cryptic `snarkVM` error (`Failed to parse input #0 ('field.public')`) when missed. `prepareInputs` introspects the function signature and auto converts bare strings to field elements making dynamic dispatch work naturally with human readable inputs like `my_program`, `aleo`, `my_function`

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

- 6 unit tests for `prepareInputs` covering: bare string conversion, already-encoded passthrough, non-field types untouched, input count mismatch, invalid program graceful fallback, mixed field/non-field inputs
- E2e node template (`dynamic-dispatch.ts`) exercises real VM execution with 3 test cases:
    - Bare string field inputs auto-converted, output verified as `43u128`
    - Raw RecordPlaintext string accepted for dynamic.record input, output verified as parseable `DynamicRecord`
    - Explicit `DynamicRecord.fromRecord().toString()` still works (backward compat)
- CI updated to run yarn test for `template-node-ts`, which includes the dynamic dispatch e2e tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `ProgramManager` transaction/authorization builders by altering how inputs are preprocessed, so unexpected conversions could affect existing callers relying on raw string semantics. Guardrails (field-literal detection, signature length check, try/catch fallback) reduce but don’t eliminate behavior-change risk.
> 
> **Overview**
> Adds `ProgramManager.prepareInputs` to **introspect a function’s input types** and automatically convert non-literal strings into `field` values (via `stringToField`) when the signature expects `field`.
> 
> Wires this preprocessing into multiple execution/authorization flows (execution tx build, `authorize`, unchecked authorization, proving request build, offline `run`, key synthesis, and devnode execution), so dynamic-dispatch callers can pass human-readable identifiers directly.
> 
> Extends the `create-leo-app` `node-ts` template with a new `dynamic-dispatch` example and runs it in CI (`yarn test`), and adds unit tests covering conversion/passthrough and fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9adca1b2cc4fce32813caf28cfc8949cee979bd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->