### PR TITLE
Update snarkVM version to v4.6.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Yarn monorepo for the **Provable SDK** — a TypeScript/Rust SDK for building zero-knowledge applications on the Aleo 
 blockchain. The SDK re-exports core protocol objects from SnarkVM to allow users to perform operations related to their
-accounts and execute Aleo programs. Main published packages: `@provablehq/sdk` and `@provablehq/wasm` (both v0.10.3).
+accounts and execute Aleo programs. Main published packages: `@provablehq/sdk` and `@provablehq/wasm` (both v0.10.4).
 
 **Workspaces:** `sdk`, `wasm`, `create-leo-app`
 

--- a/create-leo-app/package.json
+++ b/create-leo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-leo-app",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "license": "GPL-3.0",
   "collaborators": [

--- a/create-leo-app/template-build-and-execute-authorization-ts/package.json
+++ b/create-leo-app/template-build-and-execute-authorization-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3"
+    "@provablehq/sdk": "^0.10.4"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-devnode-js/package.json
+++ b/create-leo-app/template-devnode-js/package.json
@@ -7,6 +7,6 @@
     "dev": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3"
+    "@provablehq/sdk": "^0.10.4"
   }
 }

--- a/create-leo-app/template-extension/package.json
+++ b/create-leo-app/template-extension/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf static/js && rollup --config"
   },
   "devDependencies": {
-    "@provablehq/sdk": "^0.10.3",
+    "@provablehq/sdk": "^0.10.4",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@web/rollup-plugin-import-meta-assets": "^2.2.1",
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-nextjs-ts/package.json
+++ b/create-leo-app/template-nextjs-ts/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3",
+    "@provablehq/sdk": "^0.10.4",
     "next": "15.5.15",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/create-leo-app/template-node-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-node-credits-aleo-functions-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.3"
+        "@provablehq/sdk": "^0.10.4"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
+++ b/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.3"
+        "@provablehq/sdk": "^0.10.4"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-loyalty-program-ts/package.json
+++ b/create-leo-app/template-node-loyalty-program-ts/package.json
@@ -14,7 +14,7 @@
         "start:redeem": "npm run build && node dist/index.js redeem_for_voucher"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.3",
+        "@provablehq/sdk": "^0.10.4",
         "dotenv": "^16.4.5"
     },
     "devDependencies": {

--- a/create-leo-app/template-node-ts/package.json
+++ b/create-leo-app/template-node-ts/package.json
@@ -10,7 +10,7 @@
     "test": "npm run build && node dist/index.js && node dist/dynamic-dispatch.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3"
+    "@provablehq/sdk": "^0.10.4"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-node/package.json
+++ b/create-leo-app/template-node/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3"
+    "@provablehq/sdk": "^0.10.4"
   }
 }

--- a/create-leo-app/template-offline-public-transaction-ts/package.json
+++ b/create-leo-app/template-offline-public-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node --trace-uncaught dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3"
+    "@provablehq/sdk": "^0.10.4"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-private-transaction-ts/package.json
+++ b/create-leo-app/template-private-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3"
+    "@provablehq/sdk": "^0.10.4"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-react-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-react-credits-aleo-functions-ts/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.3",
+        "@provablehq/sdk": "^0.10.4",
         "comlink": "^4.4.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-leo/package.json
+++ b/create-leo-app/template-react-leo/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3",
+    "@provablehq/sdk": "^0.10.4",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-managed-worker/package.json
+++ b/create-leo-app/template-react-managed-worker/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3",
+    "@provablehq/sdk": "^0.10.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/create-leo-app/template-react-ts/package.json
+++ b/create-leo-app/template-react-ts/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3",
+    "@provablehq/sdk": "^0.10.4",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-vanilla/package.json
+++ b/create-leo-app/template-vanilla/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@provablehq/sdk": "^0.10.3",
+        "@provablehq/sdk": "^0.10.4",
         "tslib": "^2.8.1",
         "vite": "^6.4.2"
     }

--- a/e2e/dynamic/package.json
+++ b/e2e/dynamic/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3"
+    "@provablehq/sdk": "^0.10.4"
   }
 }

--- a/e2e/mainnet/package.json
+++ b/e2e/mainnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3"
+    "@provablehq/sdk": "^0.10.4"
   }
 }

