### PR TITLE
[Fix] Refactor JWT refresh logic to use local variables

### DIFF
--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1825,7 +1825,7 @@ class AleoNetworkClient {
         // Check to see if the JWT needs refreshing.
         const isExpired = jwtData && Date.now() >= jwtData.expiration - FIVE_MINUTES;
         if (!jwtData || isExpired) {
-            if (options.apiKey && options.consumerId) {
+            if (apiKey && consumerId) {
                 jwtData = await this.refreshJwt(apiKey!, consumerId!);
                 this.jwtData = jwtData;
                 options.jwtData = jwtData;


### PR DESCRIPTION
This fixes a small bug in the SDK which doesn't correctly refresh the JWT if the API key and Consumer ID are set in the network client itself.