### PR TITLE
[Chore] Bump version to v0.10.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Yarn monorepo for the **Provable SDK** — a TypeScript/Rust SDK for building zero-knowledge applications on the Aleo 
 blockchain. The SDK re-exports core protocol objects from SnarkVM to allow users to perform operations related to their
-accounts and execute Aleo programs. Main published packages: `@provablehq/sdk` and `@provablehq/wasm` (both v0.10.1).
+accounts and execute Aleo programs. Main published packages: `@provablehq/sdk` and `@provablehq/wasm` (both v0.10.2).
 
 **Workspaces:** `sdk`, `wasm`, `create-leo-app`
 

--- a/create-leo-app/package.json
+++ b/create-leo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-leo-app",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "license": "GPL-3.0",
   "collaborators": [

--- a/create-leo-app/template-build-and-execute-authorization-ts/package.json
+++ b/create-leo-app/template-build-and-execute-authorization-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1"
+    "@provablehq/sdk": "^0.10.2"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-devnode-js/package.json
+++ b/create-leo-app/template-devnode-js/package.json
@@ -7,6 +7,6 @@
     "dev": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1"
+    "@provablehq/sdk": "^0.10.2"
   }
 }

--- a/create-leo-app/template-extension/package.json
+++ b/create-leo-app/template-extension/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf static/js && rollup --config"
   },
   "devDependencies": {
-    "@provablehq/sdk": "^0.10.1",
+    "@provablehq/sdk": "^0.10.2",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@web/rollup-plugin-import-meta-assets": "^2.2.1",
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-nextjs-ts/package.json
+++ b/create-leo-app/template-nextjs-ts/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1",
+    "@provablehq/sdk": "^0.10.2",
     "next": "15.5.14",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/create-leo-app/template-node-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-node-credits-aleo-functions-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.1"
+        "@provablehq/sdk": "^0.10.2"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
+++ b/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.0"
+        "@provablehq/sdk": "^0.10.2"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-ts/package.json
+++ b/create-leo-app/template-node-ts/package.json
@@ -10,7 +10,7 @@
     "test": "npm run build && node dist/index.js && node dist/dynamic-dispatch.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1"
+    "@provablehq/sdk": "^0.10.2"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-node/package.json
+++ b/create-leo-app/template-node/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1"
+    "@provablehq/sdk": "^0.10.2"
   }
 }

--- a/create-leo-app/template-offline-public-transaction-ts/package.json
+++ b/create-leo-app/template-offline-public-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node --trace-uncaught dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1"
+    "@provablehq/sdk": "^0.10.2"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-private-transaction-ts/package.json
+++ b/create-leo-app/template-private-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1"
+    "@provablehq/sdk": "^0.10.2"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-react-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-react-credits-aleo-functions-ts/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.1",
+        "@provablehq/sdk": "^0.10.2",
         "comlink": "^4.4.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-leo/package.json
+++ b/create-leo-app/template-react-leo/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1",
+    "@provablehq/sdk": "^0.10.2",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-managed-worker/package.json
+++ b/create-leo-app/template-react-managed-worker/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1",
+    "@provablehq/sdk": "^0.10.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/create-leo-app/template-react-ts/package.json
+++ b/create-leo-app/template-react-ts/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1",
+    "@provablehq/sdk": "^0.10.2",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-vanilla/package.json
+++ b/create-leo-app/template-vanilla/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@provablehq/sdk": "^0.10.1",
+        "@provablehq/sdk": "^0.10.2",
         "tslib": "^2.8.1",
         "vite": "^6.4.2"
     }

--- a/e2e/dynamic/package.json
+++ b/e2e/dynamic/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1"
+    "@provablehq/sdk": "^0.10.2"
   }
 }

--- a/e2e/mainnet/package.json
+++ b/e2e/mainnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1"
+    "@provablehq/sdk": "^0.10.2"
   }
 }

--- a/e2e/nodenext/package.json
+++ b/e2e/nodenext/package.json
@@ -2,7 +2,7 @@
     "name": "nodenext",
     "type": "module",
     "dependencies": {
-        "@provablehq/sdk": "^0.10.1",
+        "@provablehq/sdk": "^0.10.2",
         "typescript": "^5.7.3"
     },
     "scripts": {

--- a/e2e/testnet/package.json
+++ b/e2e/testnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.1"
+    "@provablehq/sdk": "^0.10.2"
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/sdk",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Provable Team"
@@ -51,12 +51,12 @@
   },
   "homepage": "https://github.com/ProvableHQ/sdk#readme",
   "dependencies": {
-    "@provablehq/wasm": "^0.10.1",
+    "@provablehq/wasm": "^0.10.2",
     "@scure/base": "^2.0.0",
     "comlink": "^4.4.2",
     "core-js": "^3.40.0",
-    "mime": "^4.0.6",
     "libsodium-wrappers": "^0.8.2",
+    "mime": "^4.0.6",
     "xmlhttprequest-ssl": "^4.0.0"
   },
   "devDependencies": {

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "12aca1021aef2c476bad30d2f681e891b2be4f07dbc230a96df09cb693bfb3cb"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-wasm"
-version = "0.10.1"
+version = "0.10.2"
 authors = [ "The Provable Team" ]
 description = "WebAssembly based toolkit for developing zero-knowledge applications with Aleo"
 homepage = "https://provable.com"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/wasm",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
         "@codemirror/language": "^6.10.8",
         "@codemirror/legacy-modes": "^6.4.2",
         "@codemirror/stream-parser": "^0.19.9",
-        "@provablehq/sdk": "^0.10.1",
+        "@provablehq/sdk": "^0.10.2",
         "@uiw/codemirror-theme-noctis-lilac": "^4.23.7",
         "@uiw/codemirror-theme-okaidia": "^4.23.7",
         "@uiw/react-codemirror": "^4.23.7",


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Bump SDK version to v0.10.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump touching only manifest/lockfile metadata; main risk is mismatched dependency versions if any downstream expects `0.10.1`.
> 
> **Overview**
> Updates the monorepo release to **v0.10.2** by bumping versions for `@provablehq/sdk`, `@provablehq/wasm`, and `create-leo-app`, and updating `@provablehq/sdk`/`@provablehq/wasm` dependency ranges across all `create-leo-app` templates, the `website`, and e2e packages.
> 
> Also updates the Rust crate version (`wasm/Cargo.toml`) and lockfile entry (`wasm/Cargo.lock`) for `aleo-wasm`, plus the internal docs version reference in `.claude/CLAUDE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d913daf9dbc3f1c6390071af243f272288c539af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->