### PR TITLE
[Bug] Fix Vite config file for React TS

### DIFF
--- a/create-leo-app/template-react-credits-aleo-functions-ts/vite.config.ts
+++ b/create-leo-app/template-react-credits-aleo-functions-ts/vite.config.ts
@@ -1,17 +1,31 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// https://vitejs.dev/config/
 export default defineConfig({
-    assetsInclude: ["**/*.wasm"],
-    plugins: [react()],
-    optimizeDeps: {
-        exclude: ["@provablehq/wasm"],
+  assetsInclude: ["**/*.wasm"],
+  plugins: [react()],
+
+  build: {
+    target: "esnext",
+  },
+
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
     },
-    server: {
-        headers: {
-            "Cross-Origin-Opener-Policy": "same-origin",
-            "Cross-Origin-Embedder-Policy": "require-corp",
-        },
+    exclude: [
+      "@provablehq/wasm",
+      "@provablehq/wasm-account-tools",
+    ],
+  },
+
+  server: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
     },
+  },
+  worker: {
+    format: "es",
+  },
 });

--- a/create-leo-app/template-react-leo/vite.config.js
+++ b/create-leo-app/template-react-leo/vite.config.js
@@ -1,17 +1,31 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// https://vitejs.dev/config/
 export default defineConfig({
+  assetsInclude: ["**/*.wasm"],
   plugins: [react()],
-  assetsInclude: ['**/*.wasm'],
-  optimizeDeps: {
-    exclude: ["@provablehq/wasm"],
+
+  build: {
+    target: "esnext",
   },
+
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
+    },
+    exclude: [
+      "@provablehq/wasm",
+      "@provablehq/wasm-account-tools",
+    ],
+  },
+
   server: {
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Embedder-Policy": "require-corp",
     },
+  },
+  worker: {
+    format: "es",
   },
 });

--- a/create-leo-app/template-react-loyalty-program-ts/vite.config.ts
+++ b/create-leo-app/template-react-loyalty-program-ts/vite.config.ts
@@ -1,17 +1,31 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  assetsInclude: ['**/*.wasm'],
+  assetsInclude: ["**/*.wasm"],
   plugins: [react()],
-  optimizeDeps: {
-    exclude: ["@provablehq/wasm"],
+
+  build: {
+    target: "esnext",
   },
+
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
+    },
+    exclude: [
+      "@provablehq/wasm",
+      "@provablehq/wasm-account-tools",
+    ],
+  },
+
   server: {
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Embedder-Policy": "require-corp",
     },
+  },
+  worker: {
+    format: "es",
   },
 });

--- a/create-leo-app/template-react-managed-worker/vite.config.js
+++ b/create-leo-app/template-react-managed-worker/vite.config.js
@@ -1,21 +1,31 @@
-import { defineConfig, searchForWorkspaceRoot } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  assetsInclude: ['**/*.wasm'],
+  assetsInclude: ["**/*.wasm"],
   plugins: [react()],
-  optimizeDeps: {
-    exclude: ["@provablehq/wasm"],
+
+  build: {
+    target: "esnext",
   },
-  server: {
-    // Needed if you are linking local packages for development
-    fs: {
-      allow: [searchForWorkspaceRoot(process.cwd()), "../../sdk"],
+
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
     },
+    exclude: [
+      "@provablehq/wasm",
+      "@provablehq/wasm-account-tools",
+    ],
+  },
+
+  server: {
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Embedder-Policy": "require-corp",
     },
+  },
+  worker: {
+    format: "es",
   },
 });

--- a/create-leo-app/template-react-ts/vite.config.ts
+++ b/create-leo-app/template-react-ts/vite.config.ts
@@ -1,13 +1,24 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  assetsInclude: ['**/*.wasm'],
+  assetsInclude: ["**/*.wasm"],
   plugins: [react()],
-  optimizeDeps: {
-    exclude: ["@provablehq/wasm"],
+
+  build: {
+    target: "esnext",
   },
+
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
+    },
+    exclude: [
+      "@provablehq/wasm",
+      "@provablehq/wasm-account-tools",
+    ],
+  },
+
   server: {
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",

--- a/create-leo-app/template-react-ts/vite.config.ts
+++ b/create-leo-app/template-react-ts/vite.config.ts
@@ -25,4 +25,7 @@ export default defineConfig({
       "Cross-Origin-Embedder-Policy": "require-corp",
     },
   },
+  worker: {
+    format: "es",
+  },
 });


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Currently, if users attempt to use the React TS template, they will encounter the following error relating to the `vite.config.ts` file:
```bash
✘ [ERROR] Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)

    node_modules/@provablehq/sdk/dist/testnet/browser.js:7:0:
      7 │ await sodium.ready;
        ╵ ~~~~~

12:05:48 PM [vite] (client) error while updating dependencies:
Error: Build failed with 1 error:
node_modules/@provablehq/sdk/dist/testnet/browser.js:7:0: ERROR: Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
    at failureErrorWithLog (/Users/.../node_modules/esbuild/lib/main.js:1467:15)
    at /Users/.../node_modules/esbuild/lib/main.js:926:25
    at /Users/.../node_modules/esbuild/lib/main.js:1345:9
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

This PR updates the vite config file.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Build the React TS template from the mainnet branch of the SDK:
```bash
npm create leo-app@latest
npm install
npm run dev
```
Confirm the above errors.