### PR TITLE
Bump snarkVM from 4.6.3 to 4.6.4

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2429,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41d8f3ecaa2b99adb47e2486872d71a002a6c665aa053f42b8852051643cb9"
+checksum = "119d715f601c042d9d59c2f189b08773432d2a7ef4b04ff7688ecc27f49847a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2457,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395542106981ed3b3ac83a507355621746f3a6af4dca389d0817b2ee3077d401"
+checksum = "893656aae5bb93397483608272b8b3c71fdba1549054fa73c5dd8b890043d487"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2472,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48186e30bc5011f5f8ac0db35fc830df9aa990ac7e32d2ddd03fcc7510775d0a"
+checksum = "35bf561f71b51251e11b5502209e3da815d83fd34cf1958b80efeb0815a5d0a1"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2483,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba87a02ff7826ae3fecb563fb40f362785e5c382d304bce929e10db6bdbde883"
+checksum = "11a699649cefd6a79731faae776263458768c162f9d240c951271c54c622eb98"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2494,9 +2494,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5cf7eabb9998093323c42f41a450d867620aedf896864595906af22b8e8e14"
+checksum = "6eab25b110877336a26c2a4e9d7aa4da17a4f5d856a267d7609d350b2a056b0b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2505,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f8576d8e8efc3b9271c0516e1874af32bdeae7c1d9d99d7069578b91337874"
+checksum = "2f6e888ba411e45e30464c4c6a46265b847f85271dc904ee1b664ab342fba417"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2526,15 +2526,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c0743320994726adfe47cbfdab16059745766c71e211192db5a887c9d96ca"
+checksum = "a7067c99d74bc5873b1b5cb85d965301d050dfc4e769fbab9bbc405a859c854d"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657be6afb497c71b2d357664c76a86fb65b09fdfe9c8bd683b5b5ae3d7ca95c4"
+checksum = "7ebd4a31d62f39f0125283f183b724db3e007ccf40ea0014bf10adeb7fe1d0e7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2544,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2feedd11752f0063900285ab5909600b6c2c2edff6b450c8e6200cfd3e5c2d"
+checksum = "62a16884e14ce00f6c2e42586249dde46b60ef83279b3535421262ad6bc4e613"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2559,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1476ea66b16e072a2baeda3c0adf68226842d8bbf3befbe09937e293f9bce2a4"
+checksum = "4ff1b5ccaec0191216648d4472f604dc6e5bc4e227e6fbc74a1dd878d27e49b2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2575,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d414e0757194be9ed6985989ef61b69f339f3e9a74b893a2c7d6f1761934cfe"
+checksum = "b335ea990f5ff1132a5b6235ac71833ea5619f3aacf9d2b595b3a40a247063b2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2589,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68c24c91620e52a6c8d8b5a0d535a723cf644310a1eddbe89c877bbfb39756"
+checksum = "00d18a39567176a53c46688244c62628efef3897219c90447694f353dad92ed6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2599,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a285df456d42b06453878a48e7df1270b72efea4ee55a0e3b9e961e78713db"
+checksum = "537873e60b25756a7abc875c05578534d227bb7d8126cb70aa3dd8c32bd8e90a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2610,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2e617b513f1bf1bf04015fa3ddb8c1890d5a9d4657061cc0ccd5c3818f5c09"
+checksum = "e881fed6f8281febc18aae12e41be57e362b0279187b4e37feb1318d06b6f0da"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2623,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd36e4b3d206b68ee74582a29961b58cfc1457f6da2a3c4008e76327bafbd910"
+checksum = "7244bfa31a20ddb60a2e23e3f421640b4028296889113f2a3c02359414e5d09f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca46e99952424295abf3b7b3dd959946388146f1884dd6c782476b2e86bea305"
+checksum = "bd5df465ff57026bdf7a69ec9f88c488eec2c39f60d237f7b167a15a87e7d61f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2648,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9095cfe18fa59571dcc3107378e5e041e6561d89691bc29cd6a0092824b6e1f7"
+checksum = "b3f0aba42bca8353c0267c85626e3e4f910df3e2175d432b8f5269379426dcff"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2661,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023323ee1f95500648215d233ba26206dfc972dc19b15d9e3744c4c1e0433ae"
+checksum = "21dc2d9c6696a12ff1dcb9b20c98a1fbc9333a662e40249346bd2a8e7475818f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2675,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44713ba11313795de7da049cf16bc07be613d1243e5880fe1a28690cf193832"
+checksum = "bf0e579907d922e2be74b6bb666057f6ec93d914e49cc728c1e4af0726e6ea42"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2687,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63689f738d211db545030c79ad6d6c0a78ca518244ffba2478cc0b08be6a76f9"
+checksum = "e55c27912211d02e030e8f7deecab0f0c544d687e276bd8a7d4fb63471920a54"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2704,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f71fb8fb21af8b2da89c9cd5704debda8683dfaef8fa67ce01e708abdd862"
+checksum = "053443c5a9e33e431feec39af3192ad7d33c75c1329b0139bef344594774f897"
 dependencies = [
  "aleo-std",
  "parking_lot",
@@ -2718,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109e97c1efa69c48ac7f986aa8138771ea2405bc12e843236752b43c1ea20888"
+checksum = "55bf4643d55248e04edbb8b3c83579e6db2167bb0586fc5da251440ea685084d"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2739,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59195824c8a39ed4d5da14b040b9882c3b93372a457437cccac9e790ba553017"
+checksum = "200cd0226727cf27ceeb694c06b665e772cee7e1abd84cfe5d5e658bf78858ae"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2758,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b4516e280d02abe25f5ecb7c80ed38e283d85c63ffffdad96068d38094c504"
+checksum = "baf708ca1522bcbbd900e73f1f43023e52d7674612b0b6adef1154a42f0a5b1f"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2780,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f104414ff1dfa381592f3680cbff3b25c3b056753aaec3ecd8666bc04d8c72"
+checksum = "9ea805853f2d4c45face4fa6a52002c0afe6dd530893d8c644dd28b410b765f9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2796,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673eda6755c67ce964ea86ec34bf84ed7b3761555da04c7c1f48c1eb7d526fe3"
+checksum = "70633df2627e4995374f20404c2a318aa91a510e9fb479293753b87c79ca7be6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2808,18 +2808,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8498560afe70be5d31c69f85de786c7d13b0d693ebc05aa4c30d03f9001ce8"
+checksum = "09f5e8f8179a2b2632c606dafaf486cbb72254509c3badc50ec00e0b1e062f72"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3aa70874aacf216e68ffc9a5cd884941bb4c341539d2fdfb766a769196f9bf"
+checksum = "3274d95a85586722730260e9314b1157d48800bc828fce631c3f5bfa8294c85b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2828,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c023134c3a954539a70e3f31244cb5a75c74c44d51a2aef74ec49202956eef"
+checksum = "6a6307b854a9ba23acaff37ce6eba6d58a751772774a2081e8f37c98819e54d1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2840,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7d14a02ed38370b2a298babd834df5ef9c9a042ca4a733891b2b23548eb9b"
+checksum = "97b4b6f9da98590708659f4c88f99ffad786142950e77e414756a3de3eb2bf1e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2852,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbadeafbb64909a7657b802bf312df6cc9a0b94e6d81c422122dcf726a5c190"
+checksum = "b7c505655de71020863ea695bb809426c21c8d9dc8d2db9f41ab4e553cf19533"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2864,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1851af4baf2f6db4c8df4349b78d16b3e0eb556c818200dc7a638189391286"
+checksum = "48bcac646f2a4d516e354cec2c36815bfda778f53957bdb25b9ba950bfa0a275"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2876,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955feaf7b09e52fad52a3969249bb7180108e92839a4c962f28a2a3a2309a219"
+checksum = "7fbc19c063065b3e43b7f6cef1690e887f0ddc5bb7a301562d67e93c08d44bec"
 dependencies = [
  "rand 0.8.5",
  "rustc_version",
@@ -2890,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211b032047953d555c637d448c3ee02a2f643f7d7088cacef7abc415837bed1e"
+checksum = "8e5aafa68efe23a9b68536cb0f8abd317a465af99228b4a758b5331c67f59d41"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2908,9 +2908,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653e14aec9a7c7a0ee39540d90b73a3a8d2f8342364228116b437865775a5868"
+checksum = "acc565d15e4303ef27af8ba580684edfabe1b660f5d4e55d09196b2428c359c1"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -2921,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24daa2178e2530c89cff0baff88579edf0ddaa37c71aa90726efb31bb261d2bc"
+checksum = "0835b84996855ae997944ca16b18115c6393a041bbd0a77ad5504000a5a84d9e"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2945,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf34fb5c96501e0ffc535374c364598590ff3004487a80727b1c8ba7586dbdbd"
+checksum = "79276eb9122d95964ea71ff987d712c2d1b468f830911c40f20f03f6c195ffac"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2958,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b568ce106d2622814edb61d773a504feb98551b30bfc34ebdc209a9f3b9e9f9d"
+checksum = "7cd6ef69a6d2b2e821e2b04e75ad75f4e4c9ab83e8426497dc89aaf9136902f4"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2972,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560afb6cac08c75455281b959489d93a0cb1368717fdc06d134ab2090d9e0b21"
+checksum = "0542c430495c121c13511d1fe632ef5307196a9ae796d6cfb237a3fb4ffe4260"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2985,9 +2985,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d6ab9c3446552e91605ad960aeaa8debd23bd465756f065833d3e901381be6"
+checksum = "ac89aa6ba0312dbc05a556de10e35668e924543e4cc2aa454af0d8256d163b5f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2996,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d30879a7e41538dd615f4189f0468adbfb8d2b92e45344e019a0a11515886c1"
+checksum = "07cfb1441bf68d2c17923a0d36d45a81f9bfd05bd4654d6760e7c3c82e0b0d23"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3012,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee91eaf1161b98dfe2c600b2a4826fe347118b7edb56cbf17c823d0b3e2df221"
+checksum = "c86c845b4d31f8e57c0a944fbbe14eb9b2e6ba2b71ee1c5b58b84b7f644f0268"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3022,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7845e51be18e1f2de174c5163eb246d9d40a8f287c8b1e2f1c2f2c4a8412cd68"
+checksum = "696c2e4444ee134512b08a592ab242c892b0bfc6f0b2be1ad3f0021cab895fb1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3042,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0763a133f24cb35eeb563fc5147f2b72cd5a2d66e1c0b32728353b568e229d"
+checksum = "1378ca86d374b8b37d952e8e50d4c8914cf936dca15fabb9a101de4d1e55e380"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3065,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc71d586bc2dd756fe9e597049a7cd008511e9d1d81468064619e42caf85e2f"
+checksum = "e03735b5a4bc13727f43c05e940a003e5da49e8867ba15dfef4d798ea84b6c5b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3083,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48246830e05fe3623b16cdd0fca4554e5f832dbdcb8322330b876b386c42b6d5"
+checksum = "4b80163916a2846a1012233b04a940e046567b3406fb96b95e61aed805d8ee2c"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3109,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f41fcf4b6d90baf373d5f4950f5c186d9c05bc13013b6d049d8b34f455dec40"
+checksum = "5e5e8d826b801aa2e0e50047865e322f0021434c26c7830976380e277f6883a2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3135,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dd8b3ab90b0982d00180a5ed4df17ab8d9dd126c3c70936fd25342755094a3"
+checksum = "54105a74b11c4a23e2a280b0e9deee3cceb25ccf12414fdbca8af8364f9c6079"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3170,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-error"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8993bde50d434e9347c0e8d7d0a82ed9af087dc0dbfbaf5123e7c1e4dc08d18"
+checksum = "e3144c277090e5952fb4397ff5b42fbc7201c2ea4df8378c4c76c7bb071617de"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -3182,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e68bd2c717804de3733b80bfd88dd1437af9bd98a5f89b4da3f920dd190b11e"
+checksum = "4caf6b84d6ed903e38c23367b0a7d9cf0b0c4f3215b99694bfc132e2e187d229"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3209,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cef02fdb9dec470440e2b0ba5c3e3f3a4e49854eb7f6c06a4348dc778edc16a"
+checksum = "19a695085223df25c5d5d786ca764bfc6bae038d33c4e278275fcbc8fb31bb46"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -3231,9 +3231,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967353a74e2e49725138ecc12e916cdb204a86b64f61814f1bae4c05e591ff1f"
+checksum = "a6efb60e0d76473c58228b2a6e1ddafcf87dfb750291bc020c8167e0c05c43ea"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3245,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ff49b6b60a1716af5b4eed6de41697eb6e6a8fbb6d911524bc1f188b3496dc"
+checksum = "29bc1cabe778a4693015a520b0684b114281550113c4e377d15ec50701ed4ded"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3269,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a2df2cf14f60bea146abbecbfadf7b74dda0a27c37aa33ad1fe31688f356e5"
+checksum = "47cd05497f2badd1649b454c77bce1c5159bd4da8a685117f7d6f27314af307e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -3280,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb20e51081c0e855a50f2cf208c1e1c2eae1fe7cfed1b5988d57350820dda2dc"
+checksum = "04752844b7260b835572782c305e409e006d9ba04d3bdb3b199dd391f960ab1e"
 dependencies = [
  "getrandom 0.2.16",
  "snarkvm-console",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -22,14 +22,14 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-version = "4.6.3"
+version = "4.6.4"
 
 [dependencies.snarkvm-circuit-network]
-version = "4.6.3"
+version = "4.6.4"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-version = "4.6.3"
+version = "4.6.4"
 default-features = false
 features = [
     "account",
@@ -42,31 +42,31 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-version = "4.6.3"
+version = "4.6.4"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-version = "4.6.3"
+version = "4.6.4"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-version = "4.6.3"
+version = "4.6.4"
 
 [dependencies.snarkvm-parameters]
-version = "4.6.3"
+version = "4.6.4"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-version = "4.6.3"
+version = "4.6.4"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-version = "4.6.3"
+version = "4.6.4"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-version = "4.6.3"
+version = "4.6.4"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]


### PR DESCRIPTION
Bump SnarkVM version to v4.6.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code-change surface, but it upgrades core cryptography/ledger `snarkvm-*` crates in the WASM build, which can subtly affect runtime behavior and compatibility.
> 
> **Overview**
> Updates the `wasm` crate to depend on `snarkvm-*` v4.6.4 (from v4.6.3).
> 
> Regenerates `wasm/Cargo.lock` to reflect the new `snarkvm` crate versions and checksums across algorithms, circuits, console, ledger, synthesizer, and utilities packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb5f293b1cd95702127fde3d4a093108177280d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->