### PR TITLE
[Feature] Add lossy cross-cast WASM bindings for scalar, integer, boolean, field, and group types

### DIFF
--- a/sdk/tests/cast-lossy.test.ts
+++ b/sdk/tests/cast-lossy.test.ts
@@ -1,0 +1,219 @@
+import { expect } from "chai";
+import {
+    Address,
+    Field,
+    Scalar,
+    Group,
+    Boolean,
+    I8, I16, I32, I64, I128,
+    U8, U16, U32, U64, U128,
+} from "../src/node.js";
+
+describe('cast_lossy type conversions', () => {
+
+    describe('Field conversions', () => {
+        it('Field.toScalar() round-trips for small values', () => {
+            const scalar = Scalar.fromString("42scalar");
+            const field = scalar.toField();
+            const back = field.toScalar();
+            expect(back.toString()).to.equal(scalar.toString());
+        });
+
+        it('Field.toBoolean() extracts LSB', () => {
+            expect(Field.fromString("0field").toBoolean().toString()).to.equal("false");
+            expect(Field.fromString("1field").toBoolean().toString()).to.equal("true");
+            expect(Field.fromString("2field").toBoolean().toString()).to.equal("false");
+            expect(Field.fromString("3field").toBoolean().toString()).to.equal("true");
+        });
+
+        it('Field.toGroup() never throws', () => {
+            expect(() => Field.fromString("0field").toGroup()).to.not.throw();
+            expect(() => Field.fromString("1field").toGroup()).to.not.throw();
+            expect(() => Field.fromString("12345field").toGroup()).to.not.throw();
+        });
+
+        it('Field.toAddress() produces valid address', () => {
+            const addr = Field.fromString("42field").toAddress();
+            expect(addr.toString()).to.match(/^aleo1/);
+        });
+
+        it('Field.toU32() preserves small values', () => {
+            expect(Field.fromString("255field").toU32().toString()).to.equal("255u32");
+        });
+
+        it('Field.toU8() truncates large values', () => {
+            expect(Field.fromString("256field").toU8().toString()).to.equal("0u8");
+            expect(Field.fromString("257field").toU8().toString()).to.equal("1u8");
+        });
+
+        it('Field has all integer conversion methods', () => {
+            const f = Field.fromString("42field");
+            expect(f.toU8().toString()).to.equal("42u8");
+            expect(f.toU16().toString()).to.equal("42u16");
+            expect(f.toU32().toString()).to.equal("42u32");
+            expect(f.toU64().toString()).to.equal("42u64");
+            expect(f.toU128().toString()).to.equal("42u128");
+            expect(f.toI8().toString()).to.equal("42i8");
+            expect(f.toI16().toString()).to.equal("42i16");
+            expect(f.toI32().toString()).to.equal("42i32");
+            expect(f.toI64().toString()).to.equal("42i64");
+            expect(f.toI128().toString()).to.equal("42i128");
+        });
+    });
+
+    describe('Scalar conversions', () => {
+        it('Scalar.toBoolean() extracts LSB', () => {
+            expect(Scalar.fromString("0scalar").toBoolean().toString()).to.equal("false");
+            expect(Scalar.fromString("1scalar").toBoolean().toString()).to.equal("true");
+        });
+
+        it('Scalar.toGroup() never throws', () => {
+            expect(() => Scalar.fromString("42scalar").toGroup()).to.not.throw();
+        });
+
+        it('Scalar.toAddress() produces valid address', () => {
+            const addr = Scalar.fromString("42scalar").toAddress();
+            expect(addr.toString()).to.match(/^aleo1/);
+        });
+
+        it('Scalar.toU32() preserves small values', () => {
+            expect(Scalar.fromString("100scalar").toU32().toString()).to.equal("100u32");
+        });
+    });
+
+    describe('Boolean conversions', () => {
+        it('Boolean.toField() converts correctly', () => {
+            expect(Boolean.fromString("true").toField().toString()).to.equal("1field");
+            expect(Boolean.fromString("false").toField().toString()).to.equal("0field");
+        });
+
+        it('Boolean.toScalar() converts correctly', () => {
+            expect(Boolean.fromString("true").toScalar().toString()).to.equal("1scalar");
+            expect(Boolean.fromString("false").toScalar().toString()).to.equal("0scalar");
+        });
+
+        it('Boolean.toGroup() never throws', () => {
+            expect(() => Boolean.fromString("true").toGroup()).to.not.throw();
+            expect(() => Boolean.fromString("false").toGroup()).to.not.throw();
+        });
+
+        it('Boolean.toU8() converts correctly', () => {
+            expect(Boolean.fromString("true").toU8().toString()).to.equal("1u8");
+            expect(Boolean.fromString("false").toU8().toString()).to.equal("0u8");
+        });
+
+        it('Boolean round-trips through Field', () => {
+            const t = Boolean.fromString("true");
+            expect(t.toField().toBoolean().toString()).to.equal("true");
+
+            const f = Boolean.fromString("false");
+            expect(f.toField().toBoolean().toString()).to.equal("false");
+        });
+    });
+
+    describe('Integer conversions', () => {
+        it('Integer.toField() is lossless', () => {
+            const val = U32.fromString("42u32");
+            const field = val.toField();
+            const back = U32.fromField(field);
+            expect(back.toString()).to.equal("42u32");
+        });
+
+        it('Integer.fromFieldLossy() round-trips for in-range values', () => {
+            const val = U8.fromString("200u8");
+            const field = val.toField();
+            const back = U8.fromFieldLossy(field);
+            expect(back.toString()).to.equal("200u8");
+        });
+
+        it('Integer.toBoolean() extracts LSB', () => {
+            expect(U32.fromString("0u32").toBoolean().toString()).to.equal("false");
+            expect(U32.fromString("1u32").toBoolean().toString()).to.equal("true");
+            expect(U32.fromString("4u32").toBoolean().toString()).to.equal("false");
+        });
+
+        it('Integer.toGroup() never throws', () => {
+            expect(() => U32.fromString("42u32").toGroup()).to.not.throw();
+        });
+
+        it('Integer.toAddress() produces valid address', () => {
+            const addr = U32.fromString("42u32").toAddress();
+            expect(addr.toString()).to.match(/^aleo1/);
+        });
+
+        it('Integer cross-cast: U32.toU8() truncates', () => {
+            expect(U32.fromString("256u32").toU8().toString()).to.equal("0u8");
+            expect(U32.fromString("257u32").toU8().toString()).to.equal("1u8");
+        });
+
+        it('Integer cross-cast: U8.toU32() widens', () => {
+            expect(U8.fromString("255u8").toU32().toString()).to.equal("255u32");
+        });
+
+        it('Integer cross-cast: I32.toU32() works', () => {
+            expect(I32.fromString("42i32").toU32().toString()).to.equal("42u32");
+        });
+
+        it('Integer cross-cast: identity', () => {
+            expect(U32.fromString("42u32").toU32().toString()).to.equal("42u32");
+        });
+    });
+
+    describe('Group conversions', () => {
+        it('Group.toField() returns x-coordinate', () => {
+            const group = Group.generator();
+            const field = group.toField();
+            const xCoord = group.toXCoordinate();
+            expect(field.toString()).to.equal(xCoord.toString());
+        });
+
+        it('Group.toScalar() does not throw', () => {
+            expect(() => Group.generator().toScalar()).to.not.throw();
+        });
+
+        it('Group.toBoolean() extracts LSB of x-coordinate', () => {
+            const group = Group.generator();
+            const groupBool = group.toBoolean();
+            const fieldBool = group.toField().toBoolean();
+            expect(groupBool.toString()).to.equal(fieldBool.toString());
+        });
+
+        it('Group.toAddress() produces valid address', () => {
+            const addr = Group.generator().toAddress();
+            expect(addr.toString()).to.match(/^aleo1/);
+        });
+
+        it('Group.toU32() does not throw', () => {
+            expect(() => Group.generator().toU32()).to.not.throw();
+        });
+    });
+
+    describe('Address conversions', () => {
+        it('Address.toField() does not throw', () => {
+            const addr = Field.fromString("42field").toAddress();
+            expect(() => addr.toField()).to.not.throw();
+        });
+
+        it('Address.toScalar() does not throw', () => {
+            const addr = Field.fromString("42field").toAddress();
+            expect(() => addr.toScalar()).to.not.throw();
+        });
+
+        it('Address.toBoolean() does not throw', () => {
+            const addr = Field.fromString("42field").toAddress();
+            expect(() => addr.toBoolean()).to.not.throw();
+        });
+
+        it('Address.toU32() does not throw', () => {
+            const addr = Field.fromString("42field").toAddress();
+            expect(() => addr.toU32()).to.not.throw();
+        });
+
+        it('Address → Group → Address round-trips', () => {
+            const addr = Field.fromString("42field").toAddress();
+            const group = addr.toGroup();
+            const back = group.toAddress();
+            expect(back.toString()).to.equal(addr.toString());
+        });
+    });
+});

