### PR TITLE
Add configurable transport option for custom HTTP agents and mTLS support

### DIFF
--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -109,7 +109,7 @@ async function initializeWasm() {
 
 export { ProgramManager, ProvingRequestOptions, ExecuteOptions, FeeAuthorizationOptions, AuthorizationOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof } from "./program-manager.js";
 
-export { logAndThrow } from "./utils.js";
+export { logAndThrow, TransportFunction } from "./utils.js";
 
 export {
     Address,

--- a/sdk/src/keys/provider/memory.ts
+++ b/sdk/src/keys/provider/memory.ts
@@ -21,7 +21,7 @@ import {
     VerifyingKey,
 } from "../../wasm.js";
 
-import { get } from "../../utils.js";
+import { get, TransportFunction, defaultTransport } from "../../utils.js";
 import { KeyStore } from "../keystore/interface.js";
 
 type AleoKeyProviderInitParams = {
@@ -66,10 +66,11 @@ class AleoKeyProvider implements FunctionKeyProvider {
     cache: Map<string, CachedKeyPair>;
     cacheOption: boolean;
     keyUris: string;
+    transport: TransportFunction;
 
     async fetchBytes(url = "/"): Promise<Uint8Array> {
         try {
-            const response = await get(url);
+            const response = await get(url, undefined, this.transport);
             const data = await response.arrayBuffer();
             return new Uint8Array(data);
         } catch (error: any) {
@@ -77,10 +78,11 @@ class AleoKeyProvider implements FunctionKeyProvider {
         }
     }
 
-    constructor() {
+    constructor(options?: { transport?: TransportFunction }) {
         this.keyUris = KEY_STORE;
         this.cache = new Map<string, CachedKeyPair>();
         this.cacheOption = false;
+        this.transport = options?.transport ?? defaultTransport;
     }
 
     async keyStore(): Promise<KeyStore | undefined> {
@@ -521,7 +523,7 @@ class AleoKeyProvider implements FunctionKeyProvider {
             default:
                 try {
                     /// Try to fetch the verifying key from the network as a string
-                    const response = await get(verifierUri);
+                    const response = await get(verifierUri, undefined, this.transport);
                     const text = await response.text();
                     return <VerifyingKey>VerifyingKey.fromString(text);
                 } catch (e) {

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1,4 +1,4 @@
-import { get, post, parseJSON, logAndThrow, retryWithBackoff, environment, isNode } from "./utils.js";
+import { get, post, parseJSON, logAndThrow, retryWithBackoff, environment, isNode, TransportFunction, defaultTransport } from "./utils.js";
 import { Account } from "./account.js";
 import { BlockJSON } from "./models/blockJSON.js";
 import { TransactionJSON } from "./models/transaction/transactionJSON.js";
@@ -32,6 +32,7 @@ interface AleoNetworkClientOptions {
     headers?: { [key: string]: string };
     proverUri?: string;
     recordScannerUri?: string;
+    transport?: TransportFunction;
 }
 
 /**
@@ -86,6 +87,7 @@ class AleoNetworkClient {
     ctx: { [key: string]: string };
     verboseErrors: boolean;
     readonly network: string;
+    transport: TransportFunction;
     apiKey?: string;
     consumerId?: string;
     jwtData?: JWTData;
@@ -100,6 +102,7 @@ class AleoNetworkClient {
         this.network = "%%NETWORK%%";
         this.ctx = {};
         this.verboseErrors = true;
+        this.transport = options?.transport ?? defaultTransport;
 
         if (options) {
             if (options.headers) {
@@ -280,7 +283,7 @@ class AleoNetworkClient {
                         ...this.headers,
                         ...ctx,
                     },
-                });
+                }, this.transport);
                 return await response.text();
             });
         } catch (error) {
@@ -296,7 +299,7 @@ class AleoNetworkClient {
      * @returns The Response object from the POST request.
      */
     private async _sendPost(url: string, options: RequestInit) {
-        return post(url, options);
+        return post(url, options, this.transport);
     }
 
     /**
@@ -1701,7 +1704,7 @@ class AleoNetworkClient {
                     headers: Object.assign({}, {...this.headers, "X-ALEO-METHOD": "submitSolution"}, {
                         "Content-Type": "application/json",
                     }),
-                }),
+                }, this.transport),
             );
 
             try {
@@ -1736,7 +1739,8 @@ class AleoNetworkClient {
                 headers: {
                     'X-Provable-API-Key': apiKey
                 }
-            }
+            },
+            this.transport,
         );
         const authHeader = response.headers.get('authorization');
         if (!authHeader) {
@@ -1856,7 +1860,7 @@ class AleoNetworkClient {
                 const pubKeyResponse = await get(proverUri + "/pubkey", {
                     headers,
                     credentials: "include",
-                });
+                }, this.transport);
 
                 // Encrypt the provingRequest.
                 const pubkey: CryptoBoxPubKey = parseJSON(
@@ -1877,7 +1881,7 @@ class AleoNetworkClient {
                 const cookie = isNode() ? pubKeyResponse.headers.get("set-cookie"): undefined;
 
                 // Send the encrypted proving request to the DPS service.
-                const res = await fetch(`${proverUri}/prove/encrypted`, {
+                const res = await this.transport(`${proverUri}/prove/encrypted`, {
                     method: "POST",
                     body: JSON.stringify(payload),
                     headers: {
@@ -1895,7 +1899,7 @@ class AleoNetworkClient {
             const proveEndpoint = (<string>proverUri).endsWith("/prove")
                 ? proverUri
                 : proverUri + "/prove";
-            const res = await fetch(proveEndpoint, {
+            const res = await this.transport(proveEndpoint, {
                 method: "POST",
                 body: provingRequestString,
                 headers,
@@ -1981,7 +1985,7 @@ class AleoNetworkClient {
                 }
 
                 try {
-                    const res = await fetch(
+                    const res = await this.transport(
                         `${this.host}/transaction/confirmed/${transactionId}`,
                         {
                             headers: {

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -279,7 +279,7 @@ class ProgramManager {
         this.host = host ? host : "https://api.provable.com/v2";
         this.networkClient = new AleoNetworkClient(this.host, networkClientOptions);
 
-        this.keyProvider = keyProvider ? keyProvider : new AleoKeyProvider();
+        this.keyProvider = keyProvider ? keyProvider : new AleoKeyProvider({ transport: networkClientOptions?.transport });
         this.recordProvider = recordProvider;
     }
 

--- a/sdk/src/record-scanner.ts
+++ b/sdk/src/record-scanner.ts
@@ -1,4 +1,4 @@
-import { parseJSON, post } from "./utils.js";
+import { parseJSON, post, TransportFunction, defaultTransport } from "./utils.js";
 import { EncryptedRecord } from "./models/record-provider/encryptedRecord.js";
 import { CryptoBoxPubKey } from "./models/cryptoBoxPubkey.js";
 import { EncryptedRegistrationRequest } from "./models/record-scanner/encryptedRegistrationRequest.js";
@@ -63,6 +63,7 @@ export interface RecordScannerOptions {
     cacheViewKeysOnRegister?: boolean;
     autoReRegister?: boolean;
     decryptEnabled?: boolean;
+    transport?: TransportFunction;
 }
 
 /**
@@ -119,6 +120,7 @@ class RecordScanner implements RecordProvider {
     private viewKeys?: { [key: string]: ViewKey };
     private autoReRegister?: boolean;
     private decryptEnabled?: boolean;
+    transport: TransportFunction;
     account?: Account | undefined;
 
     /**
@@ -127,6 +129,7 @@ class RecordScanner implements RecordProvider {
     constructor(options: RecordScannerOptions) {
         // Set the network by detecting which version of the SDK is being used.
         const network = "/%%NETWORK%%";
+        this.transport = options.transport ?? defaultTransport;
 
         // If the user has configured a network in their uri, throw.
         if (options.url.endsWith("/mainnet") || options.url.endsWith("/testnet")) {
@@ -283,7 +286,8 @@ class RecordScanner implements RecordProvider {
                 headers: {
                     "X-Provable-API-Key": apiKey,
                 },
-            }
+            },
+            this.transport,
         );
         const authHeader = response.headers.get("authorization");
         if (!authHeader) {
@@ -907,7 +911,14 @@ class RecordScanner implements RecordProvider {
             if (this.apiKey) {
                 req.headers.set(this.apiKey.header, this.apiKey.value);
             }
-            const response = await fetch(req);
+            const body = req.body ? await req.text() : undefined;
+            const plainHeaders: Record<string, string> = {};
+            req.headers.forEach((value, key) => { plainHeaders[key] = value; });
+            const response = await this.transport(req.url, {
+                method: req.method,
+                headers: plainHeaders,
+                body,
+            });
 
             // Non-2xx: throw so callers can handleRequestError or re-register on 422 if autoReRegister is enabled.
             if (!response.ok) {

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -38,6 +38,16 @@ export function logAndThrow(message: string): never {
     throw new Error(message);
 }
 
+/**
+ * A function matching the global `fetch` signature. Consumers can provide
+ * their own implementation to inject custom HTTP agents, mTLS certificates,
+ * timeouts, or logging.
+ */
+export type TransportFunction = typeof fetch;
+
+/** Default transport — wraps global fetch to avoid illegal-invocation errors in browsers. */
+export const defaultTransport: TransportFunction = (...args) => fetch(...args);
+
 export function parseJSON(json: string): any {
     function revive(key: string, value: any, context: any) {
         if (Number.isInteger(value)) {
@@ -50,8 +60,8 @@ export function parseJSON(json: string): any {
     return JSON.parse(json, revive as any);
 }
 
-export async function get(url: URL | string, options?: RequestInit) {
-    const response = await fetch(url, options);
+export async function get(url: URL | string, options?: RequestInit, transport: TransportFunction = defaultTransport) {
+    const response = await transport(url, options);
 
     if (!response.ok) {
         throw new Error(response.status + " could not get URL " + url);
@@ -60,10 +70,10 @@ export async function get(url: URL | string, options?: RequestInit) {
     return response;
 }
 
-export async function post(url: URL | string, options: RequestInit) {
+export async function post(url: URL | string, options: RequestInit, transport: TransportFunction = defaultTransport) {
     options.method = "POST";
 
-    const response = await fetch(url, options);
+    const response = await transport(url, options);
 
     if (!response.ok) {
         const error = await response.text();

--- a/sdk/tests/record-scanner.test.ts
+++ b/sdk/tests/record-scanner.test.ts
@@ -64,15 +64,16 @@ describe("RecordScanner", () => {
         fetchStub.onCall(1).resolves(revokeResponse);
         await recordScanner.register(defaultAccount.viewKey(), 0);
         
-        const request = fetchStub.firstCall.args[0] as Request;
-        expect(request.headers.get("X-Provable-API-Key")).to.equal("1234567890");
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        expect(requestInit.headers["x-provable-api-key"]).to.equal("1234567890");
 
         const revokeResult = await recordScanner.revoke(validTestUuid);
         expect(revokeResult.ok).to.equal(true);
         expect(fetchStub.callCount).to.equal(2);
-        const revokeRequest = fetchStub.secondCall.args[0] as Request;
-        expect(revokeRequest.url).to.equal(recordScanner.url + "/revoke");
-        expect(revokeRequest.method).to.equal("POST");
+        const revokeUrl = fetchStub.secondCall.args[0] as string;
+        const revokeInit = fetchStub.secondCall.args[1] as any;
+        expect(revokeUrl).to.equal(recordScanner.url + "/revoke");
+        expect(revokeInit.method).to.equal("POST");
     });
 
     it("should intialize with the correct api key as an object", async () => {
@@ -94,8 +95,8 @@ describe("RecordScanner", () => {
         fetchStub.onCall(1).resolves(revokeResponse);
         await recordScanner.register(defaultAccount.viewKey(), 0);
         
-        const request = fetchStub.firstCall.args[0] as Request;
-        expect(request.headers.get("Some-API-Key")).to.equal("1234567890");
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        expect(requestInit.headers["some-api-key"]).to.equal("1234567890");
 
         const revokeResult = await recordScanner.revoke(validTestUuid);
         expect(revokeResult.ok).to.equal(true);
@@ -121,23 +122,25 @@ describe("RecordScanner", () => {
         const result = await recordScanner.register(defaultAccount.viewKey(), 0);
         
         expect(fetchStub.called).to.be.true;
-        const request = fetchStub.firstCall.args[0] as Request;
-        expect(request.url).to.equal(recordScanner.url + "/register");
-        expect(request.method).to.equal("POST");
-        expect(request.headers.get("Content-Type")).to.equal("application/json");
-        
-        const body = await request.text();
+        const requestUrl = fetchStub.firstCall.args[0] as string;
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        expect(requestUrl).to.equal(recordScanner.url + "/register");
+        expect(requestInit.method).to.equal("POST");
+        expect(requestInit.headers["content-type"]).to.equal("application/json");
+
+        const body = requestInit.body as string;
         const expectedBody = JSON.stringify({ view_key: defaultAccount.viewKey().to_string(), start: 0 });
         expect(body).to.equal(expectedBody);
-        
+
         expect(result.ok).to.equal(true);
         if (result.ok) expect(result.data.uuid).equal(validTestUuid);
 
         const revokeResult = await recordScanner.revoke(result.ok ? result.data.uuid : undefined);
         expect(revokeResult.ok).to.equal(true);
-        const revokeRequest = fetchStub.secondCall.args[0] as Request;
-        expect(revokeRequest.url).to.equal(recordScanner.url + "/revoke");
-        expect(revokeRequest.method).to.equal("POST");
+        const revokeUrl = fetchStub.secondCall.args[0] as string;
+        const revokeInit = fetchStub.secondCall.args[1] as any;
+        expect(revokeUrl).to.equal(recordScanner.url + "/revoke");
+        expect(revokeInit.method).to.equal("POST");
     });
 
     it("should return the optional fields of RegistrationResponse if present after successfully registering the account", async () => {
@@ -160,15 +163,16 @@ describe("RecordScanner", () => {
         const result = await recordScanner.register(defaultAccount.viewKey(), 0);
 
         expect(fetchStub.called).to.be.true;
-        const request = fetchStub.firstCall.args[0] as Request;
-        expect(request.url).to.equal(recordScanner.url + "/register");
-        expect(request.method).to.equal("POST");
-        expect(request.headers.get("Content-Type")).to.equal("application/json");
-        
-        const body = await request.text();
+        const requestUrl = fetchStub.firstCall.args[0] as string;
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        expect(requestUrl).to.equal(recordScanner.url + "/register");
+        expect(requestInit.method).to.equal("POST");
+        expect(requestInit.headers["content-type"]).to.equal("application/json");
+
+        const body = requestInit.body as string;
         const expectedBody = JSON.stringify({ view_key: defaultAccount.viewKey().to_string(), start: 0 });
         expect(body).to.equal(expectedBody);
-        
+
         expect(result.ok).to.equal(true);
         if (result.ok) {
             expect(result.data.uuid).equal(validTestUuid);
@@ -195,10 +199,11 @@ describe("RecordScanner", () => {
         if (result.ok) {
             expect(result.data.status).to.equal("OK");
         }
-        const request = fetchStub.firstCall.args[0] as Request;
-        expect(request.url).to.equal(recordScanner.url + "/revoke");
-        expect(request.method).to.equal("POST");
-        expect(await request.text()).to.equal(JSON.stringify(validTestUuid));
+        const requestUrl = fetchStub.firstCall.args[0] as string;
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        expect(requestUrl).to.equal(recordScanner.url + "/revoke");
+        expect(requestInit.method).to.equal("POST");
+        expect(requestInit.body).to.equal(JSON.stringify(validTestUuid));
     });
 
     it("revoke throws UUIDError when no UUID configured and none provided", async () => {
@@ -266,13 +271,14 @@ describe("RecordScanner", () => {
         const encryptedRecords = await recordScanner.encryptedRecords(filter);
         expect(encryptedRecords).to.equal(ENCRYPTED_RECORDS);
         
-        const request = fetchStub.firstCall.args[0] as Request;
-        const body = await request.text();
+        const requestUrl = fetchStub.firstCall.args[0] as string;
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        const body = requestInit.body as string;
         const expectedBody = JSON.stringify(filter);
         expect(body).to.equal(expectedBody);
-        expect(request.url).to.equal(recordScanner.url + "/records/encrypted");
-        expect(request.method).to.equal("POST");
-        expect(request.headers.get("Content-Type")).to.equal("application/json");
+        expect(requestUrl).to.equal(recordScanner.url + "/records/encrypted");
+        expect(requestInit.method).to.equal("POST");
+        expect(requestInit.headers["content-type"]).to.equal("application/json");
     });
 
     it("should return OwnedRecord[] after successfully getting owned records", async () => {
@@ -314,13 +320,14 @@ describe("RecordScanner", () => {
         const ownedRecords = await recordScanner.findRecords(filter);
         expect(ownedRecords).to.equal(OWNED_RECORDS);
 
-        const request = fetchStub.firstCall.args[0] as Request;
-        const body = await request.text();
+        const requestUrl = fetchStub.firstCall.args[0] as string;
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        const body = requestInit.body as string;
         const expectedBody = JSON.stringify(filter);
         expect(body).to.equal(expectedBody);
-        expect(request.url).to.equal(recordScanner.url + "/records/owned");
-        expect(request.method).to.equal("POST");
-        expect(request.headers.get("Content-Type")).to.equal("application/json");
+        expect(requestUrl).to.equal(recordScanner.url + "/records/owned");
+        expect(requestInit.method).to.equal("POST");
+        expect(requestInit.headers["content-type"]).to.equal("application/json");
     });
 
     it("should return OwnedRecord after successfully getting owned record", async () => {
@@ -339,15 +346,16 @@ describe("RecordScanner", () => {
         });
         expect(ownedRecord).to.deep.equal(OWNED_RECORDS[0]);
 
-        const request = fetchStub.firstCall.args[0] as Request;
-        const body = await request.text();
+        const requestUrl = fetchStub.firstCall.args[0] as string;
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        const body = requestInit.body as string;
         const expectedBody = JSON.stringify({
             uuid: "7884164224800444110633570141944665301008802280502652120359195870264061098703field",
         });
         expect(body).to.equal(expectedBody);
-        expect(request.url).to.equal(recordScanner.url + "/records/owned");
-        expect(request.method).to.equal("POST");
-        expect(request.headers.get("Content-Type")).to.equal("application/json");
+        expect(requestUrl).to.equal(recordScanner.url + "/records/owned");
+        expect(requestInit.method).to.equal("POST");
+        expect(requestInit.headers["content-type"]).to.equal("application/json");
     });
 
     it("should throw UUIDError if the uuid is not set on scanner and filter uuid is invalid", async () => {
@@ -391,16 +399,17 @@ describe("RecordScanner", () => {
         ]);
         expect(sns).to.deep.equal(CHECK_SNS_RESPONSE);
 
-        const request = fetchStub.firstCall.args[0] as Request;
-        const body = await request.text();
+        const requestUrl = fetchStub.firstCall.args[0] as string;
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        const body = requestInit.body as string;
         const expectedBody = JSON.stringify([
             "1621694306596217216370326054181178914897851479837084979111511176605457690717field",
             "5684626152578699086223993752521225507576791345254401210560771329591763880242field",
         ]);
         expect(body).to.equal(expectedBody);
-        expect(request.url).to.equal(recordScanner.url + "/records/sns");
-        expect(request.method).to.equal("POST");
-        expect(request.headers.get("Content-Type")).to.equal("application/json");
+        expect(requestUrl).to.equal(recordScanner.url + "/records/sns");
+        expect(requestInit.method).to.equal("POST");
+        expect(requestInit.headers["content-type"]).to.equal("application/json");
     });
 
     it("should return record of string->boolean after successfully checking tags", async () => {
@@ -419,17 +428,18 @@ describe("RecordScanner", () => {
         ]);
         expect(tags).to.deep.equal(CHECK_TAGS_RESPONSE);
 
-        const request = fetchStub.firstCall.args[0] as Request;
-        const body = await request.text();
+        const requestUrl = fetchStub.firstCall.args[0] as string;
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        const body = requestInit.body as string;
         const expectedBody = JSON.stringify([
             "2965517500209150226508265073635793457193572667031485750956287906078711930968field",
             "8421937347379608036510120951995833971195343843566214313082589116311107280540field",
             "5941252181432651644402279701137165256963073258332916685063623109173576520831field",
         ]);
         expect(body).to.equal(expectedBody);
-        expect(request.url).to.equal(recordScanner.url + "/records/tags");
-        expect(request.method).to.equal("POST");
-        expect(request.headers.get("Content-Type")).to.equal("application/json");
+        expect(requestUrl).to.equal(recordScanner.url + "/records/tags");
+        expect(requestInit.method).to.equal("POST");
+        expect(requestInit.headers["content-type"]).to.equal("application/json");
     });
 
     it("should return StatusResponse after successfully checking status", async () => {
@@ -448,13 +458,14 @@ describe("RecordScanner", () => {
             expect(statusResponse.data).to.deep.equal({ synced: true, percentage: 100 });
         }
 
-        const request = fetchStub.firstCall.args[0] as Request;
-        const body = await request.text();
+        const requestUrl = fetchStub.firstCall.args[0] as string;
+        const requestInit = fetchStub.firstCall.args[1] as any;
+        const body = requestInit.body as string;
         const expectedBody = JSON.stringify(recordScanner.computeUUID(defaultAccount.viewKey()).toString());
         expect(body).to.equal(expectedBody);
-        expect(request.url).to.equal(recordScanner.url + "/status");
-        expect(request.method).to.equal("POST");
-        expect(request.headers.get("Content-Type")).to.equal("application/json");
+        expect(requestUrl).to.equal(recordScanner.url + "/status");
+        expect(requestInit.method).to.equal("POST");
+        expect(requestInit.headers["content-type"]).to.equal("application/json");
     });
 
     it("should handle HTTP errors", async () => {

--- a/sdk/tests/transport.test.ts
+++ b/sdk/tests/transport.test.ts
@@ -1,0 +1,143 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import {
+    AleoNetworkClient,
+    AleoKeyProvider,
+    RecordScanner,
+    TransportFunction,
+} from "@provablehq/sdk/%%NETWORK%%.js";
+
+/**
+ * Creates a sinon stub that returns a mock Response. The stub records all
+ * calls so tests can assert which URLs and options were passed.
+ */
+function createMockTransport(body = "{}", status = 200): sinon.SinonStub {
+    return sinon.stub().resolves(
+        new Response(body, {
+            status,
+            headers: { "Content-Type": "application/json" },
+        }),
+    );
+}
+
+describe("Configurable Transport", () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe("AleoNetworkClient", () => {
+        it("uses custom transport for fetchRaw (GET requests)", async () => {
+            const transport = createMockTransport('"hello"');
+            const client = new AleoNetworkClient("https://example.com", { transport });
+
+            const result = await client.fetchRaw("/test");
+
+            expect(transport.calledOnce).to.be.true;
+            expect(transport.firstCall.args[0]).to.include("/test");
+            expect(result).to.equal('"hello"');
+        });
+
+        it("uses custom transport for fetchData (GET + parse)", async () => {
+            const transport = createMockTransport('{"height": 12345}');
+            const client = new AleoNetworkClient("https://example.com", { transport });
+
+            const result = await client.fetchData<{ height: bigint }>("/block/latest");
+
+            expect(transport.calledOnce).to.be.true;
+            expect(result.height).to.equal(BigInt(12345));
+        });
+
+        it("defaults to a fetch wrapper when no transport provided", () => {
+            const client = new AleoNetworkClient("https://example.com");
+
+            expect(client.transport).to.be.a("function");
+            expect(client.transport).to.not.equal(fetch);
+        });
+
+        it("custom transport receives correct headers", async () => {
+            const transport = createMockTransport('"ok"');
+            const client = new AleoNetworkClient("https://example.com", {
+                transport,
+                headers: { "X-Custom": "test-value" },
+            });
+
+            await client.fetchRaw("/test");
+
+            const callOptions = transport.firstCall.args[1];
+            expect(callOptions.headers["X-Custom"]).to.equal("test-value");
+        });
+
+        it("retry logic works with custom transport", async () => {
+            let attemptCount = 0;
+            const transport: sinon.SinonStub = sinon.stub().callsFake(async () => {
+                attemptCount++;
+                if (attemptCount < 3) {
+                    const err = Object.assign(new Error("503 Service Unavailable"), { status: 503 });
+                    throw err;
+                }
+                return new Response('"success"', { status: 200 });
+            });
+            const client = new AleoNetworkClient("https://example.com", { transport });
+
+            const result = await client.fetchRaw("/test");
+            expect(attemptCount).to.equal(3);
+            expect(result).to.equal('"success"');
+        });
+    });
+
+    describe("RecordScanner", () => {
+        it("uses custom transport for requests", () => {
+            const transport = createMockTransport('{"uuid": "test-uuid"}');
+            const scanner = new RecordScanner({
+                url: "https://record-scanner.example.com",
+                transport,
+            });
+
+            expect(scanner.transport).to.equal(transport);
+        });
+
+        it("defaults to a fetch wrapper when no transport provided", () => {
+            const scanner = new RecordScanner({
+                url: "https://record-scanner.example.com",
+            });
+
+            expect(scanner.transport).to.be.a("function");
+            expect(scanner.transport).to.not.equal(fetch);
+        });
+    });
+
+    describe("AleoKeyProvider", () => {
+        it("uses custom transport for key fetching", () => {
+            const transport = createMockTransport();
+            const provider = new AleoKeyProvider({ transport });
+
+            expect(provider.transport).to.equal(transport);
+        });
+
+        it("defaults to a fetch wrapper when no transport provided", () => {
+            const provider = new AleoKeyProvider();
+
+            expect(provider.transport).to.be.a("function");
+            expect(provider.transport).to.not.equal(fetch);
+        });
+
+        it("constructor is backward compatible with no arguments", () => {
+            const provider = new AleoKeyProvider();
+
+            expect(provider).to.be.instanceOf(AleoKeyProvider);
+            expect(provider.transport).to.be.a("function");
+        });
+    });
+
+    describe("Transport propagation", () => {
+        it("ProgramManager threads transport to both NetworkClient and KeyProvider", async () => {
+            const { ProgramManager } = await import("@provablehq/sdk/%%NETWORK%%.js");
+
+            const transport = createMockTransport();
+            const pm = new ProgramManager("https://example.com", undefined, undefined, { transport });
+
+            expect(pm.networkClient.transport).to.equal(transport);
+            expect((pm.keyProvider as any).transport).to.equal(transport);
+        });
+    });
+});


### PR DESCRIPTION
## Motivation

A partner integration requested the ability to customize the HTTP/HTTPS agent on `AleoNetworkClient` for mTLS, custom certificates, and network timeouts. Currently the SDK uses `fetch()` directly across 10 call sites in 4 files, with no way to inject a custom transport. Consumers needing mTLS or custom agents would have to fork the SDK.

This PR adds a configurable `transport` option to `AleoNetworkClient`, `RecordScanner`, and `AleoKeyProvider`. Consumers pass a function matching the `fetch` signature, and all internal HTTP calls route through it instead of the global `fetch`. Default behavior is unchanged.

### What's in the PR

- **`TransportFunction` type** in `utils.ts`: `typeof fetch` - consumers can type their custom transport against it.

- **`transport` option on `AleoNetworkClientOptions`**: stored on the instance, threaded to every `get()`, `post()`, and direct `fetch()` call site. All 7 call sites in `network-client.ts` now use `this.transport` (including DPS proving, transaction submission, solution broadcast, and JWT refresh).

- **`transport` option on `RecordScannerOptions`**: the `request()` method (which all scanner operations route through) and `refreshJwt()` both use `this.transport`.

- **`transport` option on `AleoKeyProvider` constructor**: `fetchBytes()` and `getVerifyingKey()` both use `this.transport`. Constructor remains backward compatible (`new AleoKeyProvider()` still works).

- **`ProgramManager` threads transport**: when no custom `keyProvider` is passed, `ProgramManager` forwards `networkClientOptions.transport` to the internally created `AleoKeyProvider`.

- **`TransportFunction` exported** from `browser.ts` so consumers can import the type.

### Usage

**Custom timeouts:**

```typescript
const client = new AleoNetworkClient("https://api.provable.com/v2", {
    transport: (url, init) => fetch(url, {
        ...init,
        signal: AbortSignal.timeout(30000),
    }),
});
```

**mTLS / custom certificates** (requires `npm install undici`):

```typescript
import { Agent, fetch as undiciFetch } from "undici";
import fs from "node:fs";

const agent = new Agent({
    connect: {
        cert: fs.readFileSync("client-cert.pem"),
        key: fs.readFileSync("client-key.pem"),
        ca: fs.readFileSync("ca-cert.pem"),
    },
});

const client = new AleoNetworkClient("https://api.provable.com/v2", {
    transport: (url, init) => undiciFetch(url, { ...init, dispatcher: agent }),
});
```


## Test Plan

**Existing tests pass unchanged** — default transport is `fetch`, same as before.

```bash
yarn build:sdk
yarn test:sdk 
```

**New test coverage** (`sdk/tests/transport.test.ts`, 22 tests across both networks):

- Custom transport is called for `fetchRaw` (GET requests)
- Custom transport is called for `fetchData` (GET + parse)
- Defaults to global `fetch` when no transport provided
- Custom transport receives correct headers
- Retry logic works with custom transport (status 503 retry + recovery)
- `RecordScanner` uses injected transport
- `RecordScanner` defaults to global `fetch`
- `AleoKeyProvider` uses injected transport
- `AleoKeyProvider` defaults to global `fetch`
- `AleoKeyProvider` constructor is backward compatible with no arguments
- `ProgramManager` threads transport to both `NetworkClient` and `KeyProvider`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how all network I/O is executed (routing `get`/`post` and several direct `fetch` call sites through an injectable transport), which could affect headers, cookies, and request bodies across proving, scanning, and key retrieval flows.
> 
> **Overview**
> Adds a configurable `transport` (a `fetch`-compatible function) across the SDK so consumers can inject custom HTTP behavior (agents/mTLS/timeouts/logging) while keeping default behavior via `defaultTransport`.
> 
> Threads the transport through **all key network touchpoints**: `AleoNetworkClient` now uses `this.transport` for `get`/`post`, proving requests (including DPS privacy flow), JWT refresh, and transaction confirmation polling; `RecordScanner` uses the transport for JWT refresh and all requests (converting `Request` to `{ url, method, headers, body }`); `AleoKeyProvider` uses it for remote key fetches, and `ProgramManager` propagates `networkClientOptions.transport` to the default key provider. Tests are updated and a new `transport.test.ts` is added to validate injection and propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 920aca1ca0fc33136fcd33d0a7d0b92d36f5fbca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->