### PR TITLE
Update yarn.lock to match the 0.10.6 version bump from #1321

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2711,12 +2711,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@provablehq/sdk@npm:^0.10.0, @provablehq/sdk@npm:^0.10.5, @provablehq/sdk@workspace:sdk":
+"@provablehq/sdk@npm:^0.10.0, @provablehq/sdk@npm:^0.10.6, @provablehq/sdk@workspace:sdk":
   version: 0.0.0-use.local
   resolution: "@provablehq/sdk@workspace:sdk"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.18.2"
-    "@provablehq/wasm": "npm:^0.10.5"
+    "@provablehq/wasm": "npm:^0.10.6"
     "@rollup/plugin-replace": "npm:^6.0.2"
     "@scure/base": "npm:^2.0.0"
     "@serenity-kit/noble-sodium": "npm:0.2.3"
@@ -2750,7 +2750,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@provablehq/wasm@npm:^0.10.5, @provablehq/wasm@workspace:wasm":
+"@provablehq/wasm@npm:^0.10.6, @provablehq/wasm@workspace:wasm":
   version: 0.0.0-use.local
   resolution: "@provablehq/wasm@workspace:wasm"
   dependencies:
@@ -4478,7 +4478,7 @@ __metadata:
     "@babel/core": "npm:^7.26.7"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4511,7 +4511,7 @@ __metadata:
     "@babel/core": "npm:^7.26.7"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4543,7 +4543,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -4577,7 +4577,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aleo-starter@workspace:create-leo-app/template-vanilla"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     tslib: "npm:^2.8.1"
     vite: "npm:^6.4.2"
   languageName: unknown
@@ -4595,7 +4595,7 @@ __metadata:
     "@codemirror/language": "npm:^6.10.8"
     "@codemirror/legacy-modes": "npm:^6.4.2"
     "@codemirror/stream-parser": "npm:^0.19.9"
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@uiw/codemirror-theme-noctis-lilac": "npm:^4.23.7"
@@ -6404,7 +6404,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "devnode-starter@workspace:create-leo-app/template-devnode-js"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
   languageName: unknown
   linkType: soft
 
@@ -6582,7 +6582,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-dynamic@workspace:e2e/dynamic"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
   languageName: unknown
   linkType: soft
 
@@ -6590,7 +6590,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-mainnet@workspace:e2e/mainnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
   languageName: unknown
   linkType: soft
 
@@ -6598,7 +6598,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-testnet@workspace:e2e/testnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
   languageName: unknown
   linkType: soft
 
@@ -7339,7 +7339,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "extension-starter@workspace:create-leo-app/template-extension"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     "@rollup/plugin-node-resolve": "npm:^16.0.0"
     "@web/rollup-plugin-import-meta-assets": "npm:^2.2.1"
     rimraf: "npm:^6.0.1"
@@ -9997,7 +9997,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-build-and-execute-authorization-ts-starter@workspace:create-leo-app/template-build-and-execute-authorization-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10075,7 +10075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-offline-transaction-example@workspace:create-leo-app/template-offline-public-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10094,7 +10094,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-starter@workspace:create-leo-app/template-node"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
   languageName: unknown
   linkType: soft
 
@@ -10102,7 +10102,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-starter@workspace:create-leo-app/template-node-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10114,7 +10114,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-transfer-private-starter@workspace:create-leo-app/template-private-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10126,7 +10126,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nodenext@workspace:e2e/nodenext"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
@@ -13453,7 +13453,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-nextjs@workspace:create-leo-app/template-nextjs-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
@@ -13469,7 +13469,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-credits-aleo-functions-ts@workspace:create-leo-app/template-node-credits-aleo-functions-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13481,7 +13481,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-dynamic-dispatch-proving-ts@workspace:create-leo-app/template-node-dynamic-dispatch-proving-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13505,7 +13505,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-loyalty-program-ts@workspace:create-leo-app/template-node-loyalty-program-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     dotenv: "npm:^16.4.5"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
@@ -13522,7 +13522,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -13560,7 +13560,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.10.5"
+    "@provablehq/sdk": "npm:^0.10.6"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"


### PR DESCRIPTION
## Motivation

#1321 bumped the versions in `package.json` (including the internal workspace
dependency ranges) but did not regenerate `yarn.lock`. Under Yarn Berry,
`yarn install --immutable` hard-fails with `YN0028` ("The lockfile would have
been modified by this install") on any `package.json` ↔ lockfile mismatch.
This broke CI on `mainnet` and blocks the 0.10.6 release.

Pre-Berry this never surfaced: Yarn 1's v1 lockfile didn't track workspace
internal ranges, and CI's `--immutable` flag was silently ignored by Classic.

## Changes

- `yarn.lock`: 25 `^0.10.5` → `^0.10.6` range updates for `@provablehq/sdk` and
  `@provablehq/wasm` across the workspace and `create-leo-app` templates. No
  other dependency changes, no transitive bumps, no checksum changes.

## Verification

- `yarn install` produces exactly this diff (verified: 25 insertions, 25
  deletions, all `@provablehq/*` version ranges).
- `yarn install --immutable` now passes against the committed lockfile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change that aligns `yarn.lock` with the `@provablehq/sdk`/`@provablehq/wasm` `^0.10.6` version-range bump, primarily affecting install immutability/CI.
> 
> **Overview**
> Updates `yarn.lock` to match the `@provablehq/sdk` and `@provablehq/wasm` `^0.10.6` version-range bump across workspace packages and `create-leo-app` templates.
> 
> No source code changes; this is a lockfile sync to ensure `yarn install --immutable` no longer fails due to a `package.json`↔lockfile mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d495b63e6e2871c20f366f8ee0230a5802f1cb81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->