--- a/sdk/tests/cast-lossy.test.ts
+++ b/sdk/tests/cast-lossy.test.ts
@@ -12,76 +12,82 @@ import {
 describe('cast_lossy type conversions', () => {
 
     describe('Field conversions', () => {
-        it('Field.toScalar() round-trips for small values', () => {
+        it('Field.toScalarLossy() round-trips for small values', () => {
             const scalar = Scalar.fromString("42scalar");
             const field = scalar.toField();
-            const back = field.toScalar();
+            const back = field.toScalarLossy();
             expect(back.toString()).to.equal(scalar.toString());
         });
 
-        it('Field.toBoolean() extracts LSB', () => {
-            expect(Field.fromString("0field").toBoolean().toString()).to.equal("false");
-            expect(Field.fromString("1field").toBoolean().toString()).to.equal("true");
-            expect(Field.fromString("2field").toBoolean().toString()).to.equal("false");
-            expect(Field.fromString("3field").toBoolean().toString()).to.equal("true");
+        it('Field.toBooleanLossy() extracts LSB', () => {
+            expect(Field.fromString("0field").toBooleanLossy().toString()).to.equal("false");
+            expect(Field.fromString("1field").toBooleanLossy().toString()).to.equal("true");
+            expect(Field.fromString("2field").toBooleanLossy().toString()).to.equal("false");
+            expect(Field.fromString("3field").toBooleanLossy().toString()).to.equal("true");
         });
 
-        it('Field.toGroup() never throws', () => {
+        it('Field.toGroup() (strict) may fail for arbitrary fields', () => {
+            // Valid x-coordinate may or may not work depending on the curve
+            // Just ensure the method exists and returns Result-like behavior
             expect(() => Field.fromString("0field").toGroup()).to.not.throw();
-            expect(() => Field.fromString("1field").toGroup()).to.not.throw();
-            expect(() => Field.fromString("12345field").toGroup()).to.not.throw();
         });
 
-        it('Field.toAddress() produces valid address', () => {
-            const addr = Field.fromString("42field").toAddress();
+        it('Field.toGroupLossy() never throws', () => {
+            expect(() => Field.fromString("0field").toGroupLossy()).to.not.throw();
+            expect(() => Field.fromString("1field").toGroupLossy()).to.not.throw();
+            expect(() => Field.fromString("12345field").toGroupLossy()).to.not.throw();
+        });
+
+        it('Field.toAddressLossy() produces valid address', () => {
+            const addr = Field.fromString("42field").toAddressLossy();
             expect(addr.toString()).to.match(/^aleo1/);
         });
 
-        it('Field.toU32() preserves small values', () => {
-            expect(Field.fromString("255field").toU32().toString()).to.equal("255u32");
+        it('Field.toU32Lossy() preserves small values', () => {
+            expect(Field.fromString("255field").toU32Lossy().toString()).to.equal("255u32");
         });
 
-        it('Field.toU8() truncates large values', () => {
-            expect(Field.fromString("256field").toU8().toString()).to.equal("0u8");
-            expect(Field.fromString("257field").toU8().toString()).to.equal("1u8");
+        it('Field.toU8Lossy() truncates large values', () => {
+            expect(Field.fromString("256field").toU8Lossy().toString()).to.equal("0u8");
+            expect(Field.fromString("257field").toU8Lossy().toString()).to.equal("1u8");
         });
 
-        it('Field has all integer conversion methods', () => {
+        it('Field has all integer lossy conversion methods', () => {
             const f = Field.fromString("42field");
-            expect(f.toU8().toString()).to.equal("42u8");
-            expect(f.toU16().toString()).to.equal("42u16");
-            expect(f.toU32().toString()).to.equal("42u32");
-            expect(f.toU64().toString()).to.equal("42u64");
-            expect(f.toU128().toString()).to.equal("42u128");
-            expect(f.toI8().toString()).to.equal("42i8");
-            expect(f.toI16().toString()).to.equal("42i16");
-            expect(f.toI32().toString()).to.equal("42i32");
-            expect(f.toI64().toString()).to.equal("42i64");
-            expect(f.toI128().toString()).to.equal("42i128");
+            expect(f.toU8Lossy().toString()).to.equal("42u8");
+            expect(f.toU16Lossy().toString()).to.equal("42u16");
+            expect(f.toU32Lossy().toString()).to.equal("42u32");
+            expect(f.toU64Lossy().toString()).to.equal("42u64");
+            expect(f.toU128Lossy().toString()).to.equal("42u128");
+            expect(f.toI8Lossy().toString()).to.equal("42i8");
+            expect(f.toI16Lossy().toString()).to.equal("42i16");
+            expect(f.toI32Lossy().toString()).to.equal("42i32");
+            expect(f.toI64Lossy().toString()).to.equal("42i64");
+            expect(f.toI128Lossy().toString()).to.equal("42i128");
         });
     });
 
     describe('Scalar conversions', () => {
-        it('Scalar.toBoolean() extracts LSB', () => {
-            expect(Scalar.fromString("0scalar").toBoolean().toString()).to.equal("false");
-            expect(Scalar.fromString("1scalar").toBoolean().toString()).to.equal("true");
+        it('Scalar.toBooleanLossy() extracts LSB', () => {
+            expect(Scalar.fromString("0scalar").toBooleanLossy().toString()).to.equal("false");
+            expect(Scalar.fromString("1scalar").toBooleanLossy().toString()).to.equal("true");
         });
 
-        it('Scalar.toGroup() never throws', () => {
-            expect(() => Scalar.fromString("42scalar").toGroup()).to.not.throw();
+        it('Scalar.toGroupLossy() never throws', () => {
+            expect(() => Scalar.fromString("42scalar").toGroupLossy()).to.not.throw();
         });
 
-        it('Scalar.toAddress() produces valid address', () => {
-            const addr = Scalar.fromString("42scalar").toAddress();
+        it('Scalar.toAddressLossy() produces valid address', () => {
+            const addr = Scalar.fromString("42scalar").toAddressLossy();
             expect(addr.toString()).to.match(/^aleo1/);
         });
 
-        it('Scalar.toU32() preserves small values', () => {
-            expect(Scalar.fromString("100scalar").toU32().toString()).to.equal("100u32");
+        it('Scalar.toU32Lossy() preserves small values', () => {
+            expect(Scalar.fromString("100scalar").toU32Lossy().toString()).to.equal("100u32");
         });
     });
 
-    describe('Boolean conversions', () => {
+    describe('Boolean conversions (lossless)', () => {
         it('Boolean.toField() converts correctly', () => {
             expect(Boolean.fromString("true").toField().toString()).to.equal("1field");
             expect(Boolean.fromString("false").toField().toString()).to.equal("0field");
@@ -92,9 +98,9 @@ describe('cast_lossy type conversions', () => {
             expect(Boolean.fromString("false").toScalar().toString()).to.equal("0scalar");
         });
 
-        it('Boolean.toGroup() never throws', () => {
-            expect(() => Boolean.fromString("true").toGroup()).to.not.throw();
-            expect(() => Boolean.fromString("false").toGroup()).to.not.throw();
+        it('Boolean.toGroupLossy() never throws', () => {
+            expect(() => Boolean.fromString("true").toGroupLossy()).to.not.throw();
+            expect(() => Boolean.fromString("false").toGroupLossy()).to.not.throw();
         });
 
         it('Boolean.toU8() converts correctly', () => {
@@ -104,10 +110,10 @@ describe('cast_lossy type conversions', () => {
 
         it('Boolean round-trips through Field', () => {
             const t = Boolean.fromString("true");
-            expect(t.toField().toBoolean().toString()).to.equal("true");
+            expect(t.toField().toBooleanLossy().toString()).to.equal("true");
 
             const f = Boolean.fromString("false");
-            expect(f.toField().toBoolean().toString()).to.equal("false");
+            expect(f.toField().toBooleanLossy().toString()).to.equal("false");
         });
     });
 
@@ -126,36 +132,27 @@ describe('cast_lossy type conversions', () => {
             expect(back.toString()).to.equal("200u8");
         });
 
-        it('Integer.toBoolean() extracts LSB', () => {
-            expect(U32.fromString("0u32").toBoolean().toString()).to.equal("false");
-            expect(U32.fromString("1u32").toBoolean().toString()).to.equal("true");
-            expect(U32.fromString("4u32").toBoolean().toString()).to.equal("false");
+        it('Integer.toBooleanLossy() extracts LSB', () => {
+            expect(U32.fromString("0u32").toBooleanLossy().toString()).to.equal("false");
+            expect(U32.fromString("1u32").toBooleanLossy().toString()).to.equal("true");
+            expect(U32.fromString("4u32").toBooleanLossy().toString()).to.equal("false");
         });
 
-        it('Integer.toGroup() never throws', () => {
-            expect(() => U32.fromString("42u32").toGroup()).to.not.throw();
+        it('Integer cross-cast lossy: U32.toU8Lossy() truncates', () => {
+            expect(U32.fromString("256u32").toU8Lossy().toString()).to.equal("0u8");
+            expect(U32.fromString("257u32").toU8Lossy().toString()).to.equal("1u8");
         });
 
-        it('Integer.toAddress() produces valid address', () => {
-            const addr = U32.fromString("42u32").toAddress();
-            expect(addr.toString()).to.match(/^aleo1/);
+        it('Integer cross-cast lossy: U8.toU32Lossy() widens', () => {
+            expect(U8.fromString("255u8").toU32Lossy().toString()).to.equal("255u32");
         });
 
-        it('Integer cross-cast: U32.toU8() truncates', () => {
-            expect(U32.fromString("256u32").toU8().toString()).to.equal("0u8");
-            expect(U32.fromString("257u32").toU8().toString()).to.equal("1u8");
+        it('Integer cross-cast lossy: I32.toU32Lossy() works', () => {
+            expect(I32.fromString("42i32").toU32Lossy().toString()).to.equal("42u32");
         });
 
-        it('Integer cross-cast: U8.toU32() widens', () => {
-            expect(U8.fromString("255u8").toU32().toString()).to.equal("255u32");
-        });
-
-        it('Integer cross-cast: I32.toU32() works', () => {
-            expect(I32.fromString("42i32").toU32().toString()).to.equal("42u32");
-        });
-
-        it('Integer cross-cast: identity', () => {
-            expect(U32.fromString("42u32").toU32().toString()).to.equal("42u32");
+        it('Integer cross-cast lossy: identity', () => {
+            expect(U32.fromString("42u32").toU32Lossy().toString()).to.equal("42u32");
         });
     });
 
@@ -167,50 +164,50 @@ describe('cast_lossy type conversions', () => {
             expect(field.toString()).to.equal(xCoord.toString());
         });
 
-        it('Group.toScalar() does not throw', () => {
-            expect(() => Group.generator().toScalar()).to.not.throw();
+        it('Group.toScalarLossy() does not throw', () => {
+            expect(() => Group.generator().toScalarLossy()).to.not.throw();
         });
 
-        it('Group.toBoolean() extracts LSB of x-coordinate', () => {
+        it('Group.toBooleanLossy() extracts LSB of x-coordinate', () => {
             const group = Group.generator();
-            const groupBool = group.toBoolean();
-            const fieldBool = group.toField().toBoolean();
+            const groupBool = group.toBooleanLossy();
+            const fieldBool = group.toField().toBooleanLossy();
             expect(groupBool.toString()).to.equal(fieldBool.toString());
         });
 
-        it('Group.toAddress() produces valid address', () => {
+        it('Group.toAddress() produces valid address (lossless)', () => {
             const addr = Group.generator().toAddress();
             expect(addr.toString()).to.match(/^aleo1/);
         });
 
-        it('Group.toU32() does not throw', () => {
-            expect(() => Group.generator().toU32()).to.not.throw();
+        it('Group.toU32Lossy() does not throw', () => {
+            expect(() => Group.generator().toU32Lossy()).to.not.throw();
         });
     });
 
     describe('Address conversions', () => {
         it('Address.toField() does not throw', () => {
-            const addr = Field.fromString("42field").toAddress();
+            const addr = Field.fromString("42field").toAddressLossy();
             expect(() => addr.toField()).to.not.throw();
         });
 
-        it('Address.toScalar() does not throw', () => {
-            const addr = Field.fromString("42field").toAddress();
-            expect(() => addr.toScalar()).to.not.throw();
+        it('Address.toScalarLossy() does not throw', () => {
+            const addr = Field.fromString("42field").toAddressLossy();
+            expect(() => addr.toScalarLossy()).to.not.throw();
         });
 
-        it('Address.toBoolean() does not throw', () => {
-            const addr = Field.fromString("42field").toAddress();
-            expect(() => addr.toBoolean()).to.not.throw();
+        it('Address.toBooleanLossy() does not throw', () => {
+            const addr = Field.fromString("42field").toAddressLossy();
+            expect(() => addr.toBooleanLossy()).to.not.throw();
         });
 
-        it('Address.toU32() does not throw', () => {
-            const addr = Field.fromString("42field").toAddress();
-            expect(() => addr.toU32()).to.not.throw();
+        it('Address.toU32Lossy() does not throw', () => {
+            const addr = Field.fromString("42field").toAddressLossy();
+            expect(() => addr.toU32Lossy()).to.not.throw();
         });
 
         it('Address → Group → Address round-trips', () => {
-            const addr = Field.fromString("42field").toAddress();
+            const addr = Field.fromString("42field").toAddressLossy();
             const group = addr.toGroup();
             const back = group.toAddress();
             expect(back.toString()).to.equal(addr.toString());

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -745,7 +745,7 @@ describe('WASM Objects', () => {
                 const programAddress = Address.fromProgramId(programIDString);
                 expect(programAddress.to_string()).to.equal("aleo1lqmly7ez2k48ajf5hs92ulphaqr05qm4n8qwzj8v0yprmasgpqgsez59gg");
             }
-        }); 
+        });
     })
 });
 

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -238,7 +238,7 @@ impl Address {
         false
     }
 
-    // ── cast_lossy conversions ──────────────────────────────────────────
+    // ── cast conversions ───────────────────────────────────────────────
 
     /// Cast the address to a Field element (x-coordinate of the underlying group point).
     #[wasm_bindgen(js_name = "toField")]
@@ -246,78 +246,77 @@ impl Address {
         Field::from(self.0.to_group().to_x_coordinate())
     }
 
-    /// Cast the address to a Scalar (lossy, via x-coordinate).
-    #[wasm_bindgen(js_name = "toScalar")]
-    pub fn to_scalar(&self) -> Scalar {
-        let x_coord = self.0.to_group().to_x_coordinate();
-        Scalar::from(ScalarNative::from_field_lossy(&x_coord))
+    /// Cast the address to a Scalar with lossy truncation (via x-coordinate).
+    #[wasm_bindgen(js_name = "toScalarLossy")]
+    pub fn to_scalar_lossy(&self) -> Scalar {
+        Scalar::from(ScalarNative::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
-    /// Cast the address to a Boolean (LSB of x-coordinate).
-    #[wasm_bindgen(js_name = "toBoolean")]
-    pub fn to_boolean(&self) -> Boolean {
+    /// Cast the address to a Boolean with lossy truncation (LSB of x-coordinate).
+    #[wasm_bindgen(js_name = "toBooleanLossy")]
+    pub fn to_boolean_lossy(&self) -> Boolean {
         Boolean::new(self.0.to_group().to_x_coordinate().to_bits_le()[0])
     }
 
     // Address → Integer lossy conversions (via x-coordinate)
 
     /// Cast the address to a U8 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU8")]
-    pub fn to_u8(&self) -> U8 {
+    #[wasm_bindgen(js_name = "toU8Lossy")]
+    pub fn to_u8_lossy(&self) -> U8 {
         U8::from(U8Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
     /// Cast the address to a U16 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU16")]
-    pub fn to_u16(&self) -> U16 {
+    #[wasm_bindgen(js_name = "toU16Lossy")]
+    pub fn to_u16_lossy(&self) -> U16 {
         U16::from(U16Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
     /// Cast the address to a U32 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU32")]
-    pub fn to_u32(&self) -> U32 {
+    #[wasm_bindgen(js_name = "toU32Lossy")]
+    pub fn to_u32_lossy(&self) -> U32 {
         U32::from(U32Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
     /// Cast the address to a U64 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU64")]
-    pub fn to_u64(&self) -> U64 {
+    #[wasm_bindgen(js_name = "toU64Lossy")]
+    pub fn to_u64_lossy(&self) -> U64 {
         U64::from(U64Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
     /// Cast the address to a U128 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU128")]
-    pub fn to_u128(&self) -> U128 {
+    #[wasm_bindgen(js_name = "toU128Lossy")]
+    pub fn to_u128_lossy(&self) -> U128 {
         U128::from(U128Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
     /// Cast the address to an I8 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI8")]
-    pub fn to_i8(&self) -> I8 {
+    #[wasm_bindgen(js_name = "toI8Lossy")]
+    pub fn to_i8_lossy(&self) -> I8 {
         I8::from(I8Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
     /// Cast the address to an I16 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI16")]
-    pub fn to_i16(&self) -> I16 {
+    #[wasm_bindgen(js_name = "toI16Lossy")]
+    pub fn to_i16_lossy(&self) -> I16 {
         I16::from(I16Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
     /// Cast the address to an I32 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI32")]
-    pub fn to_i32(&self) -> I32 {
+    #[wasm_bindgen(js_name = "toI32Lossy")]
+    pub fn to_i32_lossy(&self) -> I32 {
         I32::from(I32Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
     /// Cast the address to an I64 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI64")]
-    pub fn to_i64(&self) -> I64 {
+    #[wasm_bindgen(js_name = "toI64Lossy")]
+    pub fn to_i64_lossy(&self) -> I64 {
         I64::from(I64Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 
     /// Cast the address to an I128 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI128")]
-    pub fn to_i128(&self) -> I128 {
+    #[wasm_bindgen(js_name = "toI128Lossy")]
+    pub fn to_i128_lossy(&self) -> I128 {
         I128::from(I128Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 }

--- a/wasm/src/account/address.rs
+++ b/wasm/src/account/address.rs
@@ -18,13 +18,32 @@ use crate::{
     Field,
     Group,
     Plaintext,
+    Scalar,
     account::{PrivateKey, Signature, ViewKey, compute_key::ComputeKey},
     from_js_typed_array,
     from_wasm_field_array,
     js_array_from_fields,
     native::{CurrentNetwork, FieldNative, LiteralNative},
     to_bits_array_le,
-    types::native::{AddressNative, ProgramIDNative},
+    types::{
+        Boolean,
+        integer::{I8, I16, I32, I64, I128, U8, U16, U32, U64, U128},
+        native::{
+            AddressNative,
+            I8Native,
+            I16Native,
+            I32Native,
+            I64Native,
+            I128Native,
+            ProgramIDNative,
+            ScalarNative,
+            U8Native,
+            U16Native,
+            U32Native,
+            U64Native,
+            U128Native,
+        },
+    },
 };
 use snarkvm_console::prelude::{FromBits, FromBytes, FromFields, Network, ToBits, ToBytes, ToField, ToFields};
 
@@ -217,6 +236,89 @@ impl Address {
 
         // Neither string nor Uint8Array
         false
+    }
+
+    // ── cast_lossy conversions ──────────────────────────────────────────
+
+    /// Cast the address to a Field element (x-coordinate of the underlying group point).
+    #[wasm_bindgen(js_name = "toField")]
+    pub fn to_field(&self) -> Field {
+        Field::from(self.0.to_group().to_x_coordinate())
+    }
+
+    /// Cast the address to a Scalar (lossy, via x-coordinate).
+    #[wasm_bindgen(js_name = "toScalar")]
+    pub fn to_scalar(&self) -> Scalar {
+        let x_coord = self.0.to_group().to_x_coordinate();
+        Scalar::from(ScalarNative::from_field_lossy(&x_coord))
+    }
+
+    /// Cast the address to a Boolean (LSB of x-coordinate).
+    #[wasm_bindgen(js_name = "toBoolean")]
+    pub fn to_boolean(&self) -> Boolean {
+        Boolean::new(self.0.to_group().to_x_coordinate().to_bits_le()[0])
+    }
+
+    // Address → Integer lossy conversions (via x-coordinate)
+
+    /// Cast the address to a U8 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU8")]
+    pub fn to_u8(&self) -> U8 {
+        U8::from(U8Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
+    }
+
+    /// Cast the address to a U16 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU16")]
+    pub fn to_u16(&self) -> U16 {
+        U16::from(U16Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
+    }
+
+    /// Cast the address to a U32 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU32")]
+    pub fn to_u32(&self) -> U32 {
+        U32::from(U32Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
+    }
+
+    /// Cast the address to a U64 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU64")]
+    pub fn to_u64(&self) -> U64 {
+        U64::from(U64Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
+    }
+
+    /// Cast the address to a U128 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU128")]
+    pub fn to_u128(&self) -> U128 {
+        U128::from(U128Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
+    }
+
+    /// Cast the address to an I8 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI8")]
+    pub fn to_i8(&self) -> I8 {
+        I8::from(I8Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
+    }
+
+    /// Cast the address to an I16 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI16")]
+    pub fn to_i16(&self) -> I16 {
+        I16::from(I16Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
+    }
+
+    /// Cast the address to an I32 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI32")]
+    pub fn to_i32(&self) -> I32 {
+        I32::from(I32Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
+    }
+
+    /// Cast the address to an I64 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI64")]
+    pub fn to_i64(&self) -> I64 {
+        I64::from(I64Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
+    }
+
+    /// Cast the address to an I128 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI128")]
+    pub fn to_i128(&self) -> I128 {
+        I128::from(I128Native::from_field_lossy(&self.0.to_group().to_x_coordinate()))
     }
 }
 

--- a/wasm/src/types/boolean.rs
+++ b/wasm/src/types/boolean.rs
@@ -45,7 +45,7 @@ use crate::{
     },
 };
 use snarkvm_console::{
-    prelude::{FromBits, FromBytes, ToBits, ToBytes},
+    prelude::{FromBits, FromBytes, FromField, ToBits, ToBytes},
     program::CastLossy,
 };
 use snarkvm_wasm::utilities::Uniform;
@@ -166,38 +166,50 @@ impl Boolean {
         self.0 == BooleanNative::from(other)
     }
 
-    // ── cast_lossy conversions ──────────────────────────────────────────
+    // ── cast conversions (all lossless — Boolean has minimal information) ──
 
-    /// Cast the boolean to a Field element (false=0, true=1).
+    /// Cast the boolean to a Field element (false=0, true=1). Lossless.
     #[wasm_bindgen(js_name = "toField")]
-    pub fn to_field(&self) -> Field {
-        // Safe: from_bits_le with a single bit is infallible.
-        Field::from(FieldNative::from_bits_le(&[*self.0]).unwrap())
+    pub fn to_field(&self) -> Result<Field, String> {
+        Ok(Field::from(FieldNative::from_bits_le(&[*self.0]).map_err(|e| e.to_string())?))
     }
 
-    /// Cast the boolean to a Scalar element (false=0, true=1).
+    /// Cast the boolean to a Scalar element (false=0, true=1). Lossless.
     #[wasm_bindgen(js_name = "toScalar")]
-    pub fn to_scalar(&self) -> Scalar {
-        // Safe: from_bits_le with a single bit is infallible.
-        Scalar::from(ScalarNative::from_bits_le(&[*self.0]).unwrap())
+    pub fn to_scalar(&self) -> Result<Scalar, String> {
+        Ok(Scalar::from(ScalarNative::from_bits_le(&[*self.0]).map_err(|e| e.to_string())?))
     }
 
-    /// Cast the boolean to a Group element (via Field, Elligator-2 fallback).
+    /// Cast the boolean to a Group element (strict, via Field x-coordinate recovery).
+    /// Returns an error if the resulting field is not a valid x-coordinate.
     #[wasm_bindgen(js_name = "toGroup")]
-    pub fn to_group(&self) -> Group {
-        // Safe: from_bits_le with a single bit is infallible.
-        let field = FieldNative::from_bits_le(&[*self.0]).unwrap();
+    pub fn to_group(&self) -> Result<Group, String> {
+        let field = FieldNative::from_bits_le(&[*self.0]).map_err(|e| e.to_string())?;
+        Ok(Group::from(GroupNative::from_field(&field).map_err(|e| e.to_string())?))
+    }
+
+    /// Cast the boolean to a Group element (lossy, via Field with Elligator-2 fallback).
+    /// This conversion never fails.
+    #[wasm_bindgen(js_name = "toGroupLossy")]
+    pub fn to_group_lossy(&self) -> Result<Group, String> {
+        let field = FieldNative::from_bits_le(&[*self.0]).map_err(|e| e.to_string())?;
         let group: GroupNative = field.cast_lossy();
-        Group::from(group)
+        Ok(Group::from(group))
     }
 
-    /// Cast the boolean to an Address (via Group).
+    /// Cast the boolean to an Address (strict, via Group). Returns an error if conversion fails.
     #[wasm_bindgen(js_name = "toAddress")]
-    pub fn to_address(&self) -> Address {
-        Address::from_group(self.to_group())
+    pub fn to_address(&self) -> Result<Address, String> {
+        Ok(Address::from_group(self.to_group()?))
     }
 
-    // Boolean → Integer conversions (false=0, true=1)
+    /// Cast the boolean to an Address (lossy, via Group with Elligator-2 fallback).
+    #[wasm_bindgen(js_name = "toAddressLossy")]
+    pub fn to_address_lossy(&self) -> Result<Address, String> {
+        Ok(Address::from_group(self.to_group_lossy()?))
+    }
+
+    // Boolean → Integer conversions (false=0, true=1). All lossless.
 
     /// Cast the boolean to a U8 (false=0, true=1).
     #[wasm_bindgen(js_name = "toU8")]

--- a/wasm/src/types/boolean.rs
+++ b/wasm/src/types/boolean.rs
@@ -15,12 +15,39 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    Address,
     Plaintext,
     from_js_typed_array,
     to_bits_array_le,
-    types::native::{BooleanNative, LiteralNative, PlaintextNative},
+    types::{
+        Field,
+        Group,
+        Scalar,
+        integer::{I8, I16, I32, I64, I128, U8, U16, U32, U64, U128},
+        native::{
+            BooleanNative,
+            FieldNative,
+            GroupNative,
+            I8Native,
+            I16Native,
+            I32Native,
+            I64Native,
+            I128Native,
+            LiteralNative,
+            PlaintextNative,
+            ScalarNative,
+            U8Native,
+            U16Native,
+            U32Native,
+            U64Native,
+            U128Native,
+        },
+    },
 };
-use snarkvm_console::prelude::{FromBits, FromBytes, ToBits, ToBytes};
+use snarkvm_console::{
+    prelude::{FromBits, FromBytes, ToBits, ToBytes},
+    program::CastLossy,
+};
 use snarkvm_wasm::utilities::Uniform;
 
 use js_sys::{Array, Uint8Array};
@@ -137,6 +164,99 @@ impl Boolean {
     /// Check if one boolean element equals another.
     pub fn equals(&self, other: &Boolean) -> bool {
         self.0 == BooleanNative::from(other)
+    }
+
+    // ── cast_lossy conversions ──────────────────────────────────────────
+
+    /// Cast the boolean to a Field element (false=0, true=1).
+    #[wasm_bindgen(js_name = "toField")]
+    pub fn to_field(&self) -> Field {
+        // Safe: from_bits_le with a single bit is infallible.
+        Field::from(FieldNative::from_bits_le(&[*self.0]).unwrap())
+    }
+
+    /// Cast the boolean to a Scalar element (false=0, true=1).
+    #[wasm_bindgen(js_name = "toScalar")]
+    pub fn to_scalar(&self) -> Scalar {
+        // Safe: from_bits_le with a single bit is infallible.
+        Scalar::from(ScalarNative::from_bits_le(&[*self.0]).unwrap())
+    }
+
+    /// Cast the boolean to a Group element (via Field, Elligator-2 fallback).
+    #[wasm_bindgen(js_name = "toGroup")]
+    pub fn to_group(&self) -> Group {
+        // Safe: from_bits_le with a single bit is infallible.
+        let field = FieldNative::from_bits_le(&[*self.0]).unwrap();
+        let group: GroupNative = field.cast_lossy();
+        Group::from(group)
+    }
+
+    /// Cast the boolean to an Address (via Group).
+    #[wasm_bindgen(js_name = "toAddress")]
+    pub fn to_address(&self) -> Address {
+        Address::from_group(self.to_group())
+    }
+
+    // Boolean → Integer conversions (false=0, true=1)
+
+    /// Cast the boolean to a U8 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toU8")]
+    pub fn to_u8(&self) -> U8 {
+        U8::from(U8Native::new(if *self.0 { 1 } else { 0 }))
+    }
+
+    /// Cast the boolean to a U16 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toU16")]
+    pub fn to_u16(&self) -> U16 {
+        U16::from(U16Native::new(if *self.0 { 1 } else { 0 }))
+    }
+
+    /// Cast the boolean to a U32 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toU32")]
+    pub fn to_u32(&self) -> U32 {
+        U32::from(U32Native::new(if *self.0 { 1 } else { 0 }))
+    }
+
+    /// Cast the boolean to a U64 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toU64")]
+    pub fn to_u64(&self) -> U64 {
+        U64::from(U64Native::new(if *self.0 { 1 } else { 0 }))
+    }
+
+    /// Cast the boolean to a U128 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toU128")]
+    pub fn to_u128(&self) -> U128 {
+        U128::from(U128Native::new(if *self.0 { 1 } else { 0 }))
+    }
+
+    /// Cast the boolean to an I8 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toI8")]
+    pub fn to_i8(&self) -> I8 {
+        I8::from(I8Native::new(if *self.0 { 1 } else { 0 }))
+    }
+
+    /// Cast the boolean to an I16 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toI16")]
+    pub fn to_i16(&self) -> I16 {
+        I16::from(I16Native::new(if *self.0 { 1 } else { 0 }))
+    }
+
+    /// Cast the boolean to an I32 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toI32")]
+    pub fn to_i32(&self) -> I32 {
+        I32::from(I32Native::new(if *self.0 { 1 } else { 0 }))
+    }
+
+    /// Cast the boolean to an I64 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toI64")]
+    pub fn to_i64(&self) -> I64 {
+        I64::from(I64Native::new(if *self.0 { 1 } else { 0 }))
+    }
+
+    /// Cast the boolean to an I128 (false=0, true=1).
+    #[wasm_bindgen(js_name = "toI128")]
+    pub fn to_i128(&self) -> I128 {
+        I128::from(I128Native::new(if *self.0 { 1 } else { 0 }))
     }
 }
 

--- a/wasm/src/types/field.rs
+++ b/wasm/src/types/field.rs
@@ -180,96 +180,125 @@ impl Field {
         self.0 == FieldNative::from(other)
     }
 
-    // ── cast_lossy conversions ──────────────────────────────────────────
+    // ── cast conversions ───────────────────────────────────────────────
 
     /// Cast the field element to a Scalar with lossy truncation.
-    #[wasm_bindgen(js_name = "toScalar")]
-    pub fn to_scalar(&self) -> Scalar {
+    #[wasm_bindgen(js_name = "toScalarLossy")]
+    pub fn to_scalar_lossy(&self) -> Scalar {
         Scalar::from(ScalarNative::from_field_lossy(&self.0))
     }
 
-    /// Cast the field element to a Boolean (extracts least-significant bit).
+    /// Cast the field element to a Boolean (strict).
+    /// Returns an error if the field is not zero or one.
     #[wasm_bindgen(js_name = "toBoolean")]
-    pub fn to_boolean(&self) -> Boolean {
+    pub fn to_boolean(&self) -> Result<Boolean, String> {
+        if self.0.is_zero() {
+            Ok(Boolean::new(false))
+        } else if self.0.is_one() {
+            Ok(Boolean::new(true))
+        } else {
+            Err("Failed to convert field to boolean: field element is not zero or one".to_string())
+        }
+    }
+
+    /// Cast the field element to a Boolean with lossy truncation (extracts least-significant bit).
+    #[wasm_bindgen(js_name = "toBooleanLossy")]
+    pub fn to_boolean_lossy(&self) -> Boolean {
         Boolean::new(self.0.to_bits_le()[0])
     }
 
-    /// Cast the field element to a Group element.
+    /// Cast the field element to a Group element (strict).
+    ///
+    /// Attempts to recover the group element from the field as an x-coordinate.
+    /// Returns an error if the field is not a valid x-coordinate on the curve.
+    #[wasm_bindgen(js_name = "toGroup")]
+    pub fn to_group(&self) -> Result<Group, String> {
+        Group::from_field(self)
+    }
+
+    /// Cast the field element to a Group element with lossy conversion.
     ///
     /// Uses the snarkVM cast_lossy path: tries x-coordinate recovery first,
     /// falls back to the generator for field == 1, and applies Elligator-2
     /// otherwise. This conversion never fails.
-    #[wasm_bindgen(js_name = "toGroup")]
-    pub fn to_group(&self) -> Group {
+    #[wasm_bindgen(js_name = "toGroupLossy")]
+    pub fn to_group_lossy(&self) -> Group {
         let group: GroupNative = self.0.cast_lossy();
         Group::from(group)
     }
 
-    /// Cast the field element to an Address (via Group).
+    /// Cast the field element to an Address (strict, via Group x-coordinate recovery).
+    /// Returns an error if the field is not a valid x-coordinate on the curve.
     #[wasm_bindgen(js_name = "toAddress")]
-    pub fn to_address(&self) -> Address {
-        Address::from_group(self.to_group())
+    pub fn to_address(&self) -> Result<Address, String> {
+        Ok(Address::from_group(self.to_group()?))
+    }
+
+    /// Cast the field element to an Address with lossy conversion (via Group, Elligator-2 fallback).
+    #[wasm_bindgen(js_name = "toAddressLossy")]
+    pub fn to_address_lossy(&self) -> Address {
+        Address::from_group(self.to_group_lossy())
     }
 
     // Field → Integer lossy conversions
 
     /// Cast the field to a U8 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU8")]
-    pub fn to_u8(&self) -> U8 {
+    #[wasm_bindgen(js_name = "toU8Lossy")]
+    pub fn to_u8_lossy(&self) -> U8 {
         U8::from(U8Native::from_field_lossy(&self.0))
     }
 
     /// Cast the field to a U16 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU16")]
-    pub fn to_u16(&self) -> U16 {
+    #[wasm_bindgen(js_name = "toU16Lossy")]
+    pub fn to_u16_lossy(&self) -> U16 {
         U16::from(U16Native::from_field_lossy(&self.0))
     }
 
     /// Cast the field to a U32 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU32")]
-    pub fn to_u32(&self) -> U32 {
+    #[wasm_bindgen(js_name = "toU32Lossy")]
+    pub fn to_u32_lossy(&self) -> U32 {
         U32::from(U32Native::from_field_lossy(&self.0))
     }
 
     /// Cast the field to a U64 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU64")]
-    pub fn to_u64(&self) -> U64 {
+    #[wasm_bindgen(js_name = "toU64Lossy")]
+    pub fn to_u64_lossy(&self) -> U64 {
         U64::from(U64Native::from_field_lossy(&self.0))
     }
 
     /// Cast the field to a U128 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU128")]
-    pub fn to_u128(&self) -> U128 {
+    #[wasm_bindgen(js_name = "toU128Lossy")]
+    pub fn to_u128_lossy(&self) -> U128 {
         U128::from(U128Native::from_field_lossy(&self.0))
     }
 
     /// Cast the field to an I8 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI8")]
-    pub fn to_i8(&self) -> I8 {
+    #[wasm_bindgen(js_name = "toI8Lossy")]
+    pub fn to_i8_lossy(&self) -> I8 {
         I8::from(I8Native::from_field_lossy(&self.0))
     }
 
     /// Cast the field to an I16 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI16")]
-    pub fn to_i16(&self) -> I16 {
+    #[wasm_bindgen(js_name = "toI16Lossy")]
+    pub fn to_i16_lossy(&self) -> I16 {
         I16::from(I16Native::from_field_lossy(&self.0))
     }
 
     /// Cast the field to an I32 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI32")]
-    pub fn to_i32(&self) -> I32 {
+    #[wasm_bindgen(js_name = "toI32Lossy")]
+    pub fn to_i32_lossy(&self) -> I32 {
         I32::from(I32Native::from_field_lossy(&self.0))
     }
 
     /// Cast the field to an I64 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI64")]
-    pub fn to_i64(&self) -> I64 {
+    #[wasm_bindgen(js_name = "toI64Lossy")]
+    pub fn to_i64_lossy(&self) -> I64 {
         I64::from(I64Native::from_field_lossy(&self.0))
     }
 
     /// Cast the field to an I128 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI128")]
-    pub fn to_i128(&self) -> I128 {
+    #[wasm_bindgen(js_name = "toI128Lossy")]
+    pub fn to_i128_lossy(&self) -> I128 {
         I128::from(I128Native::from_field_lossy(&self.0))
     }
 }
@@ -319,73 +348,54 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_field_to_scalar_roundtrip() {
-        // A small scalar should round-trip through field → scalar → field
+    fn test_field_to_scalar_lossy_roundtrip() {
         let scalar = Scalar::from_string("42scalar").unwrap();
         let field = scalar.to_field().unwrap();
-        let back = field.to_scalar();
+        let back = field.to_scalar_lossy();
         assert_eq!(back.to_string(), scalar.to_string());
     }
 
     #[test]
-    fn test_field_to_boolean() {
-        let zero = Field::from_string("0field").unwrap();
-        assert_eq!(zero.to_boolean().to_string(), "false");
-
-        let one = Field::from_string("1field").unwrap();
-        assert_eq!(one.to_boolean().to_string(), "true");
-
-        // Even field → LSB is false
-        let two = Field::from_string("2field").unwrap();
-        assert_eq!(two.to_boolean().to_string(), "false");
-
-        // Odd field → LSB is true
-        let three = Field::from_string("3field").unwrap();
-        assert_eq!(three.to_boolean().to_string(), "true");
+    fn test_field_to_boolean_lossy() {
+        assert_eq!(Field::from_string("0field").unwrap().to_boolean_lossy().to_string(), "false");
+        assert_eq!(Field::from_string("1field").unwrap().to_boolean_lossy().to_string(), "true");
+        assert_eq!(Field::from_string("2field").unwrap().to_boolean_lossy().to_string(), "false");
+        assert_eq!(Field::from_string("3field").unwrap().to_boolean_lossy().to_string(), "true");
     }
 
     #[test]
-    fn test_field_to_group_never_fails() {
-        // toGroup uses Elligator-2 fallback and should never fail
+    fn test_field_to_group_strict_and_lossy() {
+        // toGroupLossy uses Elligator-2 fallback and should never fail
         let field = Field::from_string("12345field").unwrap();
-        let _group = field.to_group(); // Should not panic
+        let _group = field.to_group_lossy();
 
         let zero = Field::from_string("0field").unwrap();
-        let _group = zero.to_group();
+        let _group = zero.to_group_lossy();
 
         let one = Field::from_string("1field").unwrap();
-        let _group = one.to_group();
+        let _group = one.to_group_lossy();
+
+        // toGroup (strict) may fail for arbitrary fields
+        // but should succeed when given a valid x-coordinate
     }
 
     #[test]
-    fn test_field_to_integer_roundtrip() {
-        // Small value should round-trip through field → u32 → field
+    fn test_field_to_integer_lossy_roundtrip() {
         let field = Field::from_string("255field").unwrap();
-        let u8_val = field.to_u8();
-        assert_eq!(u8_val.to_string(), "255u8");
-
-        let u32_val = field.to_u32();
-        assert_eq!(u32_val.to_string(), "255u32");
+        assert_eq!(field.to_u8_lossy().to_string(), "255u8");
+        assert_eq!(field.to_u32_lossy().to_string(), "255u32");
     }
 
     #[test]
-    fn test_field_to_integer_truncation() {
-        // 256 should truncate to 0 in U8 (only keeps low 8 bits)
-        let field = Field::from_string("256field").unwrap();
-        let u8_val = field.to_u8();
-        assert_eq!(u8_val.to_string(), "0u8");
-
-        // 257 should truncate to 1 in U8
-        let field = Field::from_string("257field").unwrap();
-        let u8_val = field.to_u8();
-        assert_eq!(u8_val.to_string(), "1u8");
+    fn test_field_to_integer_lossy_truncation() {
+        assert_eq!(Field::from_string("256field").unwrap().to_u8_lossy().to_string(), "0u8");
+        assert_eq!(Field::from_string("257field").unwrap().to_u8_lossy().to_string(), "1u8");
     }
 
     #[test]
-    fn test_field_to_address() {
+    fn test_field_to_address_lossy() {
         let field = Field::from_string("42field").unwrap();
-        let addr = field.to_address();
-        // Should produce a valid address string
+        let addr = field.to_address_lossy();
         assert!(addr.to_string().starts_with("aleo1"));
     }
 }

--- a/wasm/src/types/field.rs
+++ b/wasm/src/types/field.rs
@@ -15,12 +15,39 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    Address,
     Plaintext,
     from_js_typed_array,
     to_bits_array_le,
-    types::native::{CurrentNetwork, FieldNative, LiteralNative, PlaintextNative},
+    types::{
+        Boolean,
+        Group,
+        Scalar,
+        integer::{I8, I16, I32, I64, I128, U8, U16, U32, U64, U128},
+        native::{
+            CurrentNetwork,
+            FieldNative,
+            GroupNative,
+            I8Native,
+            I16Native,
+            I32Native,
+            I64Native,
+            I128Native,
+            LiteralNative,
+            PlaintextNative,
+            ScalarNative,
+            U8Native,
+            U16Native,
+            U32Native,
+            U64Native,
+            U128Native,
+        },
+    },
 };
-use snarkvm_console::prelude::{Double, Environment, FromBits, FromBytes, One, Pow, ToBits, ToBytes, Zero};
+use snarkvm_console::{
+    prelude::{Double, Environment, FromBits, FromBytes, One, Pow, ToBits, ToBytes, Zero},
+    program::CastLossy,
+};
 use snarkvm_wasm::{fields::PrimeField, utilities::Uniform};
 
 use js_sys::{Array, Uint8Array};
@@ -152,6 +179,99 @@ impl Field {
     pub fn equals(&self, other: &Field) -> bool {
         self.0 == FieldNative::from(other)
     }
+
+    // ── cast_lossy conversions ──────────────────────────────────────────
+
+    /// Cast the field element to a Scalar with lossy truncation.
+    #[wasm_bindgen(js_name = "toScalar")]
+    pub fn to_scalar(&self) -> Scalar {
+        Scalar::from(ScalarNative::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field element to a Boolean (extracts least-significant bit).
+    #[wasm_bindgen(js_name = "toBoolean")]
+    pub fn to_boolean(&self) -> Boolean {
+        Boolean::new(self.0.to_bits_le()[0])
+    }
+
+    /// Cast the field element to a Group element.
+    ///
+    /// Uses the snarkVM cast_lossy path: tries x-coordinate recovery first,
+    /// falls back to the generator for field == 1, and applies Elligator-2
+    /// otherwise. This conversion never fails.
+    #[wasm_bindgen(js_name = "toGroup")]
+    pub fn to_group(&self) -> Group {
+        let group: GroupNative = self.0.cast_lossy();
+        Group::from(group)
+    }
+
+    /// Cast the field element to an Address (via Group).
+    #[wasm_bindgen(js_name = "toAddress")]
+    pub fn to_address(&self) -> Address {
+        Address::from_group(self.to_group())
+    }
+
+    // Field → Integer lossy conversions
+
+    /// Cast the field to a U8 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU8")]
+    pub fn to_u8(&self) -> U8 {
+        U8::from(U8Native::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field to a U16 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU16")]
+    pub fn to_u16(&self) -> U16 {
+        U16::from(U16Native::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field to a U32 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU32")]
+    pub fn to_u32(&self) -> U32 {
+        U32::from(U32Native::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field to a U64 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU64")]
+    pub fn to_u64(&self) -> U64 {
+        U64::from(U64Native::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field to a U128 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU128")]
+    pub fn to_u128(&self) -> U128 {
+        U128::from(U128Native::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field to an I8 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI8")]
+    pub fn to_i8(&self) -> I8 {
+        I8::from(I8Native::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field to an I16 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI16")]
+    pub fn to_i16(&self) -> I16 {
+        I16::from(I16Native::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field to an I32 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI32")]
+    pub fn to_i32(&self) -> I32 {
+        I32::from(I32Native::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field to an I64 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI64")]
+    pub fn to_i64(&self) -> I64 {
+        I64::from(I64Native::from_field_lossy(&self.0))
+    }
+
+    /// Cast the field to an I128 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI128")]
+    pub fn to_i128(&self) -> I128 {
+        I128::from(I128Native::from_field_lossy(&self.0))
+    }
 }
 
 impl Deref for Field {
@@ -191,5 +311,81 @@ impl FromStr for Field {
 
     fn from_str(field: &str) -> Result<Self, Self::Err> {
         Ok(Self(FieldNative::from_str(field)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_field_to_scalar_roundtrip() {
+        // A small scalar should round-trip through field → scalar → field
+        let scalar = Scalar::from_string("42scalar").unwrap();
+        let field = scalar.to_field().unwrap();
+        let back = field.to_scalar();
+        assert_eq!(back.to_string(), scalar.to_string());
+    }
+
+    #[test]
+    fn test_field_to_boolean() {
+        let zero = Field::from_string("0field").unwrap();
+        assert_eq!(zero.to_boolean().to_string(), "false");
+
+        let one = Field::from_string("1field").unwrap();
+        assert_eq!(one.to_boolean().to_string(), "true");
+
+        // Even field → LSB is false
+        let two = Field::from_string("2field").unwrap();
+        assert_eq!(two.to_boolean().to_string(), "false");
+
+        // Odd field → LSB is true
+        let three = Field::from_string("3field").unwrap();
+        assert_eq!(three.to_boolean().to_string(), "true");
+    }
+
+    #[test]
+    fn test_field_to_group_never_fails() {
+        // toGroup uses Elligator-2 fallback and should never fail
+        let field = Field::from_string("12345field").unwrap();
+        let _group = field.to_group(); // Should not panic
+
+        let zero = Field::from_string("0field").unwrap();
+        let _group = zero.to_group();
+
+        let one = Field::from_string("1field").unwrap();
+        let _group = one.to_group();
+    }
+
+    #[test]
+    fn test_field_to_integer_roundtrip() {
+        // Small value should round-trip through field → u32 → field
+        let field = Field::from_string("255field").unwrap();
+        let u8_val = field.to_u8();
+        assert_eq!(u8_val.to_string(), "255u8");
+
+        let u32_val = field.to_u32();
+        assert_eq!(u32_val.to_string(), "255u32");
+    }
+
+    #[test]
+    fn test_field_to_integer_truncation() {
+        // 256 should truncate to 0 in U8 (only keeps low 8 bits)
+        let field = Field::from_string("256field").unwrap();
+        let u8_val = field.to_u8();
+        assert_eq!(u8_val.to_string(), "0u8");
+
+        // 257 should truncate to 1 in U8
+        let field = Field::from_string("257field").unwrap();
+        let u8_val = field.to_u8();
+        assert_eq!(u8_val.to_string(), "1u8");
+    }
+
+    #[test]
+    fn test_field_to_address() {
+        let field = Field::from_string("42field").unwrap();
+        let addr = field.to_address();
+        // Should produce a valid address string
+        assert!(addr.to_string().starts_with("aleo1"));
     }
 }

--- a/wasm/src/types/group.rs
+++ b/wasm/src/types/group.rs
@@ -23,7 +23,26 @@ use crate::{
     js_array_from_fields,
     native::AddressNative,
     to_bits_array_le,
-    types::native::{GroupNative, LiteralNative, PlaintextNative},
+    types::{
+        Boolean,
+        integer::{I8, I16, I32, I64, I128, U8, U16, U32, U64, U128},
+        native::{
+            GroupNative,
+            I8Native,
+            I16Native,
+            I32Native,
+            I64Native,
+            I128Native,
+            LiteralNative,
+            PlaintextNative,
+            ScalarNative,
+            U8Native,
+            U16Native,
+            U32Native,
+            U64Native,
+            U128Native,
+        },
+    },
 };
 use snarkvm_console::prelude::{
     Double,
@@ -177,6 +196,95 @@ impl Group {
     /// Get the generator of the group.
     pub fn generator() -> Group {
         Group::from(GroupNative::generator())
+    }
+
+    // ── cast_lossy conversions ──────────────────────────────────────────
+
+    /// Cast the group element to a Field (returns x-coordinate).
+    /// This is an alias for `toXCoordinate()` for consistency with the cast API.
+    #[wasm_bindgen(js_name = "toField")]
+    pub fn to_field(&self) -> Field {
+        self.to_x_coordinate()
+    }
+
+    /// Cast the group element to a Scalar (lossy, via x-coordinate).
+    #[wasm_bindgen(js_name = "toScalar")]
+    pub fn to_scalar(&self) -> Scalar {
+        Scalar::from(ScalarNative::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group element to a Boolean (LSB of x-coordinate).
+    #[wasm_bindgen(js_name = "toBoolean")]
+    pub fn to_boolean(&self) -> Boolean {
+        Boolean::new(self.0.to_x_coordinate().to_bits_le()[0])
+    }
+
+    /// Cast the group element to an Address.
+    #[wasm_bindgen(js_name = "toAddress")]
+    pub fn to_address(&self) -> Address {
+        Address::from_group(self.clone())
+    }
+
+    // Group → Integer lossy conversions (via x-coordinate)
+
+    /// Cast the group to a U8 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU8")]
+    pub fn to_u8(&self) -> U8 {
+        U8::from(U8Native::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group to a U16 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU16")]
+    pub fn to_u16(&self) -> U16 {
+        U16::from(U16Native::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group to a U32 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU32")]
+    pub fn to_u32(&self) -> U32 {
+        U32::from(U32Native::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group to a U64 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU64")]
+    pub fn to_u64(&self) -> U64 {
+        U64::from(U64Native::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group to a U128 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU128")]
+    pub fn to_u128(&self) -> U128 {
+        U128::from(U128Native::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group to an I8 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI8")]
+    pub fn to_i8(&self) -> I8 {
+        I8::from(I8Native::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group to an I16 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI16")]
+    pub fn to_i16(&self) -> I16 {
+        I16::from(I16Native::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group to an I32 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI32")]
+    pub fn to_i32(&self) -> I32 {
+        I32::from(I32Native::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group to an I64 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI64")]
+    pub fn to_i64(&self) -> I64 {
+        I64::from(I64Native::from_field_lossy(&self.0.to_x_coordinate()))
+    }
+
+    /// Cast the group to an I128 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI128")]
+    pub fn to_i128(&self) -> I128 {
+        I128::from(I128Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 }
 

--- a/wasm/src/types/group.rs
+++ b/wasm/src/types/group.rs
@@ -198,28 +198,28 @@ impl Group {
         Group::from(GroupNative::generator())
     }
 
-    // ── cast_lossy conversions ──────────────────────────────────────────
+    // ── cast conversions ───────────────────────────────────────────────
 
     /// Cast the group element to a Field (returns x-coordinate).
-    /// This is an alias for `toXCoordinate()` for consistency with the cast API.
+    /// This is an alias for `toXCoordinate()`.
     #[wasm_bindgen(js_name = "toField")]
     pub fn to_field(&self) -> Field {
         self.to_x_coordinate()
     }
 
-    /// Cast the group element to a Scalar (lossy, via x-coordinate).
-    #[wasm_bindgen(js_name = "toScalar")]
-    pub fn to_scalar(&self) -> Scalar {
+    /// Cast the group element to a Scalar with lossy truncation (via x-coordinate).
+    #[wasm_bindgen(js_name = "toScalarLossy")]
+    pub fn to_scalar_lossy(&self) -> Scalar {
         Scalar::from(ScalarNative::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
-    /// Cast the group element to a Boolean (LSB of x-coordinate).
-    #[wasm_bindgen(js_name = "toBoolean")]
-    pub fn to_boolean(&self) -> Boolean {
+    /// Cast the group element to a Boolean with lossy truncation (LSB of x-coordinate).
+    #[wasm_bindgen(js_name = "toBooleanLossy")]
+    pub fn to_boolean_lossy(&self) -> Boolean {
         Boolean::new(self.0.to_x_coordinate().to_bits_le()[0])
     }
 
-    /// Cast the group element to an Address.
+    /// Cast the group element to an Address (lossless — Address wraps Group).
     #[wasm_bindgen(js_name = "toAddress")]
     pub fn to_address(&self) -> Address {
         Address::from_group(self.clone())
@@ -228,62 +228,62 @@ impl Group {
     // Group → Integer lossy conversions (via x-coordinate)
 
     /// Cast the group to a U8 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU8")]
-    pub fn to_u8(&self) -> U8 {
+    #[wasm_bindgen(js_name = "toU8Lossy")]
+    pub fn to_u8_lossy(&self) -> U8 {
         U8::from(U8Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
     /// Cast the group to a U16 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU16")]
-    pub fn to_u16(&self) -> U16 {
+    #[wasm_bindgen(js_name = "toU16Lossy")]
+    pub fn to_u16_lossy(&self) -> U16 {
         U16::from(U16Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
     /// Cast the group to a U32 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU32")]
-    pub fn to_u32(&self) -> U32 {
+    #[wasm_bindgen(js_name = "toU32Lossy")]
+    pub fn to_u32_lossy(&self) -> U32 {
         U32::from(U32Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
     /// Cast the group to a U64 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU64")]
-    pub fn to_u64(&self) -> U64 {
+    #[wasm_bindgen(js_name = "toU64Lossy")]
+    pub fn to_u64_lossy(&self) -> U64 {
         U64::from(U64Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
     /// Cast the group to a U128 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU128")]
-    pub fn to_u128(&self) -> U128 {
+    #[wasm_bindgen(js_name = "toU128Lossy")]
+    pub fn to_u128_lossy(&self) -> U128 {
         U128::from(U128Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
     /// Cast the group to an I8 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI8")]
-    pub fn to_i8(&self) -> I8 {
+    #[wasm_bindgen(js_name = "toI8Lossy")]
+    pub fn to_i8_lossy(&self) -> I8 {
         I8::from(I8Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
     /// Cast the group to an I16 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI16")]
-    pub fn to_i16(&self) -> I16 {
+    #[wasm_bindgen(js_name = "toI16Lossy")]
+    pub fn to_i16_lossy(&self) -> I16 {
         I16::from(I16Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
     /// Cast the group to an I32 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI32")]
-    pub fn to_i32(&self) -> I32 {
+    #[wasm_bindgen(js_name = "toI32Lossy")]
+    pub fn to_i32_lossy(&self) -> I32 {
         I32::from(I32Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
     /// Cast the group to an I64 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI64")]
-    pub fn to_i64(&self) -> I64 {
+    #[wasm_bindgen(js_name = "toI64Lossy")]
+    pub fn to_i64_lossy(&self) -> I64 {
         I64::from(I64Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 
     /// Cast the group to an I128 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI128")]
-    pub fn to_i128(&self) -> I128 {
+    #[wasm_bindgen(js_name = "toI128Lossy")]
+    pub fn to_i128_lossy(&self) -> I128 {
         I128::from(I128Native::from_field_lossy(&self.0.to_x_coordinate()))
     }
 }

--- a/wasm/src/types/integer.rs
+++ b/wasm/src/types/integer.rs
@@ -14,26 +14,34 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{from_js_typed_array, to_bits_array_le, types::native::*};
-// use crate::types::{U8, U16, U32};
-use crate::Plaintext;
+use crate::{
+    Address,
+    Plaintext,
+    from_js_typed_array,
+    to_bits_array_le,
+    types::{Boolean, Field, Group, native::*},
+};
 use js_sys::{Array, Uint8Array};
-use snarkvm_console::prelude::{
-    AbsChecked,
-    AbsWrapped,
-    AddWrapped,
-    DivWrapped,
-    FromBits,
-    FromBytes,
-    FromField,
-    FromFields,
-    MulWrapped,
-    Pow,
-    Rem,
-    RemWrapped,
-    SubWrapped,
-    ToBits,
-    ToBytes,
+use snarkvm_console::{
+    prelude::{
+        AbsChecked,
+        AbsWrapped,
+        AddWrapped,
+        DivWrapped,
+        FromBits,
+        FromBytes,
+        FromField,
+        FromFields,
+        MulWrapped,
+        Pow,
+        Rem,
+        RemWrapped,
+        SubWrapped,
+        ToBits,
+        ToBytes,
+        ToField,
+    },
+    program::CastLossy,
 };
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
@@ -205,6 +213,41 @@ macro_rules! impl_integer {
             pub fn clone(&self) -> $name {
                 $name(self.0)
             }
+
+            // ── cast_lossy conversions ──────────────────────────────────
+
+            /// Convert the integer to a Field element (lossless).
+            #[wasm_bindgen(js_name = "toField")]
+            pub fn to_field(&self) -> Result<Field, String> {
+                Ok(Field::from(self.0.to_field().map_err(|e| e.to_string())?))
+            }
+
+            /// Construct an integer from a field element with lossy truncation.
+            #[wasm_bindgen(js_name = "fromFieldLossy")]
+            pub fn from_field_lossy(field: &Field) -> $name {
+                Self(<$native>::from_field_lossy(&FieldNative::from(field)))
+            }
+
+            /// Cast the integer to a Boolean (extracts least-significant bit).
+            #[wasm_bindgen(js_name = "toBoolean")]
+            pub fn to_boolean(&self) -> Boolean {
+                Boolean::new(self.0.to_bits_le()[0])
+            }
+
+            /// Cast the integer to a Group element (via Field, Elligator-2 fallback).
+            #[wasm_bindgen(js_name = "toGroup")]
+            pub fn to_group(&self) -> Group {
+                // Safe: Integer::to_field() is infallible for all valid integer values.
+                let field = self.0.to_field().unwrap();
+                let group: GroupNative = field.cast_lossy();
+                Group::from(group)
+            }
+
+            /// Cast the integer to an Address (via Group).
+            #[wasm_bindgen(js_name = "toAddress")]
+            pub fn to_address(&self) -> Address {
+                Address::from_group(self.to_group())
+            }
         }
 
         impl Deref for $name {
@@ -253,3 +296,174 @@ impl_integer!(U16, U16Native);
 impl_integer!(U32, U32Native);
 impl_integer!(U64, U64Native);
 impl_integer!(U128, U128Native);
+
+// ── Integer cross-cast macro ───────────────────────────────────────────
+// Stamps out lossy cross-cast methods (e.g. U32.toU8(), I64.toU32()) for
+// all 10 integer types. Each conversion goes through Field as the
+// universal intermediate: source.to_field() -> TargetNative::from_field_lossy().
+
+// Safe: Integer::to_field() is infallible for all valid integer values in snarkVM.
+macro_rules! impl_integer_cross_casts {
+    ($source:ident) => {
+        #[wasm_bindgen]
+        impl $source {
+            /// Cast to U8 with lossy truncation.
+            #[wasm_bindgen(js_name = "toU8")]
+            pub fn to_u8(&self) -> U8 {
+                U8::from(U8Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+
+            /// Cast to U16 with lossy truncation.
+            #[wasm_bindgen(js_name = "toU16")]
+            pub fn to_u16(&self) -> U16 {
+                U16::from(U16Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+
+            /// Cast to U32 with lossy truncation.
+            #[wasm_bindgen(js_name = "toU32")]
+            pub fn to_u32(&self) -> U32 {
+                U32::from(U32Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+
+            /// Cast to U64 with lossy truncation.
+            #[wasm_bindgen(js_name = "toU64")]
+            pub fn to_u64(&self) -> U64 {
+                U64::from(U64Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+
+            /// Cast to U128 with lossy truncation.
+            #[wasm_bindgen(js_name = "toU128")]
+            pub fn to_u128(&self) -> U128 {
+                U128::from(U128Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+
+            /// Cast to I8 with lossy truncation.
+            #[wasm_bindgen(js_name = "toI8")]
+            pub fn to_i8(&self) -> I8 {
+                I8::from(I8Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+
+            /// Cast to I16 with lossy truncation.
+            #[wasm_bindgen(js_name = "toI16")]
+            pub fn to_i16(&self) -> I16 {
+                I16::from(I16Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+
+            /// Cast to I32 with lossy truncation.
+            #[wasm_bindgen(js_name = "toI32")]
+            pub fn to_i32(&self) -> I32 {
+                I32::from(I32Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+
+            /// Cast to I64 with lossy truncation.
+            #[wasm_bindgen(js_name = "toI64")]
+            pub fn to_i64(&self) -> I64 {
+                I64::from(I64Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+
+            /// Cast to I128 with lossy truncation.
+            #[wasm_bindgen(js_name = "toI128")]
+            pub fn to_i128(&self) -> I128 {
+                I128::from(I128Native::from_field_lossy(&self.0.to_field().unwrap()))
+            }
+        }
+    };
+}
+
+impl_integer_cross_casts!(I8);
+impl_integer_cross_casts!(I16);
+impl_integer_cross_casts!(I32);
+impl_integer_cross_casts!(I64);
+impl_integer_cross_casts!(I128);
+impl_integer_cross_casts!(U8);
+impl_integer_cross_casts!(U16);
+impl_integer_cross_casts!(U32);
+impl_integer_cross_casts!(U64);
+impl_integer_cross_casts!(U128);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_integer_to_field_roundtrip() {
+        let val = U32::from_string("42u32").unwrap();
+        let field = val.to_field().unwrap();
+        let back = U32::from_field(&field).unwrap();
+        assert_eq!(val, back);
+    }
+
+    #[test]
+    fn test_integer_from_field_lossy_roundtrip() {
+        // In-range values should round-trip through from_field_lossy
+        let val = U8::from_string("200u8").unwrap();
+        let field = val.to_field().unwrap();
+        let back = U8::from_field_lossy(&field);
+        assert_eq!(val, back);
+    }
+
+    #[test]
+    fn test_integer_to_boolean() {
+        let zero = U32::from_string("0u32").unwrap();
+        assert_eq!(zero.to_boolean().to_string(), "false");
+
+        let one = U32::from_string("1u32").unwrap();
+        assert_eq!(one.to_boolean().to_string(), "true");
+
+        let even = U32::from_string("4u32").unwrap();
+        assert_eq!(even.to_boolean().to_string(), "false");
+
+        let odd = U32::from_string("5u32").unwrap();
+        assert_eq!(odd.to_boolean().to_string(), "true");
+    }
+
+    #[test]
+    fn test_integer_to_group() {
+        let val = U32::from_string("42u32").unwrap();
+        let _group = val.to_group(); // Should not panic
+    }
+
+    #[test]
+    fn test_integer_to_address() {
+        let val = U32::from_string("42u32").unwrap();
+        let addr = val.to_address();
+        assert!(addr.to_string().starts_with("aleo1"));
+    }
+
+    #[test]
+    fn test_cross_cast_identity() {
+        // U32 → U32 should be identity
+        let val = U32::from_string("42u32").unwrap();
+        let cast = val.to_u32();
+        assert_eq!(val, cast);
+    }
+
+    #[test]
+    fn test_cross_cast_widening() {
+        // U8(255) → U32 should preserve value
+        let val = U8::from_string("255u8").unwrap();
+        let wide = val.to_u32();
+        assert_eq!(wide.to_string(), "255u32");
+    }
+
+    #[test]
+    fn test_cross_cast_narrowing() {
+        // U32(256) → U8 should truncate to 0
+        let val = U32::from_string("256u32").unwrap();
+        let narrow = val.to_u8();
+        assert_eq!(narrow.to_string(), "0u8");
+
+        // U32(257) → U8 should truncate to 1
+        let val = U32::from_string("257u32").unwrap();
+        let narrow = val.to_u8();
+        assert_eq!(narrow.to_string(), "1u8");
+    }
+
+    #[test]
+    fn test_cross_cast_signed_unsigned() {
+        // I32(42) → U32 should be 42
+        let val = I32::from_string("42i32").unwrap();
+        let cast = val.to_u32();
+        assert_eq!(cast.to_string(), "42u32");
+    }
+}

--- a/wasm/src/types/integer.rs
+++ b/wasm/src/types/integer.rs
@@ -15,33 +15,29 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    Address,
     Plaintext,
     from_js_typed_array,
     to_bits_array_le,
-    types::{Boolean, Field, Group, native::*},
+    types::{Boolean, Field, native::*},
 };
 use js_sys::{Array, Uint8Array};
-use snarkvm_console::{
-    prelude::{
-        AbsChecked,
-        AbsWrapped,
-        AddWrapped,
-        DivWrapped,
-        FromBits,
-        FromBytes,
-        FromField,
-        FromFields,
-        MulWrapped,
-        Pow,
-        Rem,
-        RemWrapped,
-        SubWrapped,
-        ToBits,
-        ToBytes,
-        ToField,
-    },
-    program::CastLossy,
+use snarkvm_console::prelude::{
+    AbsChecked,
+    AbsWrapped,
+    AddWrapped,
+    DivWrapped,
+    FromBits,
+    FromBytes,
+    FromField,
+    FromFields,
+    MulWrapped,
+    Pow,
+    Rem,
+    RemWrapped,
+    SubWrapped,
+    ToBits,
+    ToBytes,
+    ToField,
 };
 use std::{ops::Deref, str::FromStr};
 use wasm_bindgen::prelude::*;
@@ -214,7 +210,7 @@ macro_rules! impl_integer {
                 $name(self.0)
             }
 
-            // ── cast_lossy conversions ──────────────────────────────────
+            // ── cast conversions ────────────────────────────────────────
 
             /// Convert the integer to a Field element (lossless).
             #[wasm_bindgen(js_name = "toField")]
@@ -228,25 +224,10 @@ macro_rules! impl_integer {
                 Self(<$native>::from_field_lossy(&FieldNative::from(field)))
             }
 
-            /// Cast the integer to a Boolean (extracts least-significant bit).
-            #[wasm_bindgen(js_name = "toBoolean")]
-            pub fn to_boolean(&self) -> Boolean {
+            /// Cast the integer to a Boolean with lossy truncation (extracts least-significant bit).
+            #[wasm_bindgen(js_name = "toBooleanLossy")]
+            pub fn to_boolean_lossy(&self) -> Boolean {
                 Boolean::new(self.0.to_bits_le()[0])
-            }
-
-            /// Cast the integer to a Group element (via Field, Elligator-2 fallback).
-            #[wasm_bindgen(js_name = "toGroup")]
-            pub fn to_group(&self) -> Group {
-                // Safe: Integer::to_field() is infallible for all valid integer values.
-                let field = self.0.to_field().unwrap();
-                let group: GroupNative = field.cast_lossy();
-                Group::from(group)
-            }
-
-            /// Cast the integer to an Address (via Group).
-            #[wasm_bindgen(js_name = "toAddress")]
-            pub fn to_address(&self) -> Address {
-                Address::from_group(self.to_group())
             }
         }
 
@@ -302,69 +283,68 @@ impl_integer!(U128, U128Native);
 // all 10 integer types. Each conversion goes through Field as the
 // universal intermediate: source.to_field() -> TargetNative::from_field_lossy().
 
-// Safe: Integer::to_field() is infallible for all valid integer values in snarkVM.
 macro_rules! impl_integer_cross_casts {
     ($source:ident) => {
         #[wasm_bindgen]
         impl $source {
             /// Cast to U8 with lossy truncation.
-            #[wasm_bindgen(js_name = "toU8")]
-            pub fn to_u8(&self) -> U8 {
-                U8::from(U8Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toU8Lossy")]
+            pub fn to_u8_lossy(&self) -> Result<U8, String> {
+                Ok(U8::from(U8Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
 
             /// Cast to U16 with lossy truncation.
-            #[wasm_bindgen(js_name = "toU16")]
-            pub fn to_u16(&self) -> U16 {
-                U16::from(U16Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toU16Lossy")]
+            pub fn to_u16_lossy(&self) -> Result<U16, String> {
+                Ok(U16::from(U16Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
 
             /// Cast to U32 with lossy truncation.
-            #[wasm_bindgen(js_name = "toU32")]
-            pub fn to_u32(&self) -> U32 {
-                U32::from(U32Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toU32Lossy")]
+            pub fn to_u32_lossy(&self) -> Result<U32, String> {
+                Ok(U32::from(U32Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
 
             /// Cast to U64 with lossy truncation.
-            #[wasm_bindgen(js_name = "toU64")]
-            pub fn to_u64(&self) -> U64 {
-                U64::from(U64Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toU64Lossy")]
+            pub fn to_u64_lossy(&self) -> Result<U64, String> {
+                Ok(U64::from(U64Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
 
             /// Cast to U128 with lossy truncation.
-            #[wasm_bindgen(js_name = "toU128")]
-            pub fn to_u128(&self) -> U128 {
-                U128::from(U128Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toU128Lossy")]
+            pub fn to_u128_lossy(&self) -> Result<U128, String> {
+                Ok(U128::from(U128Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
 
             /// Cast to I8 with lossy truncation.
-            #[wasm_bindgen(js_name = "toI8")]
-            pub fn to_i8(&self) -> I8 {
-                I8::from(I8Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toI8Lossy")]
+            pub fn to_i8_lossy(&self) -> Result<I8, String> {
+                Ok(I8::from(I8Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
 
             /// Cast to I16 with lossy truncation.
-            #[wasm_bindgen(js_name = "toI16")]
-            pub fn to_i16(&self) -> I16 {
-                I16::from(I16Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toI16Lossy")]
+            pub fn to_i16_lossy(&self) -> Result<I16, String> {
+                Ok(I16::from(I16Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
 
             /// Cast to I32 with lossy truncation.
-            #[wasm_bindgen(js_name = "toI32")]
-            pub fn to_i32(&self) -> I32 {
-                I32::from(I32Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toI32Lossy")]
+            pub fn to_i32_lossy(&self) -> Result<I32, String> {
+                Ok(I32::from(I32Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
 
             /// Cast to I64 with lossy truncation.
-            #[wasm_bindgen(js_name = "toI64")]
-            pub fn to_i64(&self) -> I64 {
-                I64::from(I64Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toI64Lossy")]
+            pub fn to_i64_lossy(&self) -> Result<I64, String> {
+                Ok(I64::from(I64Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
 
             /// Cast to I128 with lossy truncation.
-            #[wasm_bindgen(js_name = "toI128")]
-            pub fn to_i128(&self) -> I128 {
-                I128::from(I128Native::from_field_lossy(&self.0.to_field().unwrap()))
+            #[wasm_bindgen(js_name = "toI128Lossy")]
+            pub fn to_i128_lossy(&self) -> Result<I128, String> {
+                Ok(I128::from(I128Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
             }
         }
     };
@@ -403,67 +383,44 @@ mod tests {
     }
 
     #[test]
-    fn test_integer_to_boolean() {
+    fn test_integer_to_boolean_lossy() {
         let zero = U32::from_string("0u32").unwrap();
-        assert_eq!(zero.to_boolean().to_string(), "false");
+        assert_eq!(zero.to_boolean_lossy().to_string(), "false");
 
         let one = U32::from_string("1u32").unwrap();
-        assert_eq!(one.to_boolean().to_string(), "true");
+        assert_eq!(one.to_boolean_lossy().to_string(), "true");
 
         let even = U32::from_string("4u32").unwrap();
-        assert_eq!(even.to_boolean().to_string(), "false");
+        assert_eq!(even.to_boolean_lossy().to_string(), "false");
 
         let odd = U32::from_string("5u32").unwrap();
-        assert_eq!(odd.to_boolean().to_string(), "true");
-    }
-
-    #[test]
-    fn test_integer_to_group() {
-        let val = U32::from_string("42u32").unwrap();
-        let _group = val.to_group(); // Should not panic
-    }
-
-    #[test]
-    fn test_integer_to_address() {
-        let val = U32::from_string("42u32").unwrap();
-        let addr = val.to_address();
-        assert!(addr.to_string().starts_with("aleo1"));
+        assert_eq!(odd.to_boolean_lossy().to_string(), "true");
     }
 
     #[test]
     fn test_cross_cast_identity() {
-        // U32 → U32 should be identity
         let val = U32::from_string("42u32").unwrap();
-        let cast = val.to_u32();
+        let cast = val.to_u32_lossy().unwrap();
         assert_eq!(val, cast);
     }
 
     #[test]
     fn test_cross_cast_widening() {
-        // U8(255) → U32 should preserve value
         let val = U8::from_string("255u8").unwrap();
-        let wide = val.to_u32();
+        let wide = val.to_u32_lossy().unwrap();
         assert_eq!(wide.to_string(), "255u32");
     }
 
     #[test]
     fn test_cross_cast_narrowing() {
-        // U32(256) → U8 should truncate to 0
-        let val = U32::from_string("256u32").unwrap();
-        let narrow = val.to_u8();
-        assert_eq!(narrow.to_string(), "0u8");
-
-        // U32(257) → U8 should truncate to 1
-        let val = U32::from_string("257u32").unwrap();
-        let narrow = val.to_u8();
-        assert_eq!(narrow.to_string(), "1u8");
+        assert_eq!(U32::from_string("256u32").unwrap().to_u8_lossy().unwrap().to_string(), "0u8");
+        assert_eq!(U32::from_string("257u32").unwrap().to_u8_lossy().unwrap().to_string(), "1u8");
     }
 
     #[test]
     fn test_cross_cast_signed_unsigned() {
-        // I32(42) → U32 should be 42
         let val = I32::from_string("42i32").unwrap();
-        let cast = val.to_u32();
+        let cast = val.to_u32_lossy().unwrap();
         assert_eq!(cast.to_string(), "42u32");
     }
 }

--- a/wasm/src/types/scalar.rs
+++ b/wasm/src/types/scalar.rs
@@ -44,7 +44,7 @@ use crate::{
     },
 };
 use snarkvm_console::{
-    prelude::{Double, FromBits, FromBytes, One, Pow, ToBits, ToBytes, ToField, Uniform, Zero},
+    prelude::{Double, FromBits, FromBytes, FromField, One, Pow, ToBits, ToBytes, ToField, Uniform, Zero},
     program::CastLossy,
 };
 
@@ -175,90 +175,116 @@ impl Scalar {
         self.0 == ScalarNative::from(other)
     }
 
-    // ── cast_lossy conversions ──────────────────────────────────────────
+    // ── cast conversions ───────────────────────────────────────────────
 
-    /// Cast the scalar to a Boolean (extracts least-significant bit).
+    /// Cast the scalar to a Boolean (strict).
+    /// Returns an error if the scalar is not zero or one.
     #[wasm_bindgen(js_name = "toBoolean")]
-    pub fn to_boolean(&self) -> Boolean {
+    pub fn to_boolean(&self) -> Result<Boolean, String> {
+        if self.0.is_zero() {
+            Ok(Boolean::new(false))
+        } else if self.0.is_one() {
+            Ok(Boolean::new(true))
+        } else {
+            Err("Failed to convert scalar to boolean: scalar is not zero or one".to_string())
+        }
+    }
+
+    /// Cast the scalar to a Boolean with lossy truncation (extracts least-significant bit).
+    #[wasm_bindgen(js_name = "toBooleanLossy")]
+    pub fn to_boolean_lossy(&self) -> Boolean {
         Boolean::new(self.0.to_bits_le()[0])
     }
 
-    /// Cast the scalar to a Group element (via Field, then Elligator-2 fallback).
+    /// Cast the scalar to a Group element (strict, via Field x-coordinate recovery).
+    /// Returns an error if the resulting field is not a valid x-coordinate on the curve.
     #[wasm_bindgen(js_name = "toGroup")]
-    pub fn to_group(&self) -> Group {
-        // Safe: Scalar::to_field() is infallible for all valid scalar values.
-        let field: FieldNative = self.0.to_field().unwrap();
-        let group: GroupNative = field.cast_lossy();
-        Group::from(group)
+    pub fn to_group(&self) -> Result<Group, String> {
+        let field: FieldNative = self.0.to_field().map_err(|e| e.to_string())?;
+        Ok(Group::from(GroupNative::from_field(&field).map_err(|e| e.to_string())?))
     }
 
-    /// Cast the scalar to an Address (via Group).
+    /// Cast the scalar to a Group element with lossy conversion (via Field, Elligator-2 fallback).
+    #[wasm_bindgen(js_name = "toGroupLossy")]
+    pub fn to_group_lossy(&self) -> Result<Group, String> {
+        let field: FieldNative = self.0.to_field().map_err(|e| e.to_string())?;
+        let group: GroupNative = field.cast_lossy();
+        Ok(Group::from(group))
+    }
+
+    /// Cast the scalar to an Address (strict, via Field x-coordinate recovery).
+    /// Returns an error if the resulting field is not a valid x-coordinate on the curve.
     #[wasm_bindgen(js_name = "toAddress")]
-    pub fn to_address(&self) -> Address {
-        Address::from_group(self.to_group())
+    pub fn to_address(&self) -> Result<Address, String> {
+        Ok(Address::from_group(self.to_group()?))
+    }
+
+    /// Cast the scalar to an Address with lossy conversion (via Group, Elligator-2 fallback).
+    #[wasm_bindgen(js_name = "toAddressLossy")]
+    pub fn to_address_lossy(&self) -> Result<Address, String> {
+        Ok(Address::from_group(self.to_group_lossy()?))
     }
 
     // Scalar → Integer lossy conversions
-    // Safe: Scalar::to_field() is infallible for all valid scalar values.
 
     /// Cast the scalar to a U8 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU8")]
-    pub fn to_u8(&self) -> U8 {
-        U8::from(U8Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toU8Lossy")]
+    pub fn to_u8_lossy(&self) -> Result<U8, String> {
+        Ok(U8::from(U8Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 
     /// Cast the scalar to a U16 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU16")]
-    pub fn to_u16(&self) -> U16 {
-        U16::from(U16Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toU16Lossy")]
+    pub fn to_u16_lossy(&self) -> Result<U16, String> {
+        Ok(U16::from(U16Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 
     /// Cast the scalar to a U32 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU32")]
-    pub fn to_u32(&self) -> U32 {
-        U32::from(U32Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toU32Lossy")]
+    pub fn to_u32_lossy(&self) -> Result<U32, String> {
+        Ok(U32::from(U32Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 
     /// Cast the scalar to a U64 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU64")]
-    pub fn to_u64(&self) -> U64 {
-        U64::from(U64Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toU64Lossy")]
+    pub fn to_u64_lossy(&self) -> Result<U64, String> {
+        Ok(U64::from(U64Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 
     /// Cast the scalar to a U128 with lossy truncation.
-    #[wasm_bindgen(js_name = "toU128")]
-    pub fn to_u128(&self) -> U128 {
-        U128::from(U128Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toU128Lossy")]
+    pub fn to_u128_lossy(&self) -> Result<U128, String> {
+        Ok(U128::from(U128Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 
     /// Cast the scalar to an I8 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI8")]
-    pub fn to_i8(&self) -> I8 {
-        I8::from(I8Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toI8Lossy")]
+    pub fn to_i8_lossy(&self) -> Result<I8, String> {
+        Ok(I8::from(I8Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 
     /// Cast the scalar to an I16 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI16")]
-    pub fn to_i16(&self) -> I16 {
-        I16::from(I16Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toI16Lossy")]
+    pub fn to_i16_lossy(&self) -> Result<I16, String> {
+        Ok(I16::from(I16Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 
     /// Cast the scalar to an I32 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI32")]
-    pub fn to_i32(&self) -> I32 {
-        I32::from(I32Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toI32Lossy")]
+    pub fn to_i32_lossy(&self) -> Result<I32, String> {
+        Ok(I32::from(I32Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 
     /// Cast the scalar to an I64 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI64")]
-    pub fn to_i64(&self) -> I64 {
-        I64::from(I64Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toI64Lossy")]
+    pub fn to_i64_lossy(&self) -> Result<I64, String> {
+        Ok(I64::from(I64Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 
     /// Cast the scalar to an I128 with lossy truncation.
-    #[wasm_bindgen(js_name = "toI128")]
-    pub fn to_i128(&self) -> I128 {
-        I128::from(I128Native::from_field_lossy(&self.0.to_field().unwrap()))
+    #[wasm_bindgen(js_name = "toI128Lossy")]
+    pub fn to_i128_lossy(&self) -> Result<I128, String> {
+        Ok(I128::from(I128Native::from_field_lossy(&self.0.to_field().map_err(|e| e.to_string())?)))
     }
 }
 

--- a/wasm/src/types/scalar.rs
+++ b/wasm/src/types/scalar.rs
@@ -15,13 +15,38 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    Address,
     Field,
     Plaintext,
     from_js_typed_array,
     to_bits_array_le,
-    types::native::{LiteralNative, PlaintextNative, ScalarNative},
+    types::{
+        Boolean,
+        Group,
+        integer::{I8, I16, I32, I64, I128, U8, U16, U32, U64, U128},
+        native::{
+            FieldNative,
+            GroupNative,
+            I8Native,
+            I16Native,
+            I32Native,
+            I64Native,
+            I128Native,
+            LiteralNative,
+            PlaintextNative,
+            ScalarNative,
+            U8Native,
+            U16Native,
+            U32Native,
+            U64Native,
+            U128Native,
+        },
+    },
 };
-use snarkvm_console::prelude::{Double, FromBits, FromBytes, One, Pow, ToBits, ToBytes, ToField, Uniform, Zero};
+use snarkvm_console::{
+    prelude::{Double, FromBits, FromBytes, One, Pow, ToBits, ToBytes, ToField, Uniform, Zero},
+    program::CastLossy,
+};
 
 use js_sys::{Array, Uint8Array};
 use std::{ops::Deref, str::FromStr, sync::OnceLock};
@@ -148,6 +173,92 @@ impl Scalar {
     /// Check if one scalar element equals another.
     pub fn equals(&self, other: &Scalar) -> bool {
         self.0 == ScalarNative::from(other)
+    }
+
+    // ── cast_lossy conversions ──────────────────────────────────────────
+
+    /// Cast the scalar to a Boolean (extracts least-significant bit).
+    #[wasm_bindgen(js_name = "toBoolean")]
+    pub fn to_boolean(&self) -> Boolean {
+        Boolean::new(self.0.to_bits_le()[0])
+    }
+
+    /// Cast the scalar to a Group element (via Field, then Elligator-2 fallback).
+    #[wasm_bindgen(js_name = "toGroup")]
+    pub fn to_group(&self) -> Group {
+        // Safe: Scalar::to_field() is infallible for all valid scalar values.
+        let field: FieldNative = self.0.to_field().unwrap();
+        let group: GroupNative = field.cast_lossy();
+        Group::from(group)
+    }
+
+    /// Cast the scalar to an Address (via Group).
+    #[wasm_bindgen(js_name = "toAddress")]
+    pub fn to_address(&self) -> Address {
+        Address::from_group(self.to_group())
+    }
+
+    // Scalar → Integer lossy conversions
+    // Safe: Scalar::to_field() is infallible for all valid scalar values.
+
+    /// Cast the scalar to a U8 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU8")]
+    pub fn to_u8(&self) -> U8 {
+        U8::from(U8Native::from_field_lossy(&self.0.to_field().unwrap()))
+    }
+
+    /// Cast the scalar to a U16 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU16")]
+    pub fn to_u16(&self) -> U16 {
+        U16::from(U16Native::from_field_lossy(&self.0.to_field().unwrap()))
+    }
+
+    /// Cast the scalar to a U32 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU32")]
+    pub fn to_u32(&self) -> U32 {
+        U32::from(U32Native::from_field_lossy(&self.0.to_field().unwrap()))
+    }
+
+    /// Cast the scalar to a U64 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU64")]
+    pub fn to_u64(&self) -> U64 {
+        U64::from(U64Native::from_field_lossy(&self.0.to_field().unwrap()))
+    }
+
+    /// Cast the scalar to a U128 with lossy truncation.
+    #[wasm_bindgen(js_name = "toU128")]
+    pub fn to_u128(&self) -> U128 {
+        U128::from(U128Native::from_field_lossy(&self.0.to_field().unwrap()))
+    }
+
+    /// Cast the scalar to an I8 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI8")]
+    pub fn to_i8(&self) -> I8 {
+        I8::from(I8Native::from_field_lossy(&self.0.to_field().unwrap()))
+    }
+
+    /// Cast the scalar to an I16 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI16")]
+    pub fn to_i16(&self) -> I16 {
+        I16::from(I16Native::from_field_lossy(&self.0.to_field().unwrap()))
+    }
+
+    /// Cast the scalar to an I32 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI32")]
+    pub fn to_i32(&self) -> I32 {
+        I32::from(I32Native::from_field_lossy(&self.0.to_field().unwrap()))
+    }
+
+    /// Cast the scalar to an I64 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI64")]
+    pub fn to_i64(&self) -> I64 {
+        I64::from(I64Native::from_field_lossy(&self.0.to_field().unwrap()))
+    }
+
+    /// Cast the scalar to an I128 with lossy truncation.
+    #[wasm_bindgen(js_name = "toI128")]
+    pub fn to_i128(&self) -> I128 {
+        I128::from(I128Native::from_field_lossy(&self.0.to_field().unwrap()))
     }
 }
 


### PR DESCRIPTION
## Motivation

Aleo programs frequently need to cast between scalar types (field, group, scalar, boolean, integers). Currently the WASM layer doesn't expose these conversions, forcing SDK users to serialize to string, cross the WASM boundary, and re-parse, adding unnecessary overhead and complexity. This PR adds direct lossy cross-cast bindings (`toField`, `toGroup`, `toScalar`, `toBoolean`, `toU8`–`toI128`, `toAddress`) to all WASM scalar types, matching snarkVM's `cast_lossy` semantics. All conversions go through the field representation, with truncation for narrowing casts and mapping for field→group.

## Test Plan

- `yarn build:sdk` - TS compiles cleanly
- TS tests in `sdk/tests/cast-lossy.test.ts` covering:
  - **Field**: round-trip Field→Scalar→Field, Field→Group, Field→Address, Field→integers (U8–I128), Field→Boolean
  - **Integer**: cross-cast between integer types (U32→U8 truncation, U8→U32 widening), Integer→Field round-trip, Integer→Group, Integer→Scalar, Integer→Boolean, Integer→Address
  - **Boolean**: Boolean→Field (false=0, true=1), Boolean→integers, Boolean→Scalar, Boolean→Group, Boolean→Address
  - **Scalar**: Scalar→Field round-trip, Scalar→Group, Scalar→integers, Scalar→Boolean, Scalar→Address
  - **Group**: Group→Field, Group→Scalar, Group→integers, Group→Boolean, Group→Address, Address→Group round-trip
  - **Address**: Address→Field, Address→Group round-trip, Address→Scalar, Address→integers, Address→Boolean
- Existing `ExecutionRequest` error handling tests retained and passing
- Rust unit tests in `integer.rs` cover narrowing, widening, signed cross-casts, and `fromField`/`fromFieldLossy`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds many new WASM-exported conversion methods across core scalar types (Field/Scalar/Group/Boolean/integers/Address), which expands the public API and could introduce subtle semantic mismatches or edge-case bugs in lossy casting behavior. Changes are mostly additive and covered by new Rust and TS tests, reducing regression risk.
> 
> **Overview**
> Adds a comprehensive set of WASM bindings for *lossy and strict cross-type casts* between `Field`, `Scalar`, `Group`, `Boolean`, `Address`, and all integer types (`U8`–`U128`, `I8`–`I128`), generally routing through field representations and matching snarkVM `cast_lossy` semantics (including Elligator-2 fallback for `toGroupLossy`).
> 
> Introduces an integer cross-cast macro to generate `to*Lossy` methods for every integer-to-integer combination, plus new helpers like integer `toField`, `fromFieldLossy`, and `toBooleanLossy`, and adds coverage via a new `sdk/tests/cast-lossy.test.ts` suite and new Rust unit tests in `field.rs` and `integer.rs` (with a minor formatting fix in `sdk/tests/wasm.test.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18d8ac1ee80826ca9ab37db4fc174b1195978484. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->