### PR TITLE
[Feature] Add debug build commands for faster WASM development (#1257)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "build:sdk-docs": "sh scripts/jsdoc.sh",
     "build:create-leo-app": "cd create-leo-app && yarn build",
     "build:all": "yarn build:wasm && yarn build:sdk && yarn build:create-leo-app",
+    "build:wasm-debug": "cd wasm && BUILD_DEBUG=1 yarn build",
+    "build:all-debug": "yarn build:wasm-debug && yarn build:sdk && yarn build:create-leo-app",
     "start:website": "cd website && yarn dev",
     "test:wasm": "cd wasm && yarn test",
     "test:sdk": "cd sdk && yarn test",

--- a/wasm/build.js
+++ b/wasm/build.js
@@ -16,6 +16,8 @@ async function buildRollup(input, output) {
     }
 }
 
+const isDebugBuild = process.env.BUILD_DEBUG === "1";
+
 async function buildWasm(network) {
     await buildRollup({
         input: {
@@ -34,6 +36,7 @@ async function buildWasm(network) {
                     ],
                     wasmOpt: ["-O", "--enable-threads", "--enable-bulk-memory", "--enable-bulk-memory-opt", "--enable-nontrapping-float-to-int"],
                 },
+                optimize: isDebugBuild ? { release: false, wasmOpt: false, rustc: false } : undefined,
 
                 experimental: {
                     atomics: true,


### PR DESCRIPTION
## Motivation

The WASM build takes 3+ minutes with full release optimization, which slows down local development iteration. This PR adds `build:wasm-debug` and `build:all-debug` commands that skip release optimizations, wasm-opt, and rustc optimizations and reducing build time from ~3 minutes to ~19 seconds.

Addresses #1257.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds optional debug build scripts and a `BUILD_DEBUG` flag that disables WASM optimizations, without changing default release builds.
> 
> **Overview**
> Adds `build:wasm-debug` and `build:all-debug` scripts to speed up local development by running the WASM build with `BUILD_DEBUG=1`.
> 
> Updates `wasm/build.js` to detect `BUILD_DEBUG` and, when set, disable release/`wasm-opt`/`rustc` optimizations via the rollup Rust plugin while leaving the default build behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ced87d4017c1a42bf49897de6467fbac53f042e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->