### PR TITLE
[Chore] Harden .yarnrc.yml: scope install scripts to an explicit allowlist

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,3 @@
-approvedGitRepositories:
-  - "**"
-
-enableScripts: true
+enableScripts: false
 
 nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -39,5 +39,19 @@
   "devDependencies": {
     "prettier": "3.4.2",
     "wasm-pack": "^0.13.1"
+  },
+  "dependenciesMeta": {
+    "@swc/core": {
+      "built": true
+    },
+    "esbuild": {
+      "built": true
+    },
+    "sharp": {
+      "built": true
+    },
+    "wasm-pack": {
+      "built": true
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12589,8 +12589,16 @@ __metadata:
     prettier: "npm:3.4.2"
     wasm-pack: "npm:^0.13.1"
   dependenciesMeta:
+    "@swc/core":
+      built: true
+    esbuild:
+      built: true
     glob:
       optional: true
+    sharp:
+      built: true
+    wasm-pack:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Motivation

Hardens the repo's Yarn supply chain config so dependency install scripts no
longer run by default:

- **`.yarnrc.yml`**: sets `enableScripts: false`, so Yarn no longer runs
  `postinstall`/build scripts from arbitrary dependencies.
- **`package.json`**: adds a `dependenciesMeta` allowlist (`built: true`) for
  the packages that genuinely need install/build scripts: `@swc/core`,
  `esbuild`, `sharp`, `wasm-pack`.
- **`.yarnrc.yml`**: removes `approvedGitRepositories: ["**"]`, which
  auto-approves *any* git hosted dependency. The tree has no git hosted
  dependencies, so this is dead permissive config.
- **`yarn.lock`**: records the allowlist in the workspace entry (a consequence
  of `dependenciesMeta`, required for `--immutable` installs).

## Why

By default Yarn executes arbitrary `postinstall` scripts from every package in
the dependency tree. A single compromised dependency can run code on dev
machines and CI at install time. `enableScripts: false` makes that opt-in:
only allowlisted packages can run scripts.

## Verified under Berry

Rebased onto `mainnet` after the Yarn Berry migration (#1323). On a clean
install (all `node_modules` removed) with `enableScripts: false`:

- Only the 4 allowlisted packages run build scripts; everything else is
  skipped (e.g. `core-js`'s funding banner postinstall no longer runs).
- `yarn install --immutable` passes.
- `yarn build:all` is green, confirming the allowlist is complete.
- `yarn test:sdk`: 976 passing. The 17 failures are preexisting local env
  issues (missing CI secrets / no network), identical to before this change,
  so no regressions.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Yarn install-time behavior: dependencies’ build/postinstall scripts will no longer run unless allowlisted, which can break installs/builds in dev/CI if the allowlist is incomplete.
> 
> **Overview**
> **Hardens Yarn supply chain settings** by setting `.yarnrc.yml` to `enableScripts: false` (and removing the permissive `approvedGitRepositories` setting), so dependency install/build scripts no longer run by default.
> 
> Adds a `dependenciesMeta` allowlist in `package.json` (and corresponding `yarn.lock` metadata) marking `@swc/core`, `esbuild`, `sharp`, and `wasm-pack` as `built: true` so only these packages can run required build steps under Yarn Berry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240e705373018bfc83b0efb9c54038848912261d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->