### PR TITLE
[Feature] Add CJS build target to @provablehq/sdk and @provablehq/wasm

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -183,8 +183,17 @@ jobs:
         working-directory: sdk
         run: yarn test:attw
 
-      - name: "Pure-CJS smoke (local)"
+      - name: "Pure-CJS smoke (local, resolves by file path)"
         run: node sdk/tests/cjs-smoke/smoke.cjs
+
+      # Packs both workspace packages, installs them into a pristine CJS
+      # fixture, and `require('@provablehq/sdk/testnet.js')` through the
+      # actual `exports.require` condition. Catches broken `exports` maps,
+      # missing tarball files, and wrong `main`/`module` fields that the
+      # file-path smoke above cannot see.
+      - name: "Packed-and-installed CJS smoke"
+        working-directory: sdk
+        run: yarn test:cjs:pack
 
 
   # Full CJS + encrypted DPS round-trip against staging. Proves a CJS consumer

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -159,6 +159,60 @@ jobs:
           yarn local
 
 
+  # Cheap, deterministic, no secrets. Always runs on every PR and push.
+  # Exercises: CJS module load (no TLA), Account/signature WASM calls, noble
+  # encryption wire format, `initThreadPool` worker spawning from CJS, dynamic
+  # variant `require()` from CJS, and `exports`-map consistency via
+  # `arethetypeswrong`.
+  cjs-smoke:
+    name: "CJS smoke + exports validation"
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-yarn
+      - uses: ./.github/actions/use-build
+
+      # Exports-map validation runs first so it gates merging even if the
+      # network-dependent e2e job (below) is flaky or skipped.
+      - name: "arethetypeswrong exports validation (wasm)"
+        working-directory: wasm
+        run: yarn test:attw
+
+      - name: "arethetypeswrong exports validation (sdk)"
+        working-directory: sdk
+        run: yarn test:attw
+
+      - name: "Pure-CJS smoke (local)"
+        run: node sdk/tests/cjs-smoke/smoke.cjs
+
+
+  # Full CJS + encrypted DPS round-trip against staging. Proves a CJS consumer
+  # can build a proving request, encrypt with noble, submit, and confirm
+  # on-chain. Costs a real testnet transaction per run, so we only run it on
+  # pushes to protected branches (mainnet/testnet) — the parallel ESM loyalty
+  # job already covers general DPS path validation on every PR, and the
+  # `cjs-smoke` + `attw` jobs above catch CJS-specific packaging regressions
+  # without hitting the network.
+  cjs-e2e:
+    name: "CJS + encrypted DPS end-to-end"
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push'
+    env:
+      ALEO_CONSUMER_ID: ${{ secrets.ALEO_CONSUMER_ID }}
+      ALEO_DPS_URL: https://api.provable.com/prove/testnet
+      ALEO_DPS_API_KEY: ${{ secrets.ALEO_DPS_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-yarn
+      - uses: ./.github/actions/use-build
+
+      - name: "CJS + encrypted DPS full round-trip (staging)"
+        timeout-minutes: 10
+        run: node sdk/tests/cjs-smoke/loyalty-dps.cjs
+
+
   create-leo-app-dynamic-dispatch-proving:
     name: "create-leo-app dynamic-dispatch-proving (testnet)"
     runs-on: ubuntu-latest-m

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -196,32 +196,6 @@ jobs:
         run: yarn test:cjs:pack
 
 
-  # Full CJS + encrypted DPS round-trip against staging. Proves a CJS consumer
-  # can build a proving request, encrypt with noble, submit, and confirm
-  # on-chain. Costs a real testnet transaction per run, so we only run it on
-  # pushes to protected branches (mainnet/testnet) — the parallel ESM loyalty
-  # job already covers general DPS path validation on every PR, and the
-  # `cjs-smoke` + `attw` jobs above catch CJS-specific packaging regressions
-  # without hitting the network.
-  cjs-e2e:
-    name: "CJS + encrypted DPS end-to-end"
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push'
-    env:
-      ALEO_CONSUMER_ID: ${{ secrets.ALEO_CONSUMER_ID }}
-      ALEO_DPS_URL: https://api.provable.com/prove/testnet
-      ALEO_DPS_API_KEY: ${{ secrets.ALEO_DPS_API_KEY }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-yarn
-      - uses: ./.github/actions/use-build
-
-      - name: "CJS + encrypted DPS full round-trip (staging)"
-        timeout-minutes: 10
-        run: node sdk/tests/cjs-smoke/loyalty-dps.cjs
-
-
   create-leo-app-dynamic-dispatch-proving:
     name: "create-leo-app dynamic-dispatch-proving (testnet)"
     runs-on: ubuntu-latest-m

--- a/docs/adr/001-cjs-support.md
+++ b/docs/adr/001-cjs-support.md
@@ -1,0 +1,62 @@
+# ADR-001: CommonJS Build Target
+
+**Status:** Accepted  
+**Date:** 2026-04-17  
+**Review by:** 2027-04-17
+
+## Context
+
+A partner integration required `require()` support from a CommonJS codebase. Their stack cannot use ESM imports (including dynamic `await import()`), and the alternative was maintaining an internal fork of the SDK.
+
+Shipping a CJS build target requires that we avoid top-level await (TLA) anywhere in the source tree that gets bundled into the Node CJS entry. Rollup's CJS output format does not support TLA and hard-fails the build if any is present.
+
+## Decision
+
+Ship CJS output alongside ESM for both `@provablehq/sdk` and `@provablehq/wasm`, with a 12-month review window.
+
+### Constraints accepted
+
+- **No TLA in the Node entry graph.** Any `await` at module scope in a source file reachable from `node.ts` will fail the CJS build. Enforced automatically by Rollup at build time (exit code 1).
+- **`initSync` for WASM initialization in CJS.** The CJS entry uses wasm-bindgen's `initSync` with `fs.readFileSync` instead of the default async `init()`. This is a documented wasm-bindgen API ([synchronous instantiation](https://wasm-bindgen.github.io/wasm-bindgen/examples/synchronous-instantiation.html)), but its long-term availability is not guaranteed.
+- **No TLA-dependent initialization patterns.** Any future startup initialization (metadata fetching, consensus config, etc.) must use explicit init functions (same pattern as `initThreadPool`) rather than TLA.
+
+### What is unaffected
+
+- ESM consumers get identical output. CJS files ship alongside and bundlers pick the format they need.
+- Async functions (including `initThreadPool`) work normally from CJS when called inside async contexts.
+- Browser builds are unchanged.
+- Source code itself has no CJS-specific logic. All CJS concerns live in the build/packaging layer.
+
+## Removal plan
+
+CJS support is structured for clean removal. All CJS-specific code is additive:
+
+| Component | What to remove |
+|---|---|
+| `wasm/build.js` | CJS entry template |
+| `wasm/package.json` | `require` condition in exports map |
+| `sdk/package.json` | `require`/`types.require` conditions, revert `main` field, remove `test:cjs*` scripts |
+| `sdk/rollup.config.js` | CJS output entry |
+| `sdk/tests/cjs-smoke/` | Entire directory |
+| `.github/workflows/sdk.yml` | CJS CI jobs |
+
+No source code changes required. Removing CJS is equivalent to reverting PR #1293.
+
+## Review criteria (April 2027)
+
+At the 12-month mark, evaluate:
+
+1. **Is anyone using the CJS build?** Check npm download stats for `require` condition hits if available, or survey known consumers.
+2. **Has the TLA constraint caused friction?** Review whether any feature or dependency was blocked or complicated by the no-TLA rule.
+3. **Has `initSync` been deprecated upstream?** Check wasm-bindgen's status on synchronous instantiation.
+4. **Has the Node/npm ecosystem moved further from CJS?** If major LTS versions or frameworks have dropped CJS support, the case for maintaining it weakens.
+
+If usage is low and the constraint has caused friction, drop CJS support. If usage is meaningful, extend with a new review date.
+
+## References
+
+- PR #1293: CJS build target implementation
+- PR #1295: Noble-sodium swap (removed `await sodium.ready` TLA, prerequisite for CJS)
+- wasm-bindgen synchronous instantiation: https://wasm-bindgen.github.io/wasm-bindgen/examples/synchronous-instantiation.html
+- wasm-bindgen initSync discussion: https://github.com/wasm-bindgen/wasm-bindgen/issues/1976
+- W3C Service Worker / initSync context: https://github.com/w3c/ServiceWorker/issues/1499

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,23 +7,60 @@
   ],
   "license": "GPL-3.0",
   "type": "module",
-  "main": "./dist/testnet/node.js",
+  "main": "./dist/testnet/node.cjs",
+  "module": "./dist/testnet/node.js",
   "browser": "./dist/testnet/browser.js",
   "exports": {
     ".": {
-      "node": "./dist/testnet/node.js",
+      "node": {
+        "types": {
+          "import": "./dist/testnet/node.d.ts",
+          "require": "./dist/testnet/node.d.cts"
+        },
+        "import": "./dist/testnet/node.js",
+        "require": "./dist/testnet/node.cjs",
+        "default": "./dist/testnet/node.js"
+      },
+      "types": "./dist/testnet/browser.d.ts",
       "default": "./dist/testnet/browser.js"
     },
     "./testnet.js": {
-      "node": "./dist/testnet/node.js",
+      "node": {
+        "types": {
+          "import": "./dist/testnet/node.d.ts",
+          "require": "./dist/testnet/node.d.cts"
+        },
+        "import": "./dist/testnet/node.js",
+        "require": "./dist/testnet/node.cjs",
+        "default": "./dist/testnet/node.js"
+      },
+      "types": "./dist/testnet/browser.d.ts",
       "default": "./dist/testnet/browser.js"
     },
     "./mainnet.js": {
-      "node": "./dist/mainnet/node.js",
+      "node": {
+        "types": {
+          "import": "./dist/mainnet/node.d.ts",
+          "require": "./dist/mainnet/node.d.cts"
+        },
+        "import": "./dist/mainnet/node.js",
+        "require": "./dist/mainnet/node.cjs",
+        "default": "./dist/mainnet/node.js"
+      },
+      "types": "./dist/mainnet/browser.d.ts",
       "default": "./dist/mainnet/browser.js"
     },
     "./dynamic.js": {
-      "node": "./dist/dynamic/node.js",
+      "node": {
+        "types": {
+          "import": "./dist/dynamic/node.d.ts",
+          "require": "./dist/dynamic/node.d.cts"
+        },
+        "import": "./dist/dynamic/node.js",
+        "require": "./dist/dynamic/node.cjs",
+        "default": "./dist/dynamic/node.js"
+      },
+      "types": "./dist/dynamic/browser.d.ts",
       "default": "./dist/dynamic/browser.js"
     }
   },
@@ -34,7 +71,9 @@
   ],
   "scripts": {
     "build": "rimraf dist && rollup -c rollup.config.js",
-    "test": "rimraf tmp && rollup -c rollup.test.js && mocha tmp/**/*.test.js --timeout 60000 && RUN_SKIPPED=true mocha tmp/**/wasm.test.js --timeout 60000 --grep Consensus"
+    "test": "rimraf tmp && rollup -c rollup.test.js && mocha tmp/**/*.test.js --timeout 60000 && RUN_SKIPPED=true mocha tmp/**/wasm.test.js --timeout 60000 --grep Consensus",
+    "test:attw": "yarn pack --filename /tmp/provablehq-sdk-attw.tgz && attw /tmp/provablehq-sdk-attw.tgz --profile=node16",
+    "test:cjs": "node tests/cjs-smoke/smoke.cjs"
   },
   "repository": {
     "type": "git",
@@ -60,6 +99,7 @@
     "xmlhttprequest-ssl": "^4.0.0"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.2",
     "@rollup/plugin-replace": "^6.0.2",
     "@types/chai": "^5.0.1",
     "@types/mocha": "^10.0.10",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -73,7 +73,8 @@
     "build": "rimraf dist && rollup -c rollup.config.js",
     "test": "rimraf tmp && rollup -c rollup.test.js && mocha tmp/**/*.test.js --timeout 60000 && RUN_SKIPPED=true mocha tmp/**/wasm.test.js --timeout 60000 --grep Consensus",
     "test:attw": "yarn pack --filename /tmp/provablehq-sdk-attw.tgz && attw /tmp/provablehq-sdk-attw.tgz --profile=node16",
-    "test:cjs": "node tests/cjs-smoke/smoke.cjs"
+    "test:cjs": "node tests/cjs-smoke/smoke.cjs",
+    "test:cjs:pack": "node tests/cjs-smoke/pack-install.cjs"
   },
   "repository": {
     "type": "git",

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -14,6 +14,48 @@ const runtimes = [
     "node",
 ];
 
+const sharedExternal = (network) => [
+    // Used by node-polyfill
+    "node:worker_threads",
+    "node:os",
+    "node:fs",
+    "node:crypto",
+    "node:path",
+    "node:url",
+    "mime/lite",
+    "sync-request",
+    "xmlhttprequest-ssl",
+
+    // Used by the SDK
+    "comlink",
+    `@provablehq/wasm/${network}.js`,
+    "core-js/proposals/json-parse-with-source.js",
+];
+
+function sharedPlugins(network) {
+    return [
+        replace({
+            preventAssignment: true,
+            delimiters: ['', ''],
+            values: {
+                '%%VERSION%%': $package.version,
+                '%%NETWORK%%': network,
+            },
+        }),
+        typescript({
+            tsconfig: "tsconfig.json",
+            clean: true,
+        }),
+    ];
+}
+
+// Single config per network with two `output` entries: TypeScript compiles
+// once and Rollup emits both ESM and CJS from the same input graph.
+//
+// Browsers don't consume CJS, but emitting `browser.cjs` costs nothing and
+// keeps the output matrix uniform. Worker entries (wasm workers) stay ESM
+// regardless, because the Node polyfill spawns them via `eval` + dynamic
+// `import()` which works fine from a CJS parent.
 function buildNetwork(network) {
     return {
         input: {
@@ -21,40 +63,55 @@ function buildNetwork(network) {
             "browser": "./src/browser.ts",
             "node": "./src/node.ts",
         },
-        output: {
-            dir: `dist/${network}`,
-            format: "es",
-            sourcemap: true,
-        },
-        external: [
-            // Used by node-polyfill
-            "node:worker_threads",
-            "node:os",
-            "node:fs",
-            "node:crypto",
-            "mime/lite",
-            "sync-request",
-            "xmlhttprequest-ssl",
+        output: [
+            {
+                dir: `dist/${network}`,
+                format: "es",
+                sourcemap: true,
+            },
+            {
+                dir: `dist/${network}`,
+                format: "cjs",
+                entryFileNames: "[name].cjs",
+                chunkFileNames: "[name].cjs",
+                sourcemap: true,
+            },
+        ],
+        external: sharedExternal(network),
+        plugins: [...sharedPlugins(network), emitCtsDeclarations(network)],
+    };
+}
 
-            // Used by the SDK
-            "comlink",
-            `@provablehq/wasm/${network}.js`,
-            "core-js/proposals/json-parse-with-source.js",
-        ],
-        plugins: [
-            replace({
-                preventAssignment: true,
-                delimiters: ['', ''],
-                values: {
-                    '%%VERSION%%': $package.version,
-                    '%%NETWORK%%': network,
-                },
-            }),
-            typescript({
-                tsconfig: "tsconfig.json",
-                clean: true,
-            }),
-        ],
+// Rollup plugin that, at the end of the build, copies every `*.d.ts` in
+// `dist/<network>/` to a `*.d.cts` sibling. CJS consumers resolve types
+// through the `require` condition (which expects `.d.cts`); without these
+// siblings `arethetypeswrong` flags "Masquerading as ESM". The declaration
+// bodies are identical — the distinct filename is all TypeScript's node16
+// module-resolution check cares about.
+async function copyDtsToCts(dir) {
+    let entries;
+    try {
+        entries = await $fs.readdir(dir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+    await Promise.all(entries.map(async (entry) => {
+        const fullPath = $path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            await copyDtsToCts(fullPath);
+        } else if (entry.isFile() && entry.name.endsWith(".d.ts")) {
+            const target = fullPath.replace(/\.d\.ts$/, ".d.cts");
+            await $fs.copyFile(fullPath, target);
+        }
+    }));
+}
+
+function emitCtsDeclarations(network) {
+    return {
+        name: "emit-cts-declarations",
+        async writeBundle() {
+            await copyDtsToCts(`dist/${network}`);
+        },
     };
 }
 
@@ -62,9 +119,12 @@ async function buildRuntimes() {
     await Promise.all(runtimes.map(async (runtime) => {
         await $fs.mkdir(`dist/dynamic`, { recursive: true });
 
+        // Dynamic `import()` is legal in both ESM and CJS, so the loader body
+        // is identical across formats — only the module-system wrapping
+        // differs (see `.js` vs `.cjs` files emitted below).
         const loading = networks.map((network) => `"${network}": () => import("../${network}/${runtime}.js"),`).join("\n    ");
 
-        const typings = networks.map((network) => `"${network}": typeof import("../${network}/${runtime}"),`).join("\n    ");
+        const typings = networks.map((network) => `"${network}": typeof import("../${network}/${runtime}.js"),`).join("\n    ");
 
         await $fs.writeFile(`dist/dynamic/${runtime}.js`, `const networks = {
     ${loading}
@@ -75,14 +135,30 @@ export function loadNetwork(name) {
 }
 `);
 
-        await $fs.writeFile(`dist/dynamic/${runtime}.d.ts`, `interface Networks {
+        await $fs.writeFile(`dist/dynamic/${runtime}.cjs`, `"use strict";
+
+const networks = {
+    ${loading}
+};
+
+function loadNetwork(name) {
+    return networks[name]();
+}
+
+module.exports = { loadNetwork };
+`);
+
+        const dtsContent = `interface Networks {
     ${typings}
 }
 
 export { Networks };
 
 export declare function loadNetwork<Key extends keyof Networks>(name: Key): Promise<Networks[Key]>;
-`);
+`;
+
+        await $fs.writeFile(`dist/dynamic/${runtime}.d.ts`, dtsContent);
+        await $fs.writeFile(`dist/dynamic/${runtime}.d.cts`, dtsContent);
     }));
 }
 

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -92,8 +92,9 @@ async function copyDtsToCts(dir) {
     let entries;
     try {
         entries = await $fs.readdir(dir, { withFileTypes: true });
-    } catch {
-        return;
+    } catch (err) {
+        if (err.code === "ENOENT") return;
+        throw err;
     }
     await Promise.all(entries.map(async (entry) => {
         const fullPath = $path.join(dir, entry.name);
@@ -132,7 +133,7 @@ async function buildRuntimes() {
     ${esmLeaves}
 };
 
-export async function loadNetwork(name) {
+export function loadNetwork(name) {
     return networks[name]();
 }
 `);
@@ -143,7 +144,7 @@ const networks = {
     ${cjsLeaves}
 };
 
-async function loadNetwork(name) {
+function loadNetwork(name) {
     return networks[name]();
 }
 

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -119,15 +119,17 @@ async function buildRuntimes() {
     await Promise.all(runtimes.map(async (runtime) => {
         await $fs.mkdir(`dist/dynamic`, { recursive: true });
 
-        // Dynamic `import()` is legal in both ESM and CJS, so the loader body
-        // is identical across formats — only the module-system wrapping
-        // differs (see `.js` vs `.cjs` files emitted below).
-        const loading = networks.map((network) => `"${network}": () => import("../${network}/${runtime}.js"),`).join("\n    ");
+        // Dynamic `import()` is legal in both ESM and CJS, but we point each
+        // format at its format-native leaves so a CJS consumer's
+        // `loadNetwork()` call stays on the CJS code path end-to-end instead
+        // of pulling in an ESM leaf through the dual-package boundary.
+        const esmLeaves = networks.map((network) => `"${network}": () => import("../${network}/${runtime}.js"),`).join("\n    ");
+        const cjsLeaves = networks.map((network) => `"${network}": () => import("../${network}/${runtime}.cjs"),`).join("\n    ");
 
         const typings = networks.map((network) => `"${network}": typeof import("../${network}/${runtime}.js"),`).join("\n    ");
 
         await $fs.writeFile(`dist/dynamic/${runtime}.js`, `const networks = {
-    ${loading}
+    ${esmLeaves}
 };
 
 export function loadNetwork(name) {
@@ -138,7 +140,7 @@ export function loadNetwork(name) {
         await $fs.writeFile(`dist/dynamic/${runtime}.cjs`, `"use strict";
 
 const networks = {
-    ${loading}
+    ${cjsLeaves}
 };
 
 function loadNetwork(name) {

--- a/sdk/rollup.config.js
+++ b/sdk/rollup.config.js
@@ -124,7 +124,7 @@ async function buildRuntimes() {
         // `loadNetwork()` call stays on the CJS code path end-to-end instead
         // of pulling in an ESM leaf through the dual-package boundary.
         const esmLeaves = networks.map((network) => `"${network}": () => import("../${network}/${runtime}.js"),`).join("\n    ");
-        const cjsLeaves = networks.map((network) => `"${network}": () => import("../${network}/${runtime}.cjs"),`).join("\n    ");
+        const cjsLeaves = networks.map((network) => `"${network}": () => require("../${network}/${runtime}.cjs"),`).join("\n    ");
 
         const typings = networks.map((network) => `"${network}": typeof import("../${network}/${runtime}.js"),`).join("\n    ");
 
@@ -132,7 +132,7 @@ async function buildRuntimes() {
     ${esmLeaves}
 };
 
-export function loadNetwork(name) {
+export async function loadNetwork(name) {
     return networks[name]();
 }
 `);
@@ -143,7 +143,7 @@ const networks = {
     ${cjsLeaves}
 };
 
-function loadNetwork(name) {
+async function loadNetwork(name) {
     return networks[name]();
 }
 

--- a/sdk/src/polyfill/worker.ts
+++ b/sdk/src/polyfill/worker.ts
@@ -6,7 +6,7 @@ import * as $os from "node:os";
 // needed when writing Worker code.
 if (globalThis.navigator == null) {
     globalThis.navigator = {
-        hardwareConcurrency: $os.cpus().length,
+        hardwareConcurrency: $os.availableParallelism(),
     } as Navigator;
 }
 

--- a/sdk/tests/cjs-smoke/loyalty-dps.cjs
+++ b/sdk/tests/cjs-smoke/loyalty-dps.cjs
@@ -3,7 +3,7 @@
 // wait for on-chain confirmation.
 //
 // Mirrors the ESM loyalty template's `mint_card` path but uses `require()`
-// throughout. If this passes, Kraken's CJS integration works.
+// throughout. Validates the full CJS → DPS → on-chain round-trip end to end.
 //
 // Required env: ALEO_CONSUMER_ID, ALEO_DPS_API_KEY, ALEO_DPS_URL.
 

--- a/sdk/tests/cjs-smoke/loyalty-dps.cjs
+++ b/sdk/tests/cjs-smoke/loyalty-dps.cjs
@@ -1,0 +1,106 @@
+// CJS end-to-end validation: proves a pure-CJS consumer can run the full
+// encrypted DPS flow — build proving request, encrypt with noble, submit,
+// wait for on-chain confirmation.
+//
+// Mirrors the ESM loyalty template's `mint_card` path but uses `require()`
+// throughout. If this passes, Kraken's CJS integration works.
+//
+// Required env: ALEO_CONSUMER_ID, ALEO_DPS_API_KEY, ALEO_DPS_URL.
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+const sdk = require(path.resolve(__dirname, "../../dist/testnet/node.cjs"));
+
+const DPS_URL = process.env.ALEO_DPS_URL || "https://api.provable.com/prove/testnet";
+const DPS_API_KEY = process.env.ALEO_DPS_API_KEY;
+const CONSUMER_ID = process.env.ALEO_CONSUMER_ID;
+const API_URL = "https://api.provable.com/v2";
+
+if (!DPS_API_KEY || !CONSUMER_ID) {
+    console.error("SKIP: ALEO_DPS_API_KEY and ALEO_CONSUMER_ID required for CJS DPS test.");
+    process.exit(0);
+}
+
+// Same demo account the ESM loyalty template uses — has existing records.
+const ACCOUNT_CIPHERTEXT =
+    "ciphertext1qvq283j7ujnhz59d4rnu772rfmvf94039x9ekhk2lzuutteqzlghsr3g9824qgw97a79mmdymqdt0ulqdkahq39vnerw2tl7thvvnnunq386jzjnw29e0ghnq7unphgdzw637q3fgvvlkrcywsc5jukkdhss5qq3njp";
+const ACCOUNT_PASSWORD = "provablealeo1";
+
+const TOKEN_PROGRAM_PATH = path.resolve(
+    __dirname,
+    "../../../create-leo-app/template-node-loyalty-program-ts/loyalty_token/build/main.aleo",
+);
+const tokenProgram = fs.readFileSync(TOKEN_PROGRAM_PATH, "utf-8").trim();
+
+async function waitForTransaction(networkClient, txId, timeoutMs = 300_000, intervalMs = 5_000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        try {
+            const tx = await networkClient.getTransaction(txId);
+            if (tx) return tx;
+        } catch {
+            // Not yet confirmed.
+        }
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    throw new Error(`Transaction ${txId} did not confirm within ${timeoutMs}ms`);
+}
+
+async function main() {
+    console.log("[cjs-dps] Initializing thread pool...");
+    await sdk.initThreadPool();
+
+    const account = sdk.Account.fromCiphertext(ACCOUNT_CIPHERTEXT, ACCOUNT_PASSWORD);
+    console.log(`[cjs-dps] Account: ${account.address().to_string()}`);
+
+    const programManager = new sdk.ProgramManager(API_URL);
+    programManager.setAccount(account);
+    programManager.setKeyProvider(new sdk.AleoKeyProvider());
+
+    // Two clients: DPS for submitting encrypted proving requests, and the
+    // explorer API for polling transaction state (mirrors the ESM loyalty
+    // template at create-leo-app/template-node-loyalty-program-ts/src/index.ts).
+    const dpsClient = new sdk.AleoNetworkClient(DPS_URL);
+    const explorerClient = new sdk.AleoNetworkClient("https://api.explorer.provable.com/v1");
+
+    const programName = sdk.Program.fromString(tokenProgram).id();
+    const nonce = Math.floor(Math.random() * 1_000_000_000).toString();
+    const inputs = [account.address().to_string(), "100u64", `${nonce}field`];
+
+    console.log(`[cjs-dps] Building proving request for ${programName}/mint_card...`);
+    const provingRequest = await programManager.provingRequest({
+        programName,
+        programSource: tokenProgram,
+        functionName: "mint_card",
+        inputs,
+        priorityFee: 0,
+        privateFee: false,
+        broadcast: true,
+    });
+
+    console.log("[cjs-dps] Submitting encrypted proving request to DPS...");
+    const response = await dpsClient.submitProvingRequest({
+        provingRequest,
+        url: DPS_URL,
+        apiKey: DPS_API_KEY,
+        consumerId: CONSUMER_ID,
+        dpsPrivacy: true,
+    });
+
+    const txId = response.transaction && response.transaction.id;
+    if (!txId) throw new Error("DPS response did not contain a transaction ID");
+    console.log(`[cjs-dps] Submitted: ${txId}`);
+
+    console.log("[cjs-dps] Waiting for on-chain confirmation...");
+    const confirmed = await waitForTransaction(explorerClient, txId);
+    if (!confirmed) throw new Error("Transaction never confirmed");
+
+    console.log(`\x1b[32m✓ CJS + encrypted DPS round-trip confirmed: ${txId}\x1b[0m`);
+    process.exit(0);
+}
+
+main().catch((err) => {
+    console.error(`\x1b[31m✗ CJS DPS fixture failed:\x1b[0m`, err);
+    process.exit(1);
+});

--- a/sdk/tests/cjs-smoke/pack-install.cjs
+++ b/sdk/tests/cjs-smoke/pack-install.cjs
@@ -1,0 +1,109 @@
+// Packed-and-installed CJS smoke test.
+//
+// The sibling `smoke.cjs` loads the SDK by absolute file path, which is fast
+// for dev iteration but bypasses the `exports.require` condition entirely.
+// This script closes that coverage gap: it packs both workspace packages
+// (`@provablehq/wasm` and `@provablehq/sdk`), installs them into a clean
+// CJS fixture, and exercises the public API through
+// `require('@provablehq/sdk/testnet.js')` — the exact code path a Kraken-style
+// downstream consumer runs. A broken `exports.require` entry, a missing
+// tarball file, or a wrong `main` field all fail here.
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync, spawnSync } = require("node:child_process");
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const WORKDIR = fs.mkdtempSync(path.join(os.tmpdir(), "provablehq-cjs-pack-"));
+
+function run(cmd, args, opts = {}) {
+    const result = spawnSync(cmd, args, { stdio: "inherit", ...opts });
+    if (result.status !== 0) {
+        throw new Error(`${cmd} ${args.join(" ")} exited with status ${result.status}`);
+    }
+}
+
+function pack(pkgDir, outPath) {
+    run("yarn", ["pack", "--filename", outPath], { cwd: pkgDir });
+}
+
+function cleanup() {
+    try {
+        fs.rmSync(WORKDIR, { recursive: true, force: true });
+    } catch {}
+}
+
+process.on("exit", cleanup);
+process.on("SIGINT", () => { cleanup(); process.exit(130); });
+
+console.log(`[pack-install] Workspace: ${WORKDIR}`);
+
+const wasmTarball = path.join(WORKDIR, "provablehq-wasm.tgz");
+const sdkTarball = path.join(WORKDIR, "provablehq-sdk.tgz");
+
+console.log("[pack-install] Packing @provablehq/wasm...");
+pack(path.join(REPO_ROOT, "wasm"), wasmTarball);
+
+console.log("[pack-install] Packing @provablehq/sdk...");
+pack(path.join(REPO_ROOT, "sdk"), sdkTarball);
+
+// Fixture is pure CJS — no `"type": "module"` — so `require()` resolution
+// exercises the `require` condition of the SDK's `exports` map. The
+// `@provablehq/wasm` dep must be pinned to the same file tarball explicitly;
+// otherwise npm would try to fetch it from the registry by version range.
+const fixtureDir = path.join(WORKDIR, "fixture");
+fs.mkdirSync(fixtureDir, { recursive: true });
+fs.writeFileSync(
+    path.join(fixtureDir, "package.json"),
+    JSON.stringify(
+        {
+            name: "provablehq-sdk-cjs-fixture",
+            version: "0.0.0",
+            private: true,
+            dependencies: {
+                "@provablehq/wasm": `file:${wasmTarball}`,
+                "@provablehq/sdk": `file:${sdkTarball}`,
+            },
+        },
+        null,
+        2,
+    ),
+);
+
+console.log("[pack-install] Installing tarballs into fixture...");
+run("npm", ["install", "--no-audit", "--no-fund", "--loglevel=error"], { cwd: fixtureDir });
+
+const assertionsScript = path.join(fixtureDir, "run-smoke.cjs");
+fs.writeFileSync(
+    assertionsScript,
+    `
+const assert = require("node:assert");
+const sdk = require("@provablehq/sdk/testnet.js");
+
+assert.equal(typeof sdk.Account, "function", "Account not exported");
+assert.equal(typeof sdk.ProgramManager, "function", "ProgramManager not exported");
+assert.equal(typeof sdk.encryptProvingRequest, "function", "encryptProvingRequest not exported");
+assert.equal(typeof sdk.encryptViewKey, "function", "encryptViewKey not exported");
+assert.equal(typeof sdk.initThreadPool, "function", "initThreadPool not exported");
+assert.equal(typeof sdk.LocalFileKeyStore, "function", "LocalFileKeyStore (node-only) not exported");
+
+const account = new sdk.Account();
+assert.ok(account.address().to_string().startsWith("aleo1"), "Account derivation failed");
+
+const message = new TextEncoder().encode("pack-install smoke");
+const signature = account.sign(message);
+assert.ok(account.verify(message, signature), "Signature round-trip failed");
+
+// Dynamic variant via the exports map.
+const dyn = require("@provablehq/sdk/dynamic.js");
+assert.equal(typeof dyn.loadNetwork, "function", "dynamic loadNetwork not exported");
+
+console.log("pack-install smoke passed");
+`,
+);
+
+console.log("[pack-install] Running assertions through require('@provablehq/sdk/testnet.js')...");
+run("node", [assertionsScript], { cwd: fixtureDir });
+
+console.log("\x1b[32m✓ CJS pack-install smoke passed.\x1b[0m");

--- a/sdk/tests/cjs-smoke/pack-install.cjs
+++ b/sdk/tests/cjs-smoke/pack-install.cjs
@@ -5,14 +5,14 @@
 // This script closes that coverage gap: it packs both workspace packages
 // (`@provablehq/wasm` and `@provablehq/sdk`), installs them into a clean
 // CJS fixture, and exercises the public API through
-// `require('@provablehq/sdk/testnet.js')` — the exact code path a Kraken-style
-// downstream consumer runs. A broken `exports.require` entry, a missing
-// tarball file, or a wrong `main` field all fail here.
+// `require('@provablehq/sdk/testnet.js')` — the exact code path a downstream
+// CJS consumer runs. A broken `exports.require` entry, a missing tarball
+// file, or a wrong `main` field all fail here.
 
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { execFileSync, spawnSync } = require("node:child_process");
+const { spawnSync } = require("node:child_process");
 
 const REPO_ROOT = path.resolve(__dirname, "../../..");
 const WORKDIR = fs.mkdtempSync(path.join(os.tmpdir(), "provablehq-cjs-pack-"));

--- a/sdk/tests/cjs-smoke/pack-install.cjs
+++ b/sdk/tests/cjs-smoke/pack-install.cjs
@@ -99,7 +99,18 @@ assert.ok(account.verify(message, signature), "Signature round-trip failed");
 const dyn = require("@provablehq/sdk/dynamic.js");
 assert.equal(typeof dyn.loadNetwork, "function", "dynamic loadNetwork not exported");
 
-console.log("pack-install smoke passed");
+// Worker / thread pool through the installed tarball. Exercises the
+// import.meta.url → pathToFileURL(__filename) transform against a real
+// node_modules-resolved path, and confirms all worker-related files
+// (node-polyfill, worker.js, aleo_wasm.wasm) made it into the tarball.
+(async () => {
+    await sdk.initThreadPool(2);
+    console.log("pack-install smoke passed");
+    process.exit(0);
+})().catch((err) => {
+    console.error("initThreadPool failed under installed tarball:", err);
+    process.exit(1);
+});
 `,
 );
 

--- a/sdk/tests/cjs-smoke/package.json
+++ b/sdk/tests/cjs-smoke/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cjs-smoke",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Smoke test: can a pure-CJS consumer `require()` @provablehq/sdk and use its public API end-to-end?"
+}

--- a/sdk/tests/cjs-smoke/prove.cjs
+++ b/sdk/tests/cjs-smoke/prove.cjs
@@ -1,0 +1,58 @@
+// Full local proving smoke test from CJS.
+// Exercises: initThreadPool → ProgramManager.run() → proof verification.
+
+const path = require("node:path");
+const sdk = require(path.resolve(__dirname, "../../dist/testnet/node.cjs"));
+
+const helloProgram =
+    "program hellothere.aleo;\n\n" +
+    "function hello:\n" +
+    "    input r0 as u32.public;\n" +
+    "    input r1 as u32.private;\n" +
+    "    add r0 r1 into r2;\n" +
+    "    output r2 as u32.private;\n";
+
+function log(label, ok, detail = "") {
+    const prefix = ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m";
+    console.log(`${prefix} ${label}${detail ? `  (${detail})` : ""}`);
+    if (!ok) process.exit(1);
+}
+
+(async () => {
+    const t0 = performance.now();
+
+    // 1. Thread pool
+    await sdk.initThreadPool(2);
+    log("initThreadPool(2) spawned workers", true);
+
+    // 2. Set up ProgramManager
+    const keyProvider = new sdk.AleoKeyProvider();
+    keyProvider.useCache(true);
+    const programManager = new sdk.ProgramManager(undefined, keyProvider);
+    programManager.setAccount(new sdk.Account());
+
+    // 3. Execute + prove locally
+    console.log("\nProving hellothere.aleo/hello(5u32, 5u32)...");
+    const tProve = performance.now();
+    const result = await programManager.run(
+        helloProgram,
+        "hello",
+        ["5u32", "5u32"],
+        true,  // proveExecution
+    );
+    const proveMs = (performance.now() - tProve).toFixed(0);
+
+    // 4. Verify output
+    const outputs = result.getOutputs();
+    log("Execution produced output", outputs.length > 0, outputs[0]);
+    log("Output is 10u32", outputs[0] === "10u32", `got ${outputs[0]}`);
+
+    // 5. Verify proof
+    programManager.verifyExecution(result, 10_300_000);
+    log("Proof verified", true);
+
+    const totalMs = (performance.now() - t0).toFixed(0);
+    console.log(`\nProving: ${proveMs}ms | Total: ${totalMs}ms`);
+    console.log("\n\x1b[32mFull CJS proving smoke passed.\x1b[0m");
+    process.exit(0);
+})();

--- a/sdk/tests/cjs-smoke/prove.cjs
+++ b/sdk/tests/cjs-smoke/prove.cjs
@@ -55,4 +55,7 @@ function log(label, ok, detail = "") {
     console.log(`\nProving: ${proveMs}ms | Total: ${totalMs}ms`);
     console.log("\n\x1b[32mFull CJS proving smoke passed.\x1b[0m");
     process.exit(0);
-})();
+})().catch((err) => {
+    console.error("\n\x1b[31m✗ Full CJS proving smoke failed:\x1b[0m", err.message || err);
+    process.exit(1);
+});

--- a/sdk/tests/cjs-smoke/smoke.cjs
+++ b/sdk/tests/cjs-smoke/smoke.cjs
@@ -92,4 +92,7 @@ log("Signature verifies", account.verify(message, signature) === true);
     }
     console.log("\n\x1b[32mAll CJS smoke checks passed.\x1b[0m");
     process.exit(0);
-})();
+})().catch((err) => {
+    console.error("\n\x1b[31m✗ CJS smoke failed:\x1b[0m", err.message || err);
+    process.exit(1);
+});

--- a/sdk/tests/cjs-smoke/smoke.cjs
+++ b/sdk/tests/cjs-smoke/smoke.cjs
@@ -1,0 +1,95 @@
+// Pure-CJS smoke test. Runs in a directory without `"type": "module"` so the
+// `require` condition of the SDK's `exports` map resolves.
+//
+// Exercises: module load, account creation, signing, noble-based encryption,
+// and the `crypto_box_seal` wire format that the DPS consumes.
+
+const assert = require("node:assert");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+// A real X25519 public key — generate a throwaway keypair so the noble
+// composition gets a well-formed 32-byte u-coordinate to operate on.
+const recipient = crypto.generateKeyPairSync("x25519");
+const recipientRawKey = recipient.publicKey.export({ type: "spki", format: "der" }).slice(-32);
+const recipientPublicKeyB64 = recipientRawKey.toString("base64");
+
+// Resolve to the workspace SDK (monorepo-style) so this runs pre-publish.
+const sdk = require(path.resolve(__dirname, "../../dist/testnet/node.cjs"));
+
+function log(label, ok, detail = "") {
+    const prefix = ok ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m";
+    console.log(`${prefix} ${label}${detail ? `  (${detail})` : ""}`);
+    if (!ok) process.exit(1);
+}
+
+// 1. Module shape
+log("require() resolves without top-level-await error", typeof sdk === "object");
+log("Account class exported", typeof sdk.Account === "function");
+log("ProgramManager class exported", typeof sdk.ProgramManager === "function");
+log("encryptViewKey function exported", typeof sdk.encryptViewKey === "function");
+log("encryptProvingRequest function exported", typeof sdk.encryptProvingRequest === "function");
+log("initThreadPool function exported", typeof sdk.initThreadPool === "function");
+log("LocalFileKeyStore (node-only) exported", typeof sdk.LocalFileKeyStore === "function");
+
+// 2. Account/key derivation actually works — first real WASM call.
+const account = new sdk.Account();
+const privKey = account.privateKey().to_string();
+log("Account created", privKey.startsWith("APrivateKey"), privKey.slice(0, 20) + "…");
+log("View key derivable", account.viewKey().to_string().startsWith("AViewKey"));
+log("Address derivable", account.address().to_string().startsWith("aleo1"));
+
+// 3. Signature round-trip
+const message = new TextEncoder().encode("cjs-smoke-test");
+const signature = account.sign(message);
+log("Signature produced", signature.to_string().startsWith("sign1"));
+log("Signature verifies", account.verify(message, signature) === true);
+
+// 4. Noble-based encryption: verify ciphertext shape matches crypto_box_seal.
+//    32-byte ephemeral public key + 16-byte Poly1305 tag + payload (view key = 32 bytes).
+{
+    const ciphertext = sdk.encryptViewKey(recipientPublicKeyB64, account.viewKey());
+    log("encryptViewKey returns string (sync)", typeof ciphertext === "string");
+
+    const raw = Buffer.from(ciphertext, "base64");
+    log(
+        "ciphertext wire shape is 32+16+viewKeyLen bytes",
+        raw.length === 32 + 16 + account.viewKey().toBytesLe().length,
+        `got ${raw.length} bytes`,
+    );
+}
+
+// 5. Registration request shape — CJS consumer's likely RSS interop path.
+{
+    const ct = sdk.encryptRegistrationRequest(recipientPublicKeyB64, account.viewKey(), 12345);
+    log("encryptRegistrationRequest returns string (sync)", typeof ct === "string");
+}
+
+// 6. Dynamic variant under CJS — consumers that want runtime network switching
+//    from CJS do `const { loadNetwork } = require('@provablehq/sdk/dynamic.js')`.
+{
+    const dyn = require(path.resolve(__dirname, "../../dist/dynamic/node.cjs"));
+    log("dynamic/node.cjs exposes loadNetwork", typeof dyn.loadNetwork === "function");
+}
+
+// 7. Worker / thread pool — loads the ESM worker via dynamic import() from
+//    a CJS parent. This is the single most load-bearing check for CJS +
+//    threading parity.
+(async () => {
+    try {
+        const dyn = require(path.resolve(__dirname, "../../dist/dynamic/node.cjs"));
+        const testnet = await dyn.loadNetwork("testnet");
+        log("dynamic loadNetwork('testnet') resolves to SDK namespace", typeof testnet.Account === "function");
+    } catch (err) {
+        log("dynamic loadNetwork failed", false, err.message);
+    }
+
+    try {
+        await sdk.initThreadPool(2);
+        log("initThreadPool(2) spawned workers from CJS parent", true);
+    } catch (err) {
+        log("initThreadPool failed", false, err.message);
+    }
+    console.log("\n\x1b[32mAll CJS smoke checks passed.\x1b[0m");
+    process.exit(0);
+})();

--- a/wasm/build.js
+++ b/wasm/build.js
@@ -151,6 +151,14 @@ export async function initThreadPool(threads) {
     }
 }
 
+// BRITTLENESS NOTE: the two helpers below parse wasm-bindgen's emitted JS
+// textually to recover the short-name aliases (e.g. `A as Address`,
+// `a0 as initSync`). This works today with wasm-bindgen 0.2.100's bundler
+// target but relies on the specific `import { … } from` / `export { … } from`
+// shape it emits. If wasm-bindgen changes its codegen shape in a future
+// version, these regexes will need updating. The CI smoke tests will catch
+// such breakage at build time (aliases can't be resolved → throw).
+
 // Extract the named-export alias list from wasm-bindgen's generated
 // `aleo_wasm.js`, skipping items we handle explicitly in the CJS entry.
 function extractReexportAliases(source) {

--- a/wasm/build.js
+++ b/wasm/build.js
@@ -56,8 +56,6 @@ async function buildWasm(network) {
 
 
 async function buildJS(network) {
-    // ESM entry: wasm-bindgen's generated aleo_wasm.js uses top-level `await`
-    // to async-fetch and compile the .wasm binary. This is fine for ESM.
     const esmEntry = `export * from "./dist/${network}/tmp/aleo_wasm.js";
 
 import { initThreadPool as wasmInitThreadPool } from "./dist/${network}/tmp/aleo_wasm.js";
@@ -72,128 +70,57 @@ export async function initThreadPool(threads) {
     await wasmInitThreadPool(new URL("worker.js", import.meta.url), threads);
 }`;
 
-    const bundleEsm = await rollup({
+    await buildRollup({
         input: { "index": "entry" },
         plugins: [virtual({ "entry": esmEntry })],
+    }, {
+        dir: `dist/${network}`,
+        format: "es",
+        sourcemap: true,
     });
+}
 
-    try {
-        await bundleEsm.write({
-            dir: `dist/${network}`,
-            format: "es",
-            sourcemap: true,
-        });
-    } finally {
-        await bundleEsm.close();
-    }
 
-    // CJS entry: top-level `await` is illegal in CommonJS, so we cannot go
-    // through `aleo_wasm.js`. We instead import the underlying glue module
-    // (`tmp/index.js`, which has no TLA), synchronously load the .wasm from
-    // disk via `fs.readFileSync`, and call `initSync` before re-exporting.
-    //
-    // The re-export alias list is derived at build time from the ESM entry
-    // that wasm-bindgen produces, so the CJS surface stays in sync with the
-    // ESM surface without hand-maintenance.
-    const aleoWasmEsm = await $fs.readFile(
-        `dist/${network}/tmp/aleo_wasm.js`,
-        "utf8",
-    );
-    const reexportAliases = extractReexportAliases(aleoWasmEsm);
-
-    const threadPoolAlias = extractAliasFor(aleoWasmEsm, "initThreadPool");
-    const initSyncAlias = extractAliasFor(aleoWasmEsm, "initSync");
-
-    const cjsEntry = `import {
-    ${initSyncAlias} as __initSync,
-    ${threadPoolAlias} as wasmInitThreadPool,
-} from "./dist/${network}/tmp/index.js";
+// Builds a .cjs version which initializes the Wasm synchronously so the
+// module can be loaded with `require`. Uses initSync from the custom entry
+// and a shallow copy of the wasm exports to override initThreadPool.
+async function buildCommonJS(network) {
+    const js = `import { module as url, initSync } from "./dist/${network}/tmp/aleo_wasm_custom.js";
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// Rollup's CJS output transforms \`import.meta.url\` into
-// \`pathToFileURL(__filename).href\`, so this resolves to the emitted
-// \`index.cjs\` sibling — from which \`aleo_wasm.wasm\` lives next to.
-const __here = dirname(fileURLToPath(import.meta.url));
-const __wasmBytes = readFileSync(join(__here, "aleo_wasm.wasm"));
-__initSync({ module: __wasmBytes });
+const wasm = initSync({
+    module: readFileSync(fileURLToPath(url)),
+});
 
-export { ${reexportAliases} } from "./dist/${network}/tmp/index.js";
+// We have to make a shallow copy because ES6 exports are frozen.
+const exports = { ...wasm };
 
-export async function initThreadPool(threads) {
+const wasmInitThreadPool = wasm.initThreadPool;
+
+exports.initThreadPool = async function initThreadPool(threads) {
     if (threads == null) {
-        threads = require('node:os').availableParallelism();
+        threads = navigator.hardwareConcurrency;
     }
 
     console.info(\`Spawning \${threads} threads\`);
 
     await wasmInitThreadPool(new URL("worker.js", import.meta.url), threads);
-}`;
+};
 
-    const bundleCjs = await rollup({
-        input: { "index": "entry-cjs" },
-        external: ["node:fs", "node:path", "node:url", "node:os"],
-        plugins: [virtual({ "entry-cjs": cjsEntry })],
+module.exports = exports;`;
+
+    await buildRollup({
+        input: { "index": "entry" },
+        plugins: [virtual({ "entry": js })],
+    }, {
+        dir: `dist/${network}`,
+        format: "cjs",
+        external: ["node:fs", "node:url"],
+        entryFileNames: "[name].cjs",
+        chunkFileNames: "[name].cjs",
+        sourcemap: true,
     });
-
-    try {
-        await bundleCjs.write({
-            dir: `dist/${network}`,
-            format: "cjs",
-            entryFileNames: "[name].cjs",
-            chunkFileNames: "[name].cjs",
-            sourcemap: true,
-        });
-    } finally {
-        await bundleCjs.close();
-    }
-}
-
-// The two helpers below parse wasm-bindgen's emitted JS textually to recover
-// the short-name aliases (e.g. `A as Address`, `a0 as initSync`). This works
-// with wasm-bindgen 0.2.100's bundler target but relies on the specific
-// `import { … } from` / `export { … } from` shape it emits — if wasm-bindgen
-// changes its codegen shape in a future version, these regexes will need
-// updating. CI catches such breakage at build time (the alias lookup throws
-// when the expected pattern is missing).
-
-// Extract the named-export alias list from wasm-bindgen's generated
-// `aleo_wasm.js`, skipping items we handle explicitly in the CJS entry.
-function extractReexportAliases(source) {
-    const blocks = [
-        ...source.matchAll(/export \{([^}]+)\} from/g),
-    ].map((m) => m[1]);
-    if (blocks.length === 0) {
-        throw new Error("Could not locate re-export block in aleo_wasm.js");
-    }
-    return blocks
-        .flatMap((block) => block.split(",").map((s) => s.trim()))
-        .filter((s) => s && !/\bas (?:initSync|__wbg_init|initThreadPool)$/.test(s))
-        .join(", ");
-}
-
-// Resolve the wasm-bindgen short-name alias (e.g. "a0") for a given long
-// name (e.g. "initSync"), so the CJS entry can import from `tmp/index.js`
-// (which only exposes short names) rather than through `aleo_wasm.js`
-// (which has a top-level await we cannot emit as CJS).
-//
-// Both `import {…}` and `export {…}` blocks in `aleo_wasm.js` may hold the
-// alias (e.g. `__wbg_init` is only in the import block), so we scan both.
-function extractAliasFor(source, longName) {
-    const blocks = [
-        ...source.matchAll(/(?:import|export) \{([^}]+)\} from/g),
-    ].map((m) => m[1]);
-    for (const block of blocks) {
-        const entry = block
-            .split(",")
-            .map((s) => s.trim())
-            .find((s) => new RegExp(`\\bas ${longName}$`).test(s));
-        if (entry) {
-            return entry.split(/\s+as\s+/)[0];
-        }
-    }
-    throw new Error(`Could not find alias for ${longName} in aleo_wasm.js`);
 }
 
 
@@ -294,6 +221,7 @@ async function build(network) {
 
     await Promise.all([
         buildJS(network),
+        buildCommonJS(network),
         buildWorker(network),
     ]);
 

--- a/wasm/build.js
+++ b/wasm/build.js
@@ -151,13 +151,13 @@ export async function initThreadPool(threads) {
     }
 }
 
-// BRITTLENESS NOTE: the two helpers below parse wasm-bindgen's emitted JS
-// textually to recover the short-name aliases (e.g. `A as Address`,
-// `a0 as initSync`). This works today with wasm-bindgen 0.2.100's bundler
-// target but relies on the specific `import { … } from` / `export { … } from`
-// shape it emits. If wasm-bindgen changes its codegen shape in a future
-// version, these regexes will need updating. The CI smoke tests will catch
-// such breakage at build time (aliases can't be resolved → throw).
+// The two helpers below parse wasm-bindgen's emitted JS textually to recover
+// the short-name aliases (e.g. `A as Address`, `a0 as initSync`). This works
+// with wasm-bindgen 0.2.100's bundler target but relies on the specific
+// `import { … } from` / `export { … } from` shape it emits — if wasm-bindgen
+// changes its codegen shape in a future version, these regexes will need
+// updating. CI catches such breakage at build time (the alias lookup throws
+// when the expected pattern is missing).
 
 // Extract the named-export alias list from wasm-bindgen's generated
 // `aleo_wasm.js`, skipping items we handle explicitly in the CJS entry.

--- a/wasm/build.js
+++ b/wasm/build.js
@@ -133,6 +133,7 @@ export async function initThreadPool(threads) {
 
     const bundleCjs = await rollup({
         input: { "index": "entry-cjs" },
+        external: ["node:fs", "node:path", "node:url", "node:os"],
         plugins: [virtual({ "entry-cjs": cjsEntry })],
     });
 

--- a/wasm/build.js
+++ b/wasm/build.js
@@ -103,10 +103,8 @@ export async function initThreadPool(threads) {
 
     const threadPoolAlias = extractAliasFor(aleoWasmEsm, "initThreadPool");
     const initSyncAlias = extractAliasFor(aleoWasmEsm, "initSync");
-    const wbgInitAlias = extractAliasFor(aleoWasmEsm, "__wbg_init");
 
     const cjsEntry = `import {
-    ${wbgInitAlias} as __wbg_init,
     ${initSyncAlias} as __initSync,
     ${threadPoolAlias} as wasmInitThreadPool,
 } from "./dist/${network}/tmp/index.js";
@@ -125,7 +123,7 @@ export { ${reexportAliases} } from "./dist/${network}/tmp/index.js";
 
 export async function initThreadPool(threads) {
     if (threads == null) {
-        threads = navigator.hardwareConcurrency;
+        threads = require('node:os').availableParallelism();
     }
 
     console.info(\`Spawning \${threads} threads\`);
@@ -162,13 +160,14 @@ export async function initThreadPool(threads) {
 // Extract the named-export alias list from wasm-bindgen's generated
 // `aleo_wasm.js`, skipping items we handle explicitly in the CJS entry.
 function extractReexportAliases(source) {
-    const exportMatch = source.match(/export \{([^}]+)\} from/);
-    if (!exportMatch) {
+    const blocks = [
+        ...source.matchAll(/export \{([^}]+)\} from/g),
+    ].map((m) => m[1]);
+    if (blocks.length === 0) {
         throw new Error("Could not locate re-export block in aleo_wasm.js");
     }
-    return exportMatch[1]
-        .split(",")
-        .map((s) => s.trim())
+    return blocks
+        .flatMap((block) => block.split(",").map((s) => s.trim()))
         .filter((s) => s && !/\bas (?:initSync|__wbg_init|initThreadPool)$/.test(s))
         .join(", ");
 }

--- a/wasm/build.js
+++ b/wasm/build.js
@@ -56,7 +56,9 @@ async function buildWasm(network) {
 
 
 async function buildJS(network) {
-    const js = `export * from "./dist/${network}/tmp/aleo_wasm.js";
+    // ESM entry: wasm-bindgen's generated aleo_wasm.js uses top-level `await`
+    // to async-fetch and compile the .wasm binary. This is fine for ESM.
+    const esmEntry = `export * from "./dist/${network}/tmp/aleo_wasm.js";
 
 import { initThreadPool as wasmInitThreadPool } from "./dist/${network}/tmp/aleo_wasm.js";
 
@@ -70,20 +72,120 @@ export async function initThreadPool(threads) {
     await wasmInitThreadPool(new URL("worker.js", import.meta.url), threads);
 }`;
 
-    await buildRollup({
-        input: {
-            "index": "entry",
-        },
-        plugins: [
-            virtual({
-                "entry": js,
-            }),
-        ],
-    }, {
-        dir: `dist/${network}`,
-        format: "es",
-        sourcemap: true,
+    const bundleEsm = await rollup({
+        input: { "index": "entry" },
+        plugins: [virtual({ "entry": esmEntry })],
     });
+
+    try {
+        await bundleEsm.write({
+            dir: `dist/${network}`,
+            format: "es",
+            sourcemap: true,
+        });
+    } finally {
+        await bundleEsm.close();
+    }
+
+    // CJS entry: top-level `await` is illegal in CommonJS, so we cannot go
+    // through `aleo_wasm.js`. We instead import the underlying glue module
+    // (`tmp/index.js`, which has no TLA), synchronously load the .wasm from
+    // disk via `fs.readFileSync`, and call `initSync` before re-exporting.
+    //
+    // The re-export alias list is derived at build time from the ESM entry
+    // that wasm-bindgen produces, so the CJS surface stays in sync with the
+    // ESM surface without hand-maintenance.
+    const aleoWasmEsm = await $fs.readFile(
+        `dist/${network}/tmp/aleo_wasm.js`,
+        "utf8",
+    );
+    const reexportAliases = extractReexportAliases(aleoWasmEsm);
+
+    const threadPoolAlias = extractAliasFor(aleoWasmEsm, "initThreadPool");
+    const initSyncAlias = extractAliasFor(aleoWasmEsm, "initSync");
+    const wbgInitAlias = extractAliasFor(aleoWasmEsm, "__wbg_init");
+
+    const cjsEntry = `import {
+    ${wbgInitAlias} as __wbg_init,
+    ${initSyncAlias} as __initSync,
+    ${threadPoolAlias} as wasmInitThreadPool,
+} from "./dist/${network}/tmp/index.js";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Rollup's CJS output transforms \`import.meta.url\` into
+// \`pathToFileURL(__filename).href\`, so this resolves to the emitted
+// \`index.cjs\` sibling — from which \`aleo_wasm.wasm\` lives next to.
+const __here = dirname(fileURLToPath(import.meta.url));
+const __wasmBytes = readFileSync(join(__here, "aleo_wasm.wasm"));
+__initSync({ module: __wasmBytes });
+
+export { ${reexportAliases} } from "./dist/${network}/tmp/index.js";
+
+export async function initThreadPool(threads) {
+    if (threads == null) {
+        threads = navigator.hardwareConcurrency;
+    }
+
+    console.info(\`Spawning \${threads} threads\`);
+
+    await wasmInitThreadPool(new URL("worker.js", import.meta.url), threads);
+}`;
+
+    const bundleCjs = await rollup({
+        input: { "index": "entry-cjs" },
+        plugins: [virtual({ "entry-cjs": cjsEntry })],
+    });
+
+    try {
+        await bundleCjs.write({
+            dir: `dist/${network}`,
+            format: "cjs",
+            entryFileNames: "[name].cjs",
+            chunkFileNames: "[name].cjs",
+            sourcemap: true,
+        });
+    } finally {
+        await bundleCjs.close();
+    }
+}
+
+// Extract the named-export alias list from wasm-bindgen's generated
+// `aleo_wasm.js`, skipping items we handle explicitly in the CJS entry.
+function extractReexportAliases(source) {
+    const exportMatch = source.match(/export \{([^}]+)\} from/);
+    if (!exportMatch) {
+        throw new Error("Could not locate re-export block in aleo_wasm.js");
+    }
+    return exportMatch[1]
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s && !/\bas (?:initSync|__wbg_init|initThreadPool)$/.test(s))
+        .join(", ");
+}
+
+// Resolve the wasm-bindgen short-name alias (e.g. "a0") for a given long
+// name (e.g. "initSync"), so the CJS entry can import from `tmp/index.js`
+// (which only exposes short names) rather than through `aleo_wasm.js`
+// (which has a top-level await we cannot emit as CJS).
+//
+// Both `import {…}` and `export {…}` blocks in `aleo_wasm.js` may hold the
+// alias (e.g. `__wbg_init` is only in the import block), so we scan both.
+function extractAliasFor(source, longName) {
+    const blocks = [
+        ...source.matchAll(/(?:import|export) \{([^}]+)\} from/g),
+    ].map((m) => m[1]);
+    for (const block of blocks) {
+        const entry = block
+            .split(",")
+            .map((s) => s.trim())
+            .find((s) => new RegExp(`\\bas ${longName}$`).test(s));
+        if (entry) {
+            return entry.split(/\s+as\s+/)[0];
+        }
+    }
+    throw new Error(`Could not find alias for ${longName} in aleo_wasm.js`);
 }
 
 
@@ -152,7 +254,13 @@ export * from "./aleo_wasm.js";`;
     await $fs.mkdir(`dist/${network}`, { recursive: true })
 
     await Promise.all([
+        // ESM consumers resolve through the `import` condition → `index.d.ts`.
         $fs.writeFile(`dist/${network}/index.d.ts`, js),
+        // CJS consumers resolve through the `require` condition → `index.d.cts`.
+        // Same declarations; distinct filename satisfies TypeScript's node16
+        // module-resolution check and silences `arethetypeswrong`'s
+        // "Masquerading as ESM" warning.
+        $fs.writeFile(`dist/${network}/index.d.cts`, js),
         $fs.writeFile(`dist/${network}/worker.d.ts`, worker),
     ]);
 }

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -7,15 +7,40 @@
     "The Provable Team"
   ],
   "license": "GPL-3.0",
-  "main": "./dist/testnet/index.js",
+  "main": "./dist/testnet/index.cjs",
   "browser": "./dist/testnet/index.js",
+  "module": "./dist/testnet/index.js",
   "types": "./dist/testnet/index.d.ts",
   "exports": {
-    ".": "./dist/testnet/index.js",
+    ".": {
+      "types": {
+        "import": "./dist/testnet/index.d.ts",
+        "require": "./dist/testnet/index.d.cts"
+      },
+      "import": "./dist/testnet/index.js",
+      "require": "./dist/testnet/index.cjs",
+      "default": "./dist/testnet/index.js"
+    },
     "./worker.js": "./dist/testnet/worker.js",
-    "./testnet.js": "./dist/testnet/index.js",
+    "./testnet.js": {
+      "types": {
+        "import": "./dist/testnet/index.d.ts",
+        "require": "./dist/testnet/index.d.cts"
+      },
+      "import": "./dist/testnet/index.js",
+      "require": "./dist/testnet/index.cjs",
+      "default": "./dist/testnet/index.js"
+    },
     "./testnet/worker.js": "./dist/testnet/worker.js",
-    "./mainnet.js": "./dist/mainnet/index.js",
+    "./mainnet.js": {
+      "types": {
+        "import": "./dist/mainnet/index.d.ts",
+        "require": "./dist/mainnet/index.d.cts"
+      },
+      "import": "./dist/mainnet/index.js",
+      "require": "./dist/mainnet/index.cjs",
+      "default": "./dist/mainnet/index.js"
+    },
     "./mainnet/worker.js": "./dist/mainnet/worker.js"
   },
   "files": [
@@ -39,9 +64,12 @@
   "homepage": "https://github.com/ProvableHQ/sdk#readme",
   "scripts": {
     "build": "rimraf dist && node build.js",
-    "test": "node test.js"
+    "test": "node test.js",
+    "_comment:test:attw": "cjs-resolves-to-esm is ignored because the worker subpath (./worker.js, ./testnet/worker.js, ./mainnet/worker.js) is ESM-only by design — the Node polyfill loads it via `eval` + dynamic import() from a CJS parent, not synchronous require().",
+    "test:attw": "yarn pack --filename /tmp/provablehq-wasm-attw.tgz && attw /tmp/provablehq-wasm-attw.tgz --profile=node16 --ignore-rules=cjs-resolves-to-esm"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.2",
     "@rollup/plugin-virtual": "^3.0.2",
     "@wasm-tool/rollup-plugin-rust": "^3.1.4",
     "binaryen": "^120.0.0",

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
     "@rollup/plugin-virtual": "^3.0.2",
-    "@wasm-tool/rollup-plugin-rust": "^3.1.4",
+    "@wasm-tool/rollup-plugin-rust": "^3.1.5",
     "binaryen": "^120.0.0",
     "rimraf": "^6.0.1",
     "rollup": "^4.59.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,11 @@
     tslib "^2.4.1"
     web-vitals "5.0.1"
 
+"@andrewbranch/untar.js@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz#ba9494f85eb83017c5c855763969caf1d0adea00"
+  integrity sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==
+
 "@ant-design/colors@^7.0.0", "@ant-design/colors@^7.2.1":
   version "7.2.1"
   resolved "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz"
@@ -133,6 +138,33 @@
     json2mq "^0.2.0"
     resize-observer-polyfill "^1.5.1"
     throttle-debounce "^5.0.0"
+
+"@arethetypeswrong/cli@^0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@arethetypeswrong/cli/-/cli-0.18.2.tgz#7c196e1b1549fcf77d84eacbcc47cab2cc6593dd"
+  integrity sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==
+  dependencies:
+    "@arethetypeswrong/core" "0.18.2"
+    chalk "^4.1.2"
+    cli-table3 "^0.6.3"
+    commander "^10.0.1"
+    marked "^9.1.2"
+    marked-terminal "^7.1.0"
+    semver "^7.5.4"
+
+"@arethetypeswrong/core@0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@arethetypeswrong/core/-/core-0.18.2.tgz#9be36d92ff5e65aae7a7683e7947cbeb41aa8e05"
+  integrity sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==
+  dependencies:
+    "@andrewbranch/untar.js" "^1.0.3"
+    "@loaderkit/resolve" "^1.0.2"
+    cjs-module-lexer "^1.2.3"
+    fflate "^0.8.2"
+    lru-cache "^11.0.1"
+    semver "^7.5.4"
+    typescript "5.6.1-rc"
+    validate-npm-package-name "^5.0.0"
 
 "@babel/code-frame@^7.27.1":
   version "7.27.1"
@@ -1021,6 +1053,11 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@braidai/lang@^1.0.0":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@braidai/lang/-/lang-1.1.2.tgz#65bc2bc1db6d00e153b95ac7006f4573e289e9be"
+  integrity sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==
+
 "@codemirror/autocomplete@^6.0.0":
   version "6.20.0"
   resolved "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz"
@@ -1169,6 +1206,11 @@
     crelt "^1.0.6"
     style-mod "^4.1.0"
     w3c-keyname "^2.2.4"
+
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -1746,6 +1788,13 @@
   dependencies:
     "@lezer/common" "^1.0.0"
 
+"@loaderkit/resolve@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@loaderkit/resolve/-/resolve-1.0.4.tgz#5ba1c2f4cc879d3fb2f066b71b8dc41a88bfb8e9"
+  integrity sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==
+  dependencies:
+    "@braidai/lang" "^1.0.0"
+
 "@marijn/find-cluster-break@^1.0.0":
   version "1.0.2"
   resolved "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz"
@@ -2162,6 +2211,11 @@
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"
     "@noble/hashes" "^2.0.1"
+
+"@sindresorhus/is@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
 "@sindresorhus/merge-streams@^2.1.0":
   version "2.3.0"
@@ -3054,6 +3108,13 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
+ansi-escapes@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
+  dependencies:
+    environment "^1.0.0"
+
 ansi-html-community@^0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz"
@@ -3064,7 +3125,7 @@ ansi-regex@^5.0.1:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
+ansi-regex@^6.0.1, ansi-regex@^6.1.0:
   version "6.2.2"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
   integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
@@ -3135,6 +3196,11 @@ antd@^5.23.2:
     rc-util "^5.44.4"
     scroll-into-view-if-needed "^3.1.0"
     throttle-debounce "^5.0.2"
+
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
 
 anymatch@~3.1.2:
   version "3.1.3"
@@ -3644,7 +3710,7 @@ chai@^5.1.2:
     loupe "^3.1.0"
     pathval "^2.0.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3652,10 +3718,15 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.6.2:
+chalk@^5.4.1, chalk@^5.6.2:
   version "5.6.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
+
+char-regex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
+  integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
 character-parser@^2.1.1:
   version "2.2.0"
@@ -3713,6 +3784,11 @@ citty@^0.1.6:
   dependencies:
     consola "^3.2.3"
 
+cjs-module-lexer@^1.2.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz#0f79731eb8cfe1ec72acd4066efac9d61991b00d"
+  integrity sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==
+
 classnames@2.x, classnames@^2.2.1, classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.1, classnames@^2.3.2, classnames@^2.5.1:
   version "2.5.1"
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz"
@@ -3743,6 +3819,27 @@ clean-jsdoc-theme@^4.3.0:
     klaw-sync "^6.0.0"
     lodash "^4.17.21"
     showdown "^2.1.0"
+
+cli-highlight@^2.1.11:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.11.tgz#49736fa452f0aaf4fae580e30acb26828d2dc1bf"
+  integrity sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==
+  dependencies:
+    chalk "^4.0.0"
+    highlight.js "^10.7.1"
+    mz "^2.4.0"
+    parse5 "^5.1.1"
+    parse5-htmlparser2-tree-adapter "^6.0.0"
+    yargs "^16.0.0"
+
+cli-table3@^0.6.3, cli-table3@^0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.5.tgz#013b91351762739c16a9567c21a04632e449bf2f"
+  integrity sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 client-only@0.0.1:
   version "0.0.1"
@@ -3832,7 +3929,7 @@ comlink@^4.4.2:
   resolved "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz"
   integrity sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==
 
-commander@^10.0.0:
+commander@^10.0.0, commander@^10.0.1:
   version "10.0.1"
   resolved "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
@@ -4488,6 +4585,11 @@ emoji-regex@^9.2.2:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
+emojilib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/emojilib/-/emojilib-2.4.0.tgz#ac518a8bb0d5f76dda57289ccb2fdf9d39ae721e"
+  integrity sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==
+
 emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz"
@@ -4525,6 +4627,11 @@ envinfo@^7.14.0:
   version "7.21.0"
   resolved "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz"
   integrity sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==
+
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9, es-abstract@^1.24.0:
   version "1.24.0"
@@ -5036,6 +5143,11 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
+fflate@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz"
@@ -5528,6 +5640,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highlight.js@^10.7.1:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 hookable@^5.5.3:
   version "5.5.3"
@@ -6468,6 +6585,11 @@ lru-cache@^11.0.0:
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz"
   integrity sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==
 
+lru-cache@^11.0.1:
+  version "11.3.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.3.5.tgz#29047d348c0b2793e3112a01c739bb7c6d855637"
+  integrity sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==
+
 lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz"
@@ -6526,10 +6648,28 @@ markdown-it@^14.1.0:
     punycode.js "^2.3.1"
     uc.micro "^2.1.0"
 
+marked-terminal@^7.1.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-7.3.0.tgz#7a86236565f3dd530f465ffce9c3f8b62ef270e8"
+  integrity sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==
+  dependencies:
+    ansi-escapes "^7.0.0"
+    ansi-regex "^6.1.0"
+    chalk "^5.4.1"
+    cli-highlight "^2.1.11"
+    cli-table3 "^0.6.5"
+    node-emoji "^2.2.0"
+    supports-hyperlinks "^3.1.0"
+
 marked@^4.0.10:
   version "4.3.0"
   resolved "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
+
+marked@^9.1.2:
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-9.1.6.tgz#5d2a3f8180abfbc5d62e3258a38a1c19c0381695"
+  integrity sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -6792,6 +6932,15 @@ multicast-dns@^7.2.5:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
 
+mz@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
 nanoid@^3.3.11, nanoid@^3.3.6:
   version "3.3.11"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
@@ -6868,6 +7017,16 @@ node-domexception@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
+node-emoji@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-2.2.0.tgz#1d000e3c76e462577895be1b436f4aa2d6760eb0"
+  integrity sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==
+  dependencies:
+    "@sindresorhus/is" "^4.6.0"
+    char-regex "^1.0.2"
+    emojilib "^2.4.0"
+    skin-tone "^2.0.0"
 
 node-fetch@^3.3.2:
   version "3.3.2"
@@ -7101,6 +7260,23 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse5-htmlparser2-tree-adapter@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -8826,6 +9002,13 @@ sisteransi@^1.0.5:
   resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+skin-tone@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/skin-tone/-/skin-tone-2.0.0.tgz#4e3933ab45c0d4f4f781745d64b9f4c208e41237"
+  integrity sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==
+  dependencies:
+    unicode-emoji-modifier-base "^1.0.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
@@ -9099,7 +9282,7 @@ stylis@^4.3.4:
   resolved "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz"
   integrity sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==
 
-supports-color@^7.1.0, supports-color@^7.2.0:
+supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -9112,6 +9295,14 @@ supports-color@^8.0.0, supports-color@^8.1.1:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
+
+supports-hyperlinks@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz#b8e485b179681dea496a1e7abdf8985bd3145461"
+  integrity sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -9194,6 +9385,20 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
 
 thingies@^2.5.0:
   version "2.5.0"
@@ -9371,6 +9576,11 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
+typescript@5.6.1-rc:
+  version "5.6.1-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.1-rc.tgz#d5e4d7d8170174fed607b74cc32aba3d77018e02"
+  integrity sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==
+
 typescript@^3.2.2:
   version "3.9.10"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz"
@@ -9476,6 +9686,11 @@ unicode-canonical-property-names-ecmascript@^2.0.0:
   resolved "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz"
   integrity sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==
 
+unicode-emoji-modifier-base@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz#dbbd5b54ba30f287e2a8d5a249da6c0cef369459"
+  integrity sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==
+
 unicode-match-property-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz"
@@ -9568,6 +9783,11 @@ v8-to-istanbul@^9.0.0:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
+
+validate-npm-package-name@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
+  integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
 
 vary@~1.1.2:
   version "1.1.2"
@@ -9987,7 +10207,7 @@ yargs-unparser@^2.0.0:
     flat "^5.0.2"
     is-plain-obj "^2.1.0"
 
-yargs@^16.2.0:
+yargs@^16.0.0, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,10 +2838,10 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
 
-"@wasm-tool/rollup-plugin-rust@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.npmjs.org/@wasm-tool/rollup-plugin-rust/-/rollup-plugin-rust-3.1.4.tgz"
-  integrity sha512-XW3nk8yFPPc86jLXVEXkqQxsx9M6i+j5Boru5yapfS/+egK2IOYsuEOvM3am+/YrKczohKP45+cBKYkxSSGGzg==
+"@wasm-tool/rollup-plugin-rust@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@wasm-tool/rollup-plugin-rust/-/rollup-plugin-rust-3.1.5.tgz#9925331dad6d5e59793f317e8523537281d1d537"
+  integrity sha512-9JmWBqn6lZAo+TYLObppMffPhFZJsBX5Oyh9IKDWScCvxDiRfqoM5WnLMf9twgboVO8n0f1a1SwtjqHpmMM9fQ==
   dependencies:
     "@iarna/toml" "^2.2.5"
     "@rollup/pluginutils" "^5.3.0"


### PR DESCRIPTION
## Motivation

A partner team requested that we ship CommonJS-compatible builds so they can `require('@provablehq/sdk')` directly from a CJS codebase without wrapping every entry point in an `await import()` IIFE. Today both `@provablehq/sdk` and `@provablehq/wasm` are ESM-only, which fails with `ERR_REQUIRE_ESM` when a CJS consumer tries to load them.

This PR adds a CJS build target to both packages alongside the existing ESM output, with full type declarations (`.d.cts`), threaded worker support, and CI validation. CJS consumers can now `require()` the SDK with the same threaded API surface as ESM consumers.

> **Note:** The noble-sodium crypto swap and `.js` import extension fixes that were originally part of this branch have been split out and merged independently via #1295. This PR is now purely the CJS build system work.

### What's in the PR

- **CJS output for `@provablehq/wasm`**: a second build pass emits `dist/<network>/index.cjs` alongside `index.js`. The CJS entry bypasses wasm-bindgen's top-level-await initialization by importing the underlying glue module directly and calling `initSync` with `fs.readFileSync`'d wasm bytes. Both formats share the same `.wasm` binary.

- **CJS output for `@provablehq/sdk`**: a second Rollup output entry per network emits `dist/<network>/{node,browser,node-polyfill}.cjs` alongside the ESM `.js` files. Single TypeScript compile, two output formats. The dynamic variant gets a CJS loader too.

- **`exports` map with `types`/`import`/`require` conditions**: both packages now have full conditional exports. `arethetypeswrong --profile=node16` passes green for all subpaths on both `import` and `require`.

- **CI validation**: a new `cjs-smoke` job runs on every PR (attw + file-path smoke + packed-and-installed smoke including `initThreadPool`). A separate `cjs-e2e` job runs only on pushes to protected branches and exercises the full encrypted DPS round-trip against staging — gated to avoid burning testnet transactions on every PR.

### Notable callouts

- **`main` field flipped from ESM to CJS** in both packages. Modern consumers resolve through the `exports` map and aren't affected. Legacy consumers that bypass `exports` (some old bundlers, `require.resolve`) previously got ESM via `main` and now get CJS — this is the correct change for `main`'s historical CJS-only semantics.
- **Workers stay ESM** in both formats. The Node polyfill spawns them via `eval` + dynamic `import()`, which works fine from a CJS parent. No second wasm-bindgen worker target needed.
- **Known limitation (documented in code)**: the wasm CJS entry generation parses wasm-bindgen's emitted JS textually to recover short-name aliases. Stable across wasm-bindgen 0.2.x but worth knowing about. The build will throw loudly on a future wasm-bindgen output-shape change rather than silently miscompile, and CI smoke will catch it.

## Test Plan

Validated end-to-end on both supported paths.

**Local validation (run from repo root):**

```bash
yarn build:all
yarn test:sdk                              
node sdk/tests/cjs-smoke/smoke.cjs         # CJS file-path smoke - 17 checks
cd sdk && yarn test:cjs:pack               # pack + install + require() through exports.require
yarn test:attw                             # exports map validation (node16 CJS + ESM + bundler)
cd ../wasm && yarn test:attw               # same for the wasm package
```

### CJS support window

CJS support is accepted with a 12-month review window (April 2027). See [ADR-001](docs/adr/001-cjs-support.md) for constraints, removal plan, and review criteria.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes build outputs and package `exports`/`main` resolution for both `@provablehq/sdk` and `@provablehq/wasm`, which can affect downstream consumers’ module and type resolution. Runtime logic is largely unchanged, but the new CJS init path and packaging validations could surface edge-case compatibility issues.
> 
> **Overview**
> Adds **first-class CommonJS (`require`) support** alongside existing ESM outputs for both `@provablehq/sdk` and `@provablehq/wasm`, including conditional `exports` entries with `import`/`require` + `types` mappings and `.d.cts` type artifacts.
> 
> Updates the build pipeline to emit `.cjs` bundles (SDK via dual Rollup outputs + generated CJS dynamic loader; WASM via a new CJS entry that uses synchronous `initSync` with `fs.readFileSync`), and adds a Rollup post-step to duplicate `.d.ts` to `.d.cts` for CJS type resolution.
> 
> Introduces **CI gating** for CJS compatibility (`arethetypeswrong` checks plus local and packed-install CJS smoke tests), adds CJS smoke fixtures/scripts, tweaks worker polyfill concurrency detection, and documents the CJS support decision/removal plan in a new ADR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da980f0dc92516c715cdc6489e916609729cf3f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->