### PR TITLE
RecordScanner: fix JWT refresh endpoint

### DIFF
--- a/sdk/src/record-scanner.ts
+++ b/sdk/src/record-scanner.ts
@@ -274,11 +274,11 @@ class RecordScanner implements RecordProvider {
      */
     private async refreshJwt(apiKey: string, consumerId: string): Promise<RecordScannerJWTData> {
         const response = await post(
-            `${this.url}/jwts/${consumerId}`,
+            `https://api.provable.com/jwts/${consumerId}`,
             {
                 headers: {
-                    "X-Provable-API-Key": apiKey,
-                },
+                    'X-Provable-API-Key': apiKey
+                }
             }
         );
         const authHeader = response.headers.get("authorization");


### PR DESCRIPTION
Fixes #1247.

## Motivation

`RecordScanner.refreshJwt` currently posts to the wrong JWT endpoint (`/scanner/:network/jwts/:consumerId`), which returns 401 and prevents authentication. This PR updates the request URL to the correct JWT endpoint.

## Test Plan

- Instantiate `RecordScanner` with an API key and consumer ID.
- Call `refreshJwt` (or trigger the auth flow) and verify the request goes to `https://api.provable.com/jwts/:consumerId`.
- Confirm the response includes the `authorization` header and subsequent RecordScanner operations succeed.

## Related PRs

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to the JWT refresh URL and request header formatting, affecting only the authentication refresh flow.
> 
> **Overview**
> Fixes `RecordScanner.refreshJwt` to POST to the correct Provable JWT endpoint (`https://api.provable.com/jwts/:consumerId`) instead of deriving it from the configured scanner base URL, preventing 404s during auth.
> 
> Also normalizes the API key header literal formatting in that request.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58f9a7b321dab6434c2720c2a3d77c2f1236ee47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->