--- a/e2e/nodenext/package.json
+++ b/e2e/nodenext/package.json
@@ -2,7 +2,7 @@
     "name": "nodenext",
     "type": "module",
     "dependencies": {
-        "@provablehq/sdk": "^0.10.3",
+        "@provablehq/sdk": "^0.10.4",
         "typescript": "^5.7.3"
     },
     "scripts": {

--- a/e2e/testnet/package.json
+++ b/e2e/testnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.3"
+    "@provablehq/sdk": "^0.10.4"
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/sdk",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Provable Team"
@@ -91,7 +91,7 @@
   },
   "homepage": "https://github.com/ProvableHQ/sdk#readme",
   "dependencies": {
-    "@provablehq/wasm": "^0.10.3",
+    "@provablehq/wasm": "^0.10.4",
     "@scure/base": "^2.0.0",
     "@serenity-kit/noble-sodium": "0.2.3",
     "comlink": "^4.4.2",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -513,36 +513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl"
-version = "0.4.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "socket2 0.6.1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,25 +1016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.3.1",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,7 +1136,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1209,7 +1160,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1251,6 +1201,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,11 +1235,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
- "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1496,18 +1460,6 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2045,11 +1997,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -2063,7 +2015,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -2082,18 +2034,19 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
+ "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2104,6 +2057,7 @@ dependencies = [
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -2476,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f429a027063694ce54f5537c42307938efeb7be1fdfadb68f4401e43ae66ef1a"
+checksum = "968ae18c17ffc17d685e2fdf0fd81badda60b986396c86288ef3956fe36a9634"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2504,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b0bced49dcb7592c979e1a78da3090cfb67787f69ff137ed910db78445446a"
+checksum = "ecb2f9adefd7e2f1ca7a7fcc565b7240fbcb3c4e15e10fe9b34fe0b6b4ed38e3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2519,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "344091272e885adffdac77436539d942b6ae2b0c09034e97e9d7a65e3cc293de"
+checksum = "c48163678e651152836fa558a7d269b7758de63b890599d8dcfec83f6a30c9df"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2530,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80c3d44e43781fdd75e369aaf84d7738de77c49a7c4e8eedb7ef4dfc71865cc"
+checksum = "778e9b1e9e5a99ba006936934a9307645e095d38f3db340e988a764715419261"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2541,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b64bdb90308bc02534d4c2f391c0fdbf62ce8a64d5968e0e8a33a56052f67db"
+checksum = "61af9fb395c5649181cdd06a7b8192774f08fe8960f5ea81260915ee7e0ef9e5"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2552,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b20a7c2d6d059dec7246dd7a8b939ffb8af1e4f1bc408cef64705618217f020"
+checksum = "0a0b61bb3327c0fa16e875bfc2713eb85bcefbbee1eb852dc63b5b9ebd45208b"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2573,15 +2527,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee226b229634ab0da642488855fcef298792ebb62b311883e456bc15122fe63c"
+checksum = "a338d22daeb11a28974b25dab808215b48afa1fa2f63323440e363b56bad678f"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c71fb7ef0baba25cdb2b32bf820704a4eed151f6df903cd425961900632ab83"
+checksum = "c479238d3e119631be3006d2f204e58dfe524d337dc464e9c80f3fa4e1d8deac"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2591,9 +2545,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bea3f47e9df8db42cefa8e21455f33499b6b7481be2f98de80ed15a921e9549"
+checksum = "cd643a5eb075d50dbe9592e5f97a836c0ac35f4635daa169b45f5bf4d8325d01"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2606,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199d5cd3de8e85c952ea7e09ac80317756717e01bcd4db33c3ac2d46414f951e"
+checksum = "781b6fa914eeee0ae29895508bc64c950ffe2bd2ec9b2bf263d0724504042742"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2622,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59a8bef2c1c6fe07007f5406dfcd6be048cff9a525663152b9cd30f9d2110f8"
+checksum = "dd6864ba8e389ef52b9b220436f814c35c8b974a1b35886e452dec28bc013732"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2636,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7e57ca2d796795d12151a7477564070ece334231ac5fde58e8a975b6bf822f"
+checksum = "2c7753ab8a7ac6f64fd78246b6248daa0eba972a9e793162bb90ab07add82690"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2646,9 +2600,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6c9bdfa6779a59ebe8cc7ff9bf38ec3a9cdcebc776f4aea9eaac47028126e4"
+checksum = "ef74959a5b74728b8bb9d6a6b7d00740e5d36dff439805a811fb517014c943a3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2657,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c79fe4cb41f517fc451bbbc7b607a791e0182e5b0de382df524a746b2c3805f"
+checksum = "56511a526b5e550f1eb8be82221169fda918d9d6f954db9ba957d3d2bc1ed46f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2670,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ae66c1f24476d487b38f2dd5a41e43daef0002e34154561097c93d36b00fa1"
+checksum = "210b02b6e427fb9c724cf76fe72e73248a477d4a14b1be476e48cf1bcf96cad7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2683,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc716e2b11a0674812728c7841649f27cc82814a5725f96f38acb7a81a7f956"
+checksum = "6966e9f9b0ae81868d2d653d13ee7d80a532f6d6ac77d6bad511a9212941f632"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2695,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17fbebfa47ea1415db31910c1d934c9d9b3e09c3f6aef6bbaa8ce9320b098"
+checksum = "5a7456f93289da01717545612410a58d2967f1c0fa657ab3ac228f690b5c0abe"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2708,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ea1fc6b2b77f74174156ad27b31d1d5cf2afd5561c730d1cdb0c9cb0008176"
+checksum = "006496cd774a1f5430cd1bb0fb6d3bb3f221b626df71637e35edbb057f7fd45f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2722,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6f8c2512f22397f578b599b185197c0bb4f5d1fe3d8491881a5b2cc8785ec0"
+checksum = "f1f5af343b814c2d6ec541c00d96d478d6ecae2a88b1fd0159af06080c0d7b45"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2734,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc5b83700a336e7ee2923015cde3c4c99cb2fd0e7463614a6f4f0d897672c05"
+checksum = "29e74de8695a9675c3b6ed0016c6ff58d5663769b33ff180c74195b7a2561fe4"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2751,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f145c38cfac2857dd81c8395219cde2d2c4db088f54bce253980981e05acda34"
+checksum = "cb82068fe9f2f76fa39ba1e1c2d3ab8ec81e61d191e356993cfd9580183fe330"
 dependencies = [
  "aleo-std",
  "parking_lot",
@@ -2765,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381d690384ca1ee30dc25044b86cec61acefba5d597d965019f0c6ca2c1245b2"
+checksum = "acd85152a2e701811fd05c72d313ecc82069ca5c366da47d3a4e0e7d13453b89"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2786,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98c68b26eb23584865016308d12ea1beeb89aac481a06700f79ffc80452e84e"
+checksum = "8643b35b278716c776a334282d8632eebeb7b78c5b33f6e055d440411f242e09"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2805,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ae22ecf212bff9cf4ddf003cf8675ca5ce5a6e9e7636d55aba38c64670de74"
+checksum = "b0a978757413da039408c2bf7cdf25af4a44f372da660dc571a8d5795a6b1b24"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2827,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88a64eaa97df2c0188b519af7c32e06c0609de183b538a3e171dd7eb863805f"
+checksum = "5e763d9f599a3acfdfb04bcb7a670a234ddcbf7b14ff826019e45adb47adfb20"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2843,9 +2797,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6346b45d27523b8c837edd63aef9ae4c425c591ef07353e9ef9ff2ac2ba95d23"
+checksum = "aff9358e66f770c1c04aa5937dc666f0ceefd1d4f8f339d524e1a0749192cd67"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2855,18 +2809,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbb16ba1aae336cc00a17a8073c21d7830a1cb6d666a5607387d9fe3148395a"
+checksum = "ceeb44cea5272c7a350278c56346064af8104285237f29bbb557c475461b8384"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4811c1602a2251c9d5aa57fae14626eb4013d1084ccdf5b3aad230f8a4d978"
+checksum = "1b5b46c8cb9a5036fbd744c092cdf9e7e4b3860a1cfdddf02f9eaa1a4051e4e4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2875,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ce66d7c7c62d773256bb2c0545776f4248c79b9746ece734a29566a3c157b"
+checksum = "2ffe7643d999f5a26530f98d1c4bcb25203a32681fbd2b0b2131ae8ad3be591f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2887,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fccb495c28995f3040107a76b5f2af0bf51cc7c0d2d746d0d658975b973b31"
+checksum = "0f5fd7f34bfd746e4752289bdcf287b4b665855742d2b4baa4b490ae43a2e8ef"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2899,9 +2853,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185d29f863cc20aae7cb1c32d96698e220fe504f3bca71149845816f6471040"
+checksum = "fdca15e8131d11f7f936a0e95c87bfed265499df98c937d07410c9f2de45b0fd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2911,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9984c2a761b9ce99defa4da5d6741d0159ce45e0a5754618c0b56d3a2268db76"
+checksum = "d72952068227dec6ca3f723cf5478e04bafbe1581acd0f8c1d80d4e9e795d13b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2923,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0f2277562eaff34b1a4e70fb1831677cf0958bcb248cbddaf9f0a1040d743a"
+checksum = "40698180d6b5a277a3fd00a6313a69bb51ebc29c2fb7384472c4e36d6e3173c1"
 dependencies = [
  "rand 0.8.5",
  "rustc_version",
@@ -2937,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d49b3caab7ab592744a6d0edacafd60ef39ea861708fefd9301c60aa8e008c"
+checksum = "f4f644ad19073650870a35247ce508375745a7add8bf32f3ccadab2bc0f8aab9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2955,9 +2909,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f6faf8c61f860d47855184374f78a5de84df17a2c1085bc62b8003d994a896"
+checksum = "d5fc4aa4dbf87652382f1d2c202afc6b6b509a9740b2c9a9424e816f97d298d0"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -2968,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474474ef3d68a9505506794ebdcb2c57b37e8f7f85747bd5227914459f4a0d56"
+checksum = "6ffa19feef8a6969be7752c48b0c83a13ace6905c0c0c026f391f97fb5ec16ed"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2992,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3d47a7db7340fc8b89e636fad0254677efa74a76cf2787c06ed1c6a5f39602"
+checksum = "36cc8e705e2dbfc8589f3e90b177ed9c908a3947f0b599321a9be805c14a9941"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3005,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa56b4e8005cd110a3ba1978b7613a0fef757781825448bc706a6554d94efa3"
+checksum = "b10eab47c58b1f7c1f72357d5902f4e990c703b2eced3c230d557a53b8c0d01b"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3019,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfac323378195bc6312264a02850923a48ff2055e871ac8901dbef88b64d0c83"
+checksum = "b33f91d1fa22a3d48e91da9af8755e32180a737d477afc08219df4cb51cec709"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3032,9 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a9ced395f77b4654796182b4f3032a52446eef1c90042dbf73082e5a79b463"
+checksum = "49ca86aab5895940ba4fa2fd39d4369ab7c48d658cddbeeecdd20da32aade194"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3043,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b154c97745c7efc9a5a8b4f53217a5b883d20e9f5acefd8f388a6cbf4e1f65"
+checksum = "f00741f39bbf5bdd88f77c8e86332d86ed5b087a09edb4a32f24fb589341765d"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3059,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8e9f969d9e705e3a5368dcef75da723b22407ff8c5a71d5c36e6ed0ddbe0c9"
+checksum = "a0fc5839054aa3af7dc3cc15fb9b9771f90e8f4fbbc930b631abc606f35354bb"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3069,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79650d888e693076db55e80401640264a7bb09dec904b8291e699441ed69f85"
+checksum = "10d6f366ed9db212afc8b681d0dc510693a7b742de4051de0bb63a9747994561"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3089,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6b246980634bf8f454e7b8106a91344c959d79d39f13dae157aad4da56a291"
+checksum = "841d9d31d2a037ef7887097a4e7b5d46c774f254b8bd5e5cc70d1a867fd694da"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3112,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db157202fbf9ef89abb365f458d7d8cfe3c313f9617c595c2202bbb97fb8b64"
+checksum = "dec11ea862272a9a61ab0f57c1b625b298db6346a8f289ef0a563410f0153ba8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3130,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d18589a75989ba003c9ea0d9293c5f13c972c1cf2dae4c0c6855590a3d98101"
+checksum = "7991cf47fea3ee98a54706af0aa0f50b1f4019636dd1c893a9fefa82a5189530"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3156,15 +3110,14 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f820da08d9fcfbb84f64e3991b5d9eead79f5b90e2b4a8c3fb6a749e3077570"
+checksum = "881df304a85063ae658c4d0937fde8f11647eb25b0dea10447be7284fc522888"
 dependencies = [
  "aleo-std",
  "anyhow",
  "cfg-if",
  "colored",
- "curl",
  "encoding",
  "hex",
  "js-sys",
@@ -3172,6 +3125,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "rand 0.8.5",
+ "reqwest 0.13.2",
  "serde_json",
  "sha2",
  "snarkvm-curves",
@@ -3182,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1cb18e91e9a2bd0141211e5b62fb336286079f6ec24baaa834735ae763db5"
+checksum = "64194e74e151d04fb95899f0129ca9fc725c1d88896a6c7a0905b0724cb5db93"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3217,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-error"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707971f30e78cba8b1b10048ef2d09ae616599a521ac6f38e0bbbe0c2fcad039"
+checksum = "009d28655659297a66fa075ad40dcd184cf4072fb216f117702fda83caad4af2"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -3229,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08cc01f7ffebeca96fc3d9deefa94dc3e44e339392746f817d9529bffad7e8eb"
+checksum = "25fe00f71e739c22eabee850fcf962383acab55d23064fcc119c83f306b2f7ac"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3256,9 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113d40a476f601d012e9f2805e4d04b1ae7d8ee9e9bd3a666e300dd8e489aeb2"
+checksum = "ac126a7f78dab7e79c887e2fc4559fb578abb3b6417dfbc510f0cfd010dd0eb9"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -3278,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18930ae4d7f42bbc45e387a1a716cd56fe6f67136bd6d72baf11078036db6bae"
+checksum = "2576661caf149b0600fceb55344a6ab24b7f245f3e4d0af38ff4fb779fe606e2"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3292,9 +3246,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3539164257dadcf46c115635cdfaaeabf2d237671d322ed1118af128f9e510dd"
+checksum = "66c76771c6fbd71cf866ba756a0eb5ae19f8d2b0846b8630ff44110dc63f2e10"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3316,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e61d363a69c4d5d829236eb21f96efb617e6f66173e7284826b79fc5213f83"
+checksum = "0756abcc92e46a88fd02dbde2fd1a4efef1f2ab137f097218e317d75afd037c9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -3327,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012256e8f9b801d73640419ea57f180b9b1930089466caaad7495d78fc4c0f5"
+checksum = "786479a07dd63b0b9b0307ce46592ebe2b17a049e2ec287ac58e15e734502325"
 dependencies = [
  "getrandom 0.2.16",
  "snarkvm-console",
@@ -3456,18 +3410,7 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -3475,16 +3418,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4062,35 +3995,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-wasm"
-version = "0.10.3"
+version = "0.10.4"
 authors = [ "The Provable Team" ]
 description = "WebAssembly based toolkit for developing zero-knowledge applications with Aleo"
 homepage = "https://provable.com"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -22,14 +22,14 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-version = "4.6.0"
+version = "4.6.2"
 
 [dependencies.snarkvm-circuit-network]
-version = "4.6.0"
+version = "4.6.2"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-version = "4.6.0"
+version = "4.6.2"
 default-features = false
 features = [
     "account",
@@ -42,31 +42,31 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-version = "4.6.0"
+version = "4.6.2"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-version = "4.6.0"
+version = "4.6.2"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-version = "4.6.0"
+version = "4.6.2"
 
 [dependencies.snarkvm-parameters]
-version = "4.6.0"
+version = "4.6.2"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-version = "4.6.0"
+version = "4.6.2"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-version = "4.6.0"
+version = "4.6.2"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-version = "4.6.0"
+version = "4.6.2"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/wasm",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
         "@codemirror/language": "^6.10.8",
         "@codemirror/legacy-modes": "^6.4.2",
         "@codemirror/stream-parser": "^0.19.9",
-        "@provablehq/sdk": "^0.10.3",
+        "@provablehq/sdk": "^0.10.4",
         "@uiw/codemirror-theme-noctis-lilac": "^4.23.7",
         "@uiw/codemirror-theme-okaidia": "^4.23.7",
         "@uiw/react-codemirror": "^4.23.7",


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrade in the core `wasm`/`snarkvm` stack could change cryptographic/ledger behavior or introduce subtle runtime/build issues despite minimal code changes.
> 
> **Overview**
> Updates the SDK/wasm release version to `0.10.4` and propagates the new `@provablehq/sdk` version across `create-leo-app` templates, e2e packages, and the `website` demo.
> 
> Upgrades the Rust `wasm` crate’s `snarkvm-*` dependencies from `4.6.0` to `4.6.2`, with corresponding `Cargo.lock` churn (notably shifting HTTP/TLS-related transitive deps such as `reqwest`/`hyper`/`hyper-tls` and removing `curl`-related entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ab706ca212cde240b126fbaf881c86ff98f9de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->