### PR TITLE
Updating Github Actions

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -3,7 +3,7 @@ description: Sets up Rust
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -10,7 +10,7 @@ runs:
       shell: bash
       run: corepack enable
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         cache: 'yarn'
 

--- a/.github/actions/use-build/action.yml
+++ b/.github/actions/use-build/action.yml
@@ -4,6 +4,6 @@ runs:
   using: "composite"
   steps:
     - name: Download build
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: build

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -19,9 +19,9 @@ env:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/setup-rust
 
@@ -29,7 +29,7 @@ jobs:
           yarn build:all
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build
           path: |
@@ -40,9 +40,9 @@ jobs:
 
   test-wasm:
     name: test wasm
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
 
       - run: |
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -64,14 +64,14 @@ jobs:
 
   e2e:
     name: "e2e"
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: build
     strategy:
       fail-fast: false
       matrix:
         network: [testnet, mainnet, dynamic]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -82,10 +82,10 @@ jobs:
 
   create-leo-app-cli:
     name: "create-leo-app CLI"
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -97,7 +97,7 @@ jobs:
 
   create-leo-app-build:
     name: "create-leo-app build"
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: build
     strategy:
       fail-fast: false
@@ -112,7 +112,7 @@ jobs:
           - react-ts
           - vanilla
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -123,7 +123,7 @@ jobs:
 
   create-leo-app-run:
     name: "create-leo-app run"
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: build
     strategy:
       fail-fast: false
@@ -136,7 +136,7 @@ jobs:
           - template: node-ts
             command: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -147,10 +147,10 @@ jobs:
 
   create-leo-app-loyalty-program-local:
     name: "create-leo-app loyalty-program (local)"
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest-m
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -222,10 +222,10 @@ jobs:
   # a throwing function to simulate mTLS environments.
   transport-e2e:
     name: "Transport-aware proving (testnet)"
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -237,10 +237,10 @@ jobs:
 
   create-leo-app-dynamic-dispatch-proving:
     name: "create-leo-app dynamic-dispatch-proving (testnet)"
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -252,7 +252,7 @@ jobs:
 
   create-leo-app-loyalty-program-delegated:
     name: "create-leo-app loyalty-program (delegated + scanner)"
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: build
     env:
       # Consumer ID (used for both DPS and RSS)
@@ -263,7 +263,7 @@ jobs:
       # RSS configuration
       ALEO_RSS_URL: https://api.provable.com/scanner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 
@@ -286,7 +286,7 @@ jobs:
       matrix:
         network: [testnet, mainnet]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust
 
       - name: "cargo clippy"
@@ -299,7 +299,7 @@ jobs:
     name: "rustfmt"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust
 
       - name: "cargo fmt"
@@ -314,7 +314,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/use-build
 

--- a/.github/workflows/staging-website.yml
+++ b/.github/workflows/staging-website.yml
@@ -9,7 +9,7 @@ jobs:
     name: SDK Website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/update-snarkvm.yml
+++ b/.github/workflows/update-snarkvm.yml
@@ -14,13 +14,13 @@ env:
 jobs:
   update-snarkvm-staging:
     name: Update snarkVM to latest staging
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
       - name: Checkout SDK
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: mainnet
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get latest snarkVM staging commit
         id: snarkvm-commit
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Get the latest commit hash from snarkVM staging branch
@@ -44,7 +44,7 @@ jobs:
               repo: 'snarkVM',
               branch: 'staging'
             });
-            
+
             const latestCommit = branch.commit.sha;
             console.log('Latest snarkVM staging commit:', latestCommit);
             core.setOutput('latest_commit', latestCommit);
@@ -74,7 +74,7 @@ jobs:
             echo "Error: Invalid commit hash format: $LATEST_COMMIT"
             exit 1
           fi
-          
+
           # First, update the rev in Cargo.toml to point to the new commit
           cd wasm
           cargo add snarkvm-algorithms --git https://github.com/ProvableHQ/snarkVM --rev $LATEST_COMMIT
@@ -98,7 +98,7 @@ jobs:
 
           Previous commit: ${{ steps.snarkvm-commit.outputs.current_commit }}
           Latest commit: ${{ steps.snarkvm-commit.outputs.latest_commit }}
-          
+
           This update was performed automatically by the snarkVM update workflow."
 
           # Make sure the remote branch exists and is up to date
@@ -109,7 +109,7 @@ jobs:
 
       - name: Create or update PR
         if: steps.snarkvm-commit.outputs.update_needed == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Check if a PR already exists from update-snarkvm-staging to staging
@@ -120,7 +120,7 @@ jobs:
               base: 'staging',
               state: 'open'
             });
-            
+
             if (prs.length === 0) {
               // No PR exists, create one
               const { data: pr } = await github.rest.pulls.create({

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,7 +9,7 @@ jobs:
     name: SDK Website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-yarn
       - uses: ./.github/actions/setup-rust
 


### PR DESCRIPTION
Our current CI runner and actions are 2 years out of date.

This upgrades to the latest runner and the latest version of the actions.

This fixes a lot of warnings and deprecations, and is also necessary to fix wasm-opt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI YAML and action versions; application code and runtime behavior are unchanged, though runner swaps could affect job duration or flakes until validated in CI.
> 
> **Overview**
> Bumps **GitHub Actions** across composite setup steps and workflows to current major versions: `actions/cache` **v5**, `actions/setup-node` **v6**, `actions/checkout` **v6**, `actions/upload-artifact` **v7**, `actions/download-artifact` **v8**, and `actions/github-script` **v9** (snarkVM update workflow).
> 
> Most CI jobs that used **`ubuntu-latest-m`** or pinned **`ubuntu-22.04`** now run on **`ubuntu-latest`**, aligning runners with up-to-date images (called out to address deprecations and **`wasm-opt`**). One SDK job (`create-leo-app-dynamic-dispatch`) still targets **`ubuntu-latest-m`** while peers were moved to **`ubuntu-latest`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfdbbed95e1e909970a6f54463b86e3e0b4c448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->