### PR TITLE
[Fix] Replace .unwrap() panics with descriptive errors in ExecutionRequest (#1220)

### DIFF
--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Address, AleoNetworkClient, CREDITS_PROGRAM_KEYS, DynamicRecord, Field, FunctionKeyPair, Plaintext, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext, EncryptionToolkit, Transition, Value, VerifyingKey, AleoKeyProvider, getOrInitConsensusVersionTestHeights} from "../src/node.js";
+import { Address, AleoNetworkClient, CREDITS_PROGRAM_KEYS, DynamicRecord, ExecutionRequest, Field, FunctionKeyPair, Plaintext, PrivateKey, ViewKey, Signature, RecordCiphertext, RecordPlaintext, PrivateKeyCiphertext, EncryptionToolkit, Transition, Value, VerifyingKey, AleoKeyProvider, getOrInitConsensusVersionTestHeights} from "../src/node.js";
 import {
     seed,
     message,
@@ -749,3 +749,64 @@ describe('WASM Objects', () => {
     })
 });
 
+describe('ExecutionRequest error handling', () => {
+    it('Should throw a descriptive error for structurally invalid requests', () => {
+        const invalidRequest = JSON.stringify({
+            signer: "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px",
+            network: "1u16",
+            program: "credits.aleo",
+            function: "transfer_public",
+            input_ids: [{ type: "public", id: "0field" }],
+            inputs: ["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px", "100u64"],
+            signature: "sign1invalid",
+            sk_tag: "0field",
+            tvk: "0field",
+            tcm: "0field",
+            scm: "0field",
+        });
+
+        let threw = false;
+        try {
+            ExecutionRequest.fromString(invalidRequest);
+        } catch (e) {
+            threw = true;
+            expect(e).to.not.be.instanceOf(WebAssembly.RuntimeError);
+        }
+        expect(threw, "Expected fromString to throw for invalid request").to.be.true;
+    });
+
+    it('Should throw a descriptive error for completely invalid strings', () => {
+        let threw = false;
+        try {
+            ExecutionRequest.fromString("not a valid request at all");
+        } catch (e) {
+            threw = true;
+            expect(e).to.not.be.instanceOf(WebAssembly.RuntimeError);
+        }
+        expect(threw, "Expected fromString to throw for invalid string").to.be.true;
+    });
+
+    it('Should throw a descriptive error when sign() receives invalid inputs', () => {
+        const privateKey = PrivateKey.from_string(
+            "APrivateKey1zkp7Vc4xJt8HqW9U7VhY6h32d8Z9Xi5C6ZZX3gtXxbBSJmj"
+        );
+
+        try {
+            ExecutionRequest.sign(
+                privateKey,
+                "credits.aleo",
+                "nonexistent_function",
+                ["invalid_input"],
+                ["invalid_type"],
+                undefined,
+                undefined,
+                true,
+            );
+            expect.fail("Should have thrown an error");
+        } catch (e) {
+            const msg = `${e}`;
+            expect(e).to.not.be.instanceOf(WebAssembly.RuntimeError);
+            expect(msg).to.include("Failed to deserialize input");
+        }
+    });
+});

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -250,20 +250,28 @@ impl ExecutionRequest {
         // Ensure the inputs are valid Aleo types.
         let inputs = inputs
             .iter()
-            .map(|input| ValueNative::from_str(&input.as_string().unwrap()).unwrap())
-            .collect::<Vec<ValueNative>>();
+            .enumerate()
+            .map(|(i, input)| {
+                let s = input.as_string().ok_or_else(|| format!("Input {i} is not a string"))?;
+                ValueNative::from_str(&s).map_err(|e| format!("Failed to deserialize input {i} as value '{s}' - please check the input at position {i} and try again: {e}"))
+            })
+            .collect::<Result<Vec<ValueNative>, String>>()?;
 
         // Ensure the input types specified match the types of the specified inputs.
         let input_types = input_types
             .iter()
-            .map(|input_type| ValueTypeNative::from_str(&input_type.as_string().unwrap()).unwrap())
-            .collect::<Vec<ValueTypeNative>>();
+            .enumerate()
+            .map(|(i, input_type)| {
+                let s = input_type.as_string().ok_or_else(|| format!("Input type {i} is not a string"))?;
+                ValueTypeNative::from_str(&s).map_err(|e| format!("Failed to deserialize input {i} as input type '{s}' - please check the input at position {i} and try again: {e}"))
+            })
+            .collect::<Result<Vec<ValueTypeNative>, String>>()?;
 
         // Get the root tvk if it was specified.
         let root_tvk = root_tvk.map(FieldNative::from);
         let program_checksum = program_checksum.map(FieldNative::from);
 
-        // Generate an RNG for the function fro system entropy.
+        // Generate an RNG for the function from system entropy.
         let mut rng = StdRng::from_entropy();
 
         // Generate the signature over the (program_id, function, input, and private_key) tuple.
@@ -543,14 +551,18 @@ impl ExecutionRequest {
     /// @param {string[]} input_types The input types within the request.
     /// @param {boolean} is_root Flag to indicate whether this request is the first function in the call graph.
     /// @param {Field | undefined} program_checksum The checksum of the program. This is undefined if the call is not dynamic.
-    pub fn verify(&self, input_types: Array, is_root: bool, program_checksum: Option<Field>) -> bool {
+    pub fn verify(&self, input_types: Array, is_root: bool, program_checksum: Option<Field>) -> Result<bool, String> {
         let input_types = input_types
             .iter()
-            .map(|input_type| ValueTypeNative::from_str(&input_type.as_string().unwrap()).unwrap())
-            .collect::<Vec<ValueTypeNative>>();
+            .enumerate()
+            .map(|(i, input_type)| {
+                let s = input_type.as_string().ok_or_else(|| format!("Input type {i} is not a string"))?;
+                ValueTypeNative::from_str(&s).map_err(|e| format!("Failed to deserialize input {i} as input type '{s}' - please check the input at position {i} and try again: {e}"))
+            })
+            .collect::<Result<Vec<ValueTypeNative>, String>>()?;
 
         let program_checksum = program_checksum.map(FieldNative::from);
-        self.0.verify(&input_types, is_root, program_checksum)
+        Ok(self.0.verify(&input_types, is_root, program_checksum))
     }
 
     /// Computes the function ID and serialized input data for a program function call.
@@ -895,12 +907,16 @@ impl ExecutionRequest {
                         ValueNative::Record(record) => record,
                         _ => return Err("Expected a record input for record type".to_string()),
                     };
-                    let record_view_key = record_view_keys.pop().unwrap();
+                    let record_view_key = record_view_keys
+                        .pop()
+                        .ok_or_else(|| "Insufficient record view keys for the number of record inputs".to_string())?;
                     let commitment = record_input
                         .to_commitment(program_id, record_name, &record_view_key)
                         .map_err(|e| e.to_string())?;
 
-                    let gamma = gammas_native.pop().unwrap();
+                    let gamma = gammas_native
+                        .pop()
+                        .ok_or_else(|| "Insufficient gammas for the number of record inputs".to_string())?;
                     let serial_number = RecordPlaintextNative::serial_number_from_gamma(&gamma, commitment)
                         .map_err(|e| e.to_string())?;
                     let tag = RecordPlaintextNative::tag(**sk_tag, commitment).map_err(|e| e.to_string())?;
@@ -1148,7 +1164,7 @@ mod tests {
         )
         .expect("sign should succeed");
 
-        let valid = request.verify(input_types, true, None);
+        let valid = request.verify(input_types, true, None).expect("verify should not return an error");
         assert!(valid, "verify should pass for matching input types and is_root");
     }
 


### PR DESCRIPTION
## Motivation

WASM panics in `ExecutionRequest` methods surface as inscrutable `RuntimeError: unreachable` errors with no context (see #1220). The root cause: several methods in `request.rs` used `.unwrap()` on user input parsing, which panics on invalid input instead of returning a descriptive error.

This PR replaces all `.unwrap()` calls on user input in `ExecutionRequest` with proper `Result` error propagation:

- **`sign()`**: Input and input type parsing now return indexed, contextual errors (e.g., `"Invalid input 2 'foo': Failed to parse string..."`)
- **`verify()`**: Same treatment for input type parsing; return type changed from `bool` to `Result<bool, String>`
- **`compute_input_ids_with_record_view_keys()`**: `.pop().unwrap()` on record view keys and gammas replaced with `.ok_or_else()` descriptive messages

## Test Plan

- 3 new tests in `wasm.test.ts` verify that `ExecutionRequest` methods reject invalid inputs:
  - Structurally invalid request JSON
  - Completely invalid string input
  - `sign()` with invalid inputs — asserts error contains `"Invalid input"` from the Rust error path
- Full regression: existing WASM test suite passes with no new failures

```bash
yarn build:all
cd sdk && yarn test
```

Closes #1220

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because the WASM API for `ExecutionRequest.verify` changes from `bool` to `Result<bool, String>` and error paths now return early instead of panicking, which may require downstream caller updates.
> 
> **Overview**
> **WASM `ExecutionRequest` now returns descriptive errors instead of panicking** on invalid user-provided inputs.
> 
> `ExecutionRequest.sign` and `ExecutionRequest.verify` replace several `.unwrap()`s with indexed parsing/typing validation that returns `Result<_, String>` messages (and `verify`’s return type changes from `bool` to `Result<bool, String>`). Record-input ID computation also replaces `.pop().unwrap()` on record view keys/gammas with explicit “insufficient …” errors.
> 
> Adds SDK WASM tests asserting invalid request strings/JSON and invalid `sign()` inputs throw non-`WebAssembly.RuntimeError` exceptions and include the new Rust-side error text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ed20ca9a189f9202c0e43f53c49312877c74c8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->