### PR TITLE
[Fix] JWT refresh URL in RecordScanner and AleoNetworkClient

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -12,6 +12,8 @@ env:
   PUZZLE_PK: ${{ secrets.PUZZLE_PK }}
   PUZZLE_VK: ${{ secrets.PUZZLE_VK }}
   RECORD_SCANNER_URL: ${{ secrets.RECORD_SCANNER_URL }}
+  KONG_API_KEY: ${{ secrets.ALEO_DPS_API_KEY }}
+  CONSUMER_ID: ${{ secrets.ALEO_CONSUMER_ID }}
 
 
 jobs:

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -80,6 +80,7 @@ interface DelegatedProvingParams {
  */
 class AleoNetworkClient {
     host: string;
+    private readonly baseUrl: string;
     headers: { [key: string]: string };
     account: Account | undefined;
     ctx: { [key: string]: string };
@@ -92,6 +93,9 @@ class AleoNetworkClient {
     recordScannerUri?: string;
 
     constructor(host: string, options?: AleoNetworkClientOptions) {
+        // baseUrl is the API root (origin only) — used for JWT refresh which
+        // lives at /jwts/{consumerId} on the API root, not under the versioned path.
+        this.baseUrl = new URL(host).origin;
         this.host = host + "/%%NETWORK%%";
         this.network = "%%NETWORK%%";
         this.ctx = {};
@@ -1727,7 +1731,7 @@ class AleoNetworkClient {
             throw new Error('API key and consumer ID are required to refresh JWT');
         }
         const response = await post(
-            `https://api.provable.com/jwts/${consumerId}`,
+            `${this.baseUrl}/jwts/${consumerId}`,
             {
                 headers: {
                     'X-Provable-API-Key': apiKey

--- a/sdk/src/record-scanner.ts
+++ b/sdk/src/record-scanner.ts
@@ -111,6 +111,7 @@ export interface RecordScannerOptions {
 class RecordScanner implements RecordProvider {
     readonly cacheViewKeysOnRegister?: boolean;
     readonly url: string;
+    private readonly baseUrl: string;
     private apiKey?: { header: string, value: string };
     private consumerId?: string;
     private jwtData?: RecordScannerJWTData;
@@ -133,6 +134,9 @@ class RecordScanner implements RecordProvider {
         }
 
         // Configure the url to use the network the SDK is using.
+        // baseUrl is the API root (origin only) — used for JWT refresh which
+        // lives at /jwts/{consumerId} on the API root, not under /scanner.
+        this.baseUrl = new URL(options.url).origin;
         this.url = options.url + network;
 
         // Get any view keys passed in the options.
@@ -274,7 +278,7 @@ class RecordScanner implements RecordProvider {
      */
     private async refreshJwt(apiKey: string, consumerId: string): Promise<RecordScannerJWTData> {
         const response = await post(
-            `${this.url}/jwts/${consumerId}`,
+            `${this.baseUrl}/jwts/${consumerId}`,
             {
                 headers: {
                     "X-Provable-API-Key": apiKey,

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -771,3 +771,47 @@ describe("NodeConnection", () => {
         });
     });
 });
+
+describe("AleoNetworkClient JWT refresh URL", () => {
+    let fetchStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        fetchStub = sinon.stub(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    const jwtEdgeCases = [
+        { label: "standard Provable API", host: "https://api.provable.com/v2", expectedOrigin: "https://api.provable.com" },
+        { label: "custom host with path", host: "https://custom-api.example.com/v2", expectedOrigin: "https://custom-api.example.com" },
+        { label: "host with deep path", host: "https://api.example.com/v2/extra", expectedOrigin: "https://api.example.com" },
+        { label: "host with port", host: "https://custom-api.example.com:8080/v2", expectedOrigin: "https://custom-api.example.com:8080" },
+        { label: "host with trailing slash", host: "https://api.provable.com/v2/", expectedOrigin: "https://api.provable.com" },
+        { label: "localhost with port", host: "http://localhost:3030", expectedOrigin: "http://localhost:3030" },
+    ];
+
+    jwtEdgeCases.forEach(({ label, host, expectedOrigin }) => {
+        it(`should derive JWT refresh origin from ${label}`, async () => {
+            const client = new AleoNetworkClient(host);
+            client.apiKey = "test-api-key";
+            client.consumerId = "test-consumer-id";
+
+            fetchStub.resolves({
+                ok: true,
+                status: 200,
+                headers: new Headers({ authorization: "Bearer test-jwt-token" }),
+                json: () => Promise.resolve({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+                text: () => Promise.resolve(JSON.stringify({ status: "ok" })),
+            });
+
+            try {
+                await client.submitProvingRequestSafe({ provingRequest: "test-request" });
+            } catch { }
+
+            const firstCallUrl = fetchStub.firstCall.args[0]?.toString() ?? fetchStub.firstCall.args[0]?.url;
+            expect(firstCallUrl).to.equal(`${expectedOrigin}/jwts/test-consumer-id`);
+        });
+    });
+});

--- a/sdk/tests/record-scanner.test.ts
+++ b/sdk/tests/record-scanner.test.ts
@@ -557,6 +557,42 @@ describe("RecordScanner", () => {
         });
 
     });
+
+    describe("JWT refresh URL", () => {
+        const jwtEdgeCases = [
+            { label: "standard scanner URL", url: "https://record-scanner.aleo.org", expectedOrigin: "https://record-scanner.aleo.org" },
+            { label: "Provable API with /scanner path", url: "https://api.provable.com/scanner", expectedOrigin: "https://api.provable.com" },
+            { label: "URL with deep path", url: "https://api.example.com/v2/extra", expectedOrigin: "https://api.example.com" },
+            { label: "URL with port", url: "https://custom-api.example.com:8080/scanner", expectedOrigin: "https://custom-api.example.com:8080" },
+            { label: "URL with trailing slash", url: "https://api.provable.com/scanner/", expectedOrigin: "https://api.provable.com" },
+            { label: "localhost with port", url: "http://localhost:3030", expectedOrigin: "http://localhost:3030" },
+        ];
+
+        jwtEdgeCases.forEach(({ label, url, expectedOrigin }) => {
+            it(`should derive JWT refresh origin from ${label}`, async () => {
+                recordScanner = new RecordScanner({
+                    url,
+                    apiKey: "test-api-key",
+                    consumerId: "test-consumer-id",
+                });
+
+                fetchStub.resolves({
+                    ok: true,
+                    status: 200,
+                    headers: new Headers({ authorization: "Bearer test-jwt-token" }),
+                    json: () => Promise.resolve({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+                    text: () => Promise.resolve(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 })),
+                });
+
+                try {
+                    await recordScanner.status("7884164224800444110633570141944665301008802280502652120359195870264061098703field");
+                } catch { }
+
+                const firstCallUrl = fetchStub.firstCall.args[0]?.toString() ?? fetchStub.firstCall.args[0]?.url;
+                expect(firstCallUrl).to.equal(`${expectedOrigin}/jwts/test-consumer-id`);
+            });
+        });
+    });
 });
 
 describe("Record scanner encrypted registration", function () {
@@ -647,6 +683,32 @@ describe("RecordScanner (real API)", function () {
     const accountFromEnv = process.env.PUZZLE_PK
         ? new Account({ privateKey: process.env.PUZZLE_PK as string })
         : null;
+
+    // Ensure the view key is registered before running tests that depend on it.
+    // This is needed because the test account may not be pre-registered on every network.
+    let registeredUuid: string | null = null;
+    before(async function () {
+        if (!hasRealApiEnv || !viewKey) return;
+        const scanner = new RecordScanner({
+            url: sandboxUrl,
+            ...(apiKey && { apiKey }),
+            ...(consumerId && { consumerId }),
+        });
+        const result = await scanner.register(viewKey, 0);
+        if (result.ok) {
+            registeredUuid = result.data.uuid;
+        }
+    });
+
+    after(async function () {
+        if (!registeredUuid) return;
+        const scanner = new RecordScanner({
+            url: sandboxUrl,
+            ...(apiKey && { apiKey }),
+            ...(consumerId && { consumerId }),
+        });
+        await scanner.revoke(registeredUuid);
+    });
 
     describe("utility methods", function () {
         it("computeUUID returns the same value for the same view key", function () {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

`RecordScanner.refreshJwt()` appended `/jwts/{consumerId}` to `this.url`, which already included the scanner path (e.g. `https://api.provable.com/scanner/testnet`), sending JWT refresh requests to the wrong endpoint. `AleoNetworkClient.refreshJwt()` had a similar issue and since it hardcoded `https://api.provable.com/jwts/` instead of deriving from the user-configured host, breaking self-hosted and staging environments.

Both are fixed by extracting `baseUrl = new URL(host).origin` at construction time and using it for JWT refresh.

Additionally, CI was missing the KONG_API_KEY, CONSUMER_ID, and RECORD_SCANNER_URL env vars needed for the record scanner integration tests to authenticate, and the real API tests now register the view key in a before hook so they pass on both testnet and mainnet builds.

Fixes #1247

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

- Added unit test for RecordScanner: verifies JWT refresh hits `{origin}/jwts/{consumerId}`, not `{origin}/scanner/{network}/jwts/{consumerId}`
- Added unit test for AleoNetworkClient: verifies JWT refresh derives URL from the configured host, not from a hardcoded `api.provable.com`
- [x] Both tests pass
## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/ProvableHQ/sdk,
    and link to your PR here.
-->

#1248 