### PR TITLE
[Chore] Bump SDK version to v0.11.0 + add pre-release cleanups

### DIFF
--- a/create-leo-app/package.json
+++ b/create-leo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-leo-app",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "type": "module",
   "license": "GPL-3.0",
   "collaborators": [

--- a/create-leo-app/template-build-and-execute-authorization-ts/package.json
+++ b/create-leo-app/template-build-and-execute-authorization-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-devnode-js/package.json
+++ b/create-leo-app/template-devnode-js/package.json
@@ -7,6 +7,6 @@
     "dev": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/create-leo-app/template-extension/package.json
+++ b/create-leo-app/template-extension/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf static/js && rollup --config"
   },
   "devDependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@web/rollup-plugin-import-meta-assets": "^2.2.1",
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-nextjs-ts/package.json
+++ b/create-leo-app/template-nextjs-ts/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "next": "15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/create-leo-app/template-node-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-node-credits-aleo-functions-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6"
+        "@provablehq/sdk": "^0.11.0"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
+++ b/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6"
+        "@provablehq/sdk": "^0.11.0"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-loyalty-program-ts/package.json
+++ b/create-leo-app/template-node-loyalty-program-ts/package.json
@@ -15,7 +15,7 @@
         "start:caching": "npm run build && node dist/index.js key_caching"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "dotenv": "^16.4.5"
     },
     "devDependencies": {

--- a/create-leo-app/template-node-ts/package.json
+++ b/create-leo-app/template-node-ts/package.json
@@ -10,7 +10,7 @@
     "test": "npm run build && node dist/index.js && node dist/dynamic-dispatch.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-node/package.json
+++ b/create-leo-app/template-node/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/create-leo-app/template-offline-public-transaction-ts/package.json
+++ b/create-leo-app/template-offline-public-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node --trace-uncaught dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-private-transaction-ts/package.json
+++ b/create-leo-app/template-private-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-react-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-react-credits-aleo-functions-ts/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "comlink": "^4.4.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-leo/package.json
+++ b/create-leo-app/template-react-leo/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-loyalty-program-ts/package.json
+++ b/create-leo-app/template-react-loyalty-program-ts/package.json
@@ -13,7 +13,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-managed-worker/package.json
+++ b/create-leo-app/template-react-managed-worker/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/create-leo-app/template-react-ts/package.json
+++ b/create-leo-app/template-react-ts/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-vanilla/package.json
+++ b/create-leo-app/template-vanilla/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "tslib": "^2.8.1",
         "vite": "^6.4.2"
     }

--- a/e2e/dynamic/package.json
+++ b/e2e/dynamic/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/e2e/mainnet/package.json
+++ b/e2e/mainnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/e2e/nodenext/package.json
+++ b/e2e/nodenext/package.json
@@ -2,7 +2,7 @@
     "name": "nodenext",
     "type": "module",
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "typescript": "^5.7.3"
     },
     "scripts": {

--- a/e2e/testnet/package.json
+++ b/e2e/testnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/sdk",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Provable Team"
@@ -91,7 +91,7 @@
   },
   "homepage": "https://github.com/ProvableHQ/sdk#readme",
   "dependencies": {
-    "@provablehq/wasm": "^0.10.6",
+    "@provablehq/wasm": "^0.11.0",
     "@scure/base": "^2.0.0",
     "@serenity-kit/noble-sodium": "0.2.3",
     "comlink": "^4.4.2",

--- a/sdk/src/keys/keystore/indexeddb.ts
+++ b/sdk/src/keys/keystore/indexeddb.ts
@@ -64,17 +64,18 @@ export class IndexedDBKeyStore implements KeyStore {
     /** Opens (or creates) the database, returning a cached promise. */
     private openDB(): Promise<IDBDatabase> {
         if (this.dbPromise) return this.dbPromise;
+        // Env check sits outside the Promise constructor so a failure doesn't
+        // poison the cache; a later call (e.g. after a polyfill loads) can retry.
+        if (typeof indexedDB === "undefined") {
+            return Promise.reject(
+                new Error(
+                    "IndexedDBKeyStore requires a browser or Web Worker environment: " +
+                        "`indexedDB` is not defined. If you are in Node.js or an SSR " +
+                        "context, use LocalFileKeyStore or an in-memory key provider instead.",
+                ),
+            );
+        }
         this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
-            if (typeof indexedDB === "undefined") {
-                reject(
-                    new Error(
-                        "IndexedDBKeyStore requires a browser or Web Worker environment: " +
-                            "`indexedDB` is not defined. If you are in Node.js or an SSR " +
-                            "context, use LocalFileKeyStore or an in-memory key provider instead.",
-                    ),
-                );
-                return;
-            }
             const request = indexedDB.open(this.dbName, 1);
             request.onupgradeneeded = () => {
                 const db = request.result;

--- a/sdk/src/keys/keystore/indexeddb.ts
+++ b/sdk/src/keys/keystore/indexeddb.ts
@@ -22,6 +22,17 @@ interface StoredKey {
  * It persists proving and verifying keys across page reloads and browser sessions using the
  * IndexedDB API available in all modern browsers and Web Workers.
  *
+ * **Environment**: Browser / Web Worker only. Instantiating this class is safe in any
+ * environment, but the first IndexedDB operation will reject with a clear error when
+ * `globalThis.indexedDB` is not available (e.g., Node.js, SSR contexts). Guard your
+ * imports accordingly if you bundle for server-side rendering.
+ *
+ * **Security**: Keys are stored as plaintext `Uint8Array` in IndexedDB. Any script
+ * running on the same origin — including scripts injected via XSS — can read the stored
+ * proving and verifying keys. Do **not** use this keystore for data that must remain
+ * confidential under an XSS-capable adversary; encrypt sensitive material at the
+ * application layer before persisting, or use an in-memory store.
+ *
  * @example
  * ```ts
  * import { IndexedDBKeyStore, ProgramManager } from "@provablehq/sdk";
@@ -54,6 +65,16 @@ export class IndexedDBKeyStore implements KeyStore {
     private openDB(): Promise<IDBDatabase> {
         if (this.dbPromise) return this.dbPromise;
         this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+            if (typeof indexedDB === "undefined") {
+                reject(
+                    new Error(
+                        "IndexedDBKeyStore requires a browser or Web Worker environment: " +
+                            "`indexedDB` is not defined. If you are in Node.js or an SSR " +
+                            "context, use LocalFileKeyStore or an in-memory key provider instead.",
+                    ),
+                );
+                return;
+            }
             const request = indexedDB.open(this.dbName, 1);
             request.onupgradeneeded = () => {
                 const db = request.result;

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -423,7 +423,7 @@ class ProgramManager {
             try {
                 resolvedImports = await this.networkClient.getProgramImports(programSource);
             } catch (e) {
-                console.warn(`Failed to resolve program imports from network: ${e}.`);
+                logger.warn(`Failed to resolve program imports from network: ${e}.`);
             }
         }
 
@@ -480,7 +480,7 @@ class ProgramManager {
                     }
                 }
             } catch (e) {
-                console.warn(`Failed to resolve transitive imports for ${name}: ${e}`);
+                logger.warn(`Failed to resolve transitive imports for ${name}: ${e}`);
             }
         }
 
@@ -522,7 +522,7 @@ class ProgramManager {
                         }
                     }
                 } catch (e) {
-                    console.warn(`Failed to trace call graph for ${name}: ${e}`);
+                    logger.warn(`Failed to trace call graph for ${name}: ${e}`);
                 }
             }
         }
@@ -540,7 +540,7 @@ class ProgramManager {
             try {
                 builder.addProgram(name, source, importEdition);
             } catch (e) {
-                console.warn(`Failed to add import ${name} to builder: ${e}`);
+                logger.warn(`Failed to add import ${name} to builder: ${e}`);
                 continue;
             }
 
@@ -600,7 +600,7 @@ class ProgramManager {
             const info = await this.networkClient.getProgramAmendmentCount(programName);
             return { edition: info.edition, amendment: info.amendment_count };
         } catch (e: any) {
-            console.warn(`Error finding edition/amendment for ${programName}. Network response: '${e.message}'. Defaulting to edition ${fallbackEdition ?? 1}, amendment 0.`);
+            logger.warn(`Error finding edition/amendment for ${programName}. Network response: '${e.message}'. Defaulting to edition ${fallbackEdition ?? 1}, amendment 0.`);
             return { edition: fallbackEdition ?? 1, amendment: 0 };
         }
     }
@@ -640,7 +640,7 @@ class ProgramManager {
                 const vk = await keyStore.getVerifyingKey(vkLocator);
                 if (vk) builder.addVerifyingKey(programName, fnName, vk);
             } catch (e) {
-                console.debug(`Failed to load keys for ${programName}/${fnName}: ${e}`);
+                logger.debug(`Failed to load keys for ${programName}/${fnName}: ${e}`);
             }
         }
     }
@@ -678,7 +678,7 @@ class ProgramManager {
             try {
                 fns = Array.from(builder.functionKeysAvailable(programName));
             } catch (e) {
-                console.debug(`Failed to query keys for ${programName}: ${e}`);
+                logger.debug(`Failed to query keys for ${programName}: ${e}`);
                 continue;
             }
 
@@ -698,7 +698,7 @@ class ProgramManager {
                         await keyStore.setKeys(pkLocator, vkLocator, [pk, vk]);
                     }
                 } catch (e) {
-                    console.debug(`Failed to persist key for ${programName}/${fnName}: ${e}`);
+                    logger.debug(`Failed to persist key for ${programName}/${fnName}: ${e}`);
                 }
             }
         }
@@ -1319,7 +1319,7 @@ class ProgramManager {
             if (keys) {
                 [provingKey, verifyingKey] = keys;
             } else {
-                console.log(
+                logger.log(
                     "Function keys not found in KeyStore or KeyProvider. The function keys will be synthesized",
                 );
             }
@@ -1386,7 +1386,7 @@ class ProgramManager {
         try {
             await this.persistExtractedKeys(programImportsBuilder, importEditions);
         } catch (e) {
-            console.debug(`Failed to persist extracted keys: ${e}`);
+            logger.debug(`Failed to persist extracted keys: ${e}`);
         }
 
         return result;
@@ -1522,7 +1522,7 @@ class ProgramManager {
             if (keys) {
                 [provingKey, verifyingKey] = keys;
             } else {
-                console.log(
+                logger.log(
                     "Function keys not found in KeyStore or KeyProvider. The function keys will be synthesized",
                 );
             }
@@ -1557,7 +1557,7 @@ class ProgramManager {
         try {
             await this.persistExtractedKeys(programImportsBuilder, importEditions);
         } catch (e) {
-            console.debug(`Failed to persist extracted keys: ${e}`);
+            logger.debug(`Failed to persist extracted keys: ${e}`);
         }
 
         return result;
@@ -2200,7 +2200,7 @@ class ProgramManager {
             if (keys) {
                 [provingKey, verifyingKey] = keys;
             } else {
-                console.log(
+                logger.log(
                     "Function keys not found in KeyStore or KeyProvider. The function keys will be synthesized",
                 );
             }
@@ -2238,7 +2238,7 @@ class ProgramManager {
         try {
             await this.persistExtractedKeys(builder, importEditions);
         } catch (e) {
-            console.debug(`Failed to persist extracted keys: ${e}`);
+            logger.debug(`Failed to persist extracted keys: ${e}`);
         }
 
         return result;

--- a/sdk/src/record-scanner.ts
+++ b/sdk/src/record-scanner.ts
@@ -365,6 +365,20 @@ class RecordScanner implements RecordProvider {
     }
 
     /**
+     * Registers the account with the record scanning service using the encrypted flow.
+     * Alias of {@link registerEncrypted} — preserved so existing callers using the
+     * previous unencrypted `register(viewKey, startBlock)` API continue to work
+     * unchanged while transparently using the encrypted endpoint.
+     *
+     * @param {ViewKey} viewKey The view key to register.
+     * @param {number} startBlock The block height to start scanning from.
+     * @returns {Promise<RegisterResult>} `{ ok: true, data }` on success, or `{ ok: false, status, error }` on failure.
+     */
+    async register(viewKey: ViewKey, startBlock: number): Promise<RegisterResult> {
+        return this.registerEncrypted(viewKey, startBlock);
+    }
+
+    /**
      * Registers the account with the record scanning service using the encrypted flow: 1. fetches an ephemeral public key from /pubkey - 2. encrypts the registration request (view key + start block) - 3. POSTs to /register/encrypted. Does not HTTP error on a proper error response from the record scanner; returns a result object instead.
      *
      * @param {ViewKey} viewKey The view key to register.

--- a/sdk/tests/indexeddb-keystore.test.ts
+++ b/sdk/tests/indexeddb-keystore.test.ts
@@ -63,6 +63,47 @@ describe("IndexedDBKeyStore", () => {
                 if (had) g.indexedDB = prior;
             }
         });
+
+        it("does not poison the cache: retries env check after indexedDB becomes defined", async () => {
+            const g = globalThis as any;
+            const had = "indexedDB" in g;
+            const prior = g.indexedDB;
+            if (had) delete g.indexedDB;
+            try {
+                const store = new IndexedDBKeyStore("late-polyfill-test");
+
+                // First call: indexedDB undefined → should reject.
+                let err1: Error | undefined;
+                try {
+                    await store.has(locator());
+                } catch (e) { err1 = e as Error; }
+                expect(err1, "first call should reject").to.exist;
+                expect(err1!.message).to.match(/indexedDB/i);
+
+                // Simulate a polyfill loading after the first failed call.
+                let openCallCount = 0;
+                g.indexedDB = {
+                    open(_name: string, _version: number) {
+                        openCallCount += 1;
+                        const req: any = { onerror: null, onsuccess: null, onupgradeneeded: null, onblocked: null };
+                        setTimeout(() => req.onblocked && req.onblocked(), 0);
+                        return req;
+                    },
+                };
+
+                // Second call: indexedDB now defined → should reach indexedDB.open
+                // rather than re-using the cached rejection.
+                try {
+                    await store.has(locator());
+                } catch {
+                    // expected — blocked stub fires AbortError
+                }
+                expect(openCallCount, "openDB should retry after env check now passes").to.equal(1);
+            } finally {
+                if (had) g.indexedDB = prior;
+                else delete g.indexedDB;
+            }
+        });
     });
 
     describe("locator validation (pre-IndexedDB)", () => {

--- a/sdk/tests/indexeddb-keystore.test.ts
+++ b/sdk/tests/indexeddb-keystore.test.ts
@@ -1,0 +1,209 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import {
+    IndexedDBKeyStore,
+    InvalidLocatorError,
+    ProvingKeyLocator,
+} from "../src/node.js";
+
+// Helper: build a minimal valid ProvingKeyLocator, allowing field overrides.
+function locator(overrides: Partial<ProvingKeyLocator> = {}): ProvingKeyLocator {
+    return {
+        program: "credits.aleo",
+        functionName: "transfer_private",
+        edition: 1,
+        amendment: 0,
+        network: "mainnet",
+        keyType: "prover",
+        ...overrides,
+    };
+}
+
+// Helper: install / uninstall a stub `indexedDB` on globalThis.
+function withIndexedDBStub(stub: any, fn: () => Promise<void>): Promise<void> {
+    const g = globalThis as any;
+    const had = "indexedDB" in g;
+    const prior = g.indexedDB;
+    g.indexedDB = stub;
+    return fn().finally(() => {
+        if (had) g.indexedDB = prior;
+        else delete g.indexedDB;
+    });
+}
+
+describe("IndexedDBKeyStore", () => {
+    afterEach(() => {
+        sinon.restore();
+        // Defensive cleanup in case a test threw before its finally.
+        const g = globalThis as any;
+        if (g.__indexedDBStubInstalled) {
+            delete g.indexedDB;
+            delete g.__indexedDBStubInstalled;
+        }
+    });
+
+    describe("environment guard", () => {
+        it("rejects with a clear error when indexedDB is undefined", async () => {
+            const g = globalThis as any;
+            const had = "indexedDB" in g;
+            const prior = g.indexedDB;
+            if (had) delete g.indexedDB;
+            try {
+                const store = new IndexedDBKeyStore("smoke-test");
+                let err: Error | undefined;
+                try {
+                    await store.getKeyBytes(locator());
+                } catch (e) {
+                    err = e as Error;
+                }
+                expect(err, "expected getKeyBytes to reject").to.exist;
+                expect(err!.message).to.match(/indexedDB/i);
+                expect(err!.message).to.match(/browser|Web Worker|SSR|Node/i);
+            } finally {
+                if (had) g.indexedDB = prior;
+            }
+        });
+    });
+
+    describe("locator validation (pre-IndexedDB)", () => {
+        // These tests don't need a real IndexedDB — validation throws before openDB.
+        let store: IndexedDBKeyStore;
+        beforeEach(() => {
+            store = new IndexedDBKeyStore("locator-test");
+        });
+
+        it("rejects empty program component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ program: "" }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("reserved_name");
+        });
+
+        it("rejects \".\" component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ functionName: "." }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("reserved_name");
+        });
+
+        it("rejects path-traversal component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ program: "../etc" }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("path_traversal");
+        });
+
+        it("rejects path separators in component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ functionName: "a/b" }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("path_separator");
+        });
+
+        it("rejects null byte in component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ network: "main\0net" }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("path_separator");
+        });
+
+        it("rejects negative edition", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ edition: -1 }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("negative_value");
+        });
+
+        it("rejects non-integer amendment", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ amendment: 0.5 }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("negative_value");
+        });
+    });
+
+    describe("openDB error recovery", () => {
+        // Verifies the cached dbPromise is cleared on error/blocked so a subsequent
+        // call gets a fresh attempt rather than being permanently poisoned.
+        it("retries open after an initial error", async () => {
+            let callCount = 0;
+            const stub = {
+                open(_name: string, _version: number) {
+                    callCount += 1;
+                    const req: any = { onerror: null, onsuccess: null, onupgradeneeded: null, onblocked: null };
+                    // First call errors; subsequent calls succeed with a dummy DB.
+                    setTimeout(() => {
+                        if (callCount === 1) {
+                            req.error = new Error("simulated open error");
+                            req.onerror && req.onerror();
+                        } else {
+                            req.result = { transaction: () => { throw new Error("not used in this test"); } };
+                            req.onsuccess && req.onsuccess();
+                        }
+                    }, 0);
+                    return req;
+                },
+            };
+
+            await withIndexedDBStub(stub, async () => {
+                const store = new IndexedDBKeyStore("retry-test");
+
+                // First call should reject.
+                let err1: Error | undefined;
+                try {
+                    await store.has(locator());
+                } catch (e) {
+                    err1 = e as Error;
+                }
+                expect(err1, "first call should reject").to.exist;
+                expect(err1!.message).to.match(/simulated open error/);
+                expect(callCount).to.equal(1);
+
+                // Second call should reach indexedDB.open again (cache cleared).
+                // We expect a different error here (txn stub throws), but the key
+                // assertion is that callCount increments — proving the promise
+                // wasn't poisoned.
+                try {
+                    await store.has(locator());
+                } catch {
+                    // expected — txn stub is intentionally minimal
+                }
+                expect(callCount, "openDB should retry after error").to.equal(2);
+            });
+        });
+
+        it("rejects with AbortError when open is blocked", async () => {
+            const stub = {
+                open(_name: string, _version: number) {
+                    const req: any = { onerror: null, onsuccess: null, onupgradeneeded: null, onblocked: null };
+                    setTimeout(() => req.onblocked && req.onblocked(), 0);
+                    return req;
+                },
+            };
+
+            await withIndexedDBStub(stub, async () => {
+                const store = new IndexedDBKeyStore("blocked-test");
+                let err: any;
+                try {
+                    await store.has(locator());
+                } catch (e) { err = e; }
+                expect(err).to.exist;
+                expect(err.name).to.equal("AbortError");
+            });
+        });
+    });
+});

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "12aca1021aef2c476bad30d2f681e891b2be4f07dbc230a96df09cb693bfb3cb"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.10.6"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-wasm"
-version = "0.10.6"
+version = "0.11.0"
 authors = [ "The Provable Team" ]
 description = "WebAssembly based toolkit for developing zero-knowledge applications with Aleo"
 homepage = "https://provable.com"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/wasm",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
         "@codemirror/language": "^6.10.8",
         "@codemirror/legacy-modes": "^6.4.2",
         "@codemirror/stream-parser": "^0.19.9",
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "@uiw/codemirror-theme-noctis-lilac": "^4.23.7",
         "@uiw/codemirror-theme-okaidia": "^4.23.7",
         "@uiw/react-codemirror": "^4.23.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2872,12 +2872,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@provablehq/sdk@npm:^0.10.0, @provablehq/sdk@npm:^0.10.6, @provablehq/sdk@workspace:sdk":
+"@provablehq/sdk@npm:^0.10.0":
+  version: 0.10.5
+  resolution: "@provablehq/sdk@npm:0.10.5"
+  dependencies:
+    "@provablehq/wasm": "npm:^0.10.5"
+    "@scure/base": "npm:^2.0.0"
+    "@serenity-kit/noble-sodium": "npm:0.2.3"
+    comlink: "npm:^4.4.2"
+    core-js: "npm:^3.40.0"
+    mime: "npm:^4.0.6"
+    xmlhttprequest-ssl: "npm:^4.0.0"
+  checksum: 10c0/1b72f0650ba4e571616527bd47eaf2a886db8a12a2d87e8d656e5d5dcf58b10e60d0ab6c1efa1b5b03cf952f60b6483ed1a6b383a0478906eb63eea753181d77
+  languageName: node
+  linkType: hard
+
+"@provablehq/sdk@npm:^0.11.0, @provablehq/sdk@workspace:sdk":
   version: 0.0.0-use.local
   resolution: "@provablehq/sdk@workspace:sdk"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.18.2"
-    "@provablehq/wasm": "npm:^0.10.6"
+    "@provablehq/wasm": "npm:^0.11.0"
     "@rollup/plugin-replace": "npm:^6.0.2"
     "@scure/base": "npm:^2.0.0"
     "@serenity-kit/noble-sodium": "npm:0.2.3"
@@ -2911,7 +2926,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@provablehq/wasm@npm:^0.10.6, @provablehq/wasm@workspace:wasm":
+"@provablehq/wasm@npm:^0.10.5":
+  version: 0.10.5
+  resolution: "@provablehq/wasm@npm:0.10.5"
+  checksum: 10c0/97e4c3e28a1cfcb76af9d35f6d48e44650cf43bc70e683011067515e65b707f16c53bdba476b24604b19f5f962819b6d128870c74e603d06ee86bcf53c58acaf
+  languageName: node
+  linkType: hard
+
+"@provablehq/wasm@npm:^0.11.0, @provablehq/wasm@workspace:wasm":
   version: 0.0.0-use.local
   resolution: "@provablehq/wasm@workspace:wasm"
   dependencies:
@@ -4630,7 +4652,7 @@ __metadata:
     "@babel/core": "npm:^7.26.7"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4663,7 +4685,7 @@ __metadata:
     "@babel/core": "npm:^7.26.7"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4695,7 +4717,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -4729,7 +4751,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aleo-starter@workspace:create-leo-app/template-vanilla"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     tslib: "npm:^2.8.1"
     vite: "npm:^6.4.2"
   languageName: unknown
@@ -4747,7 +4769,7 @@ __metadata:
     "@codemirror/language": "npm:^6.10.8"
     "@codemirror/legacy-modes": "npm:^6.4.2"
     "@codemirror/stream-parser": "npm:^0.19.9"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@uiw/codemirror-theme-noctis-lilac": "npm:^4.23.7"
@@ -6574,7 +6596,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "devnode-starter@workspace:create-leo-app/template-devnode-js"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -6752,7 +6774,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-dynamic@workspace:e2e/dynamic"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -6760,7 +6782,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-mainnet@workspace:e2e/mainnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -6768,7 +6790,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-testnet@workspace:e2e/testnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -7509,7 +7531,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "extension-starter@workspace:create-leo-app/template-extension"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@rollup/plugin-node-resolve": "npm:^16.0.0"
     "@web/rollup-plugin-import-meta-assets": "npm:^2.2.1"
     rimraf: "npm:^6.0.1"
@@ -10167,7 +10189,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-build-and-execute-authorization-ts-starter@workspace:create-leo-app/template-build-and-execute-authorization-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10238,7 +10260,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-offline-transaction-example@workspace:create-leo-app/template-offline-public-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10257,7 +10279,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-starter@workspace:create-leo-app/template-node"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -10265,7 +10287,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-starter@workspace:create-leo-app/template-node-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10277,7 +10299,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-transfer-private-starter@workspace:create-leo-app/template-private-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10289,7 +10311,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nodenext@workspace:e2e/nodenext"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
@@ -13653,7 +13675,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-nextjs@workspace:create-leo-app/template-nextjs-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
@@ -13669,7 +13691,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-credits-aleo-functions-ts@workspace:create-leo-app/template-node-credits-aleo-functions-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13681,7 +13703,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-dynamic-dispatch-proving-ts@workspace:create-leo-app/template-node-dynamic-dispatch-proving-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13705,7 +13727,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-loyalty-program-ts@workspace:create-leo-app/template-node-loyalty-program-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     dotenv: "npm:^16.4.5"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
@@ -13722,7 +13744,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -13760,7 +13782,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"


### PR DESCRIPTION
## Motivation

This PR bumps the SDK version to v0.11.0 and adds the following cleanups:
* Adds a guard to IndexedDB for non-browser environments
* Changes remaining console.log statements to the new logger.log
* Re-adds the register method on the `RecordScanner` object to now call `register/encrypted`.
* Documents changes in behavior

## Test Plan

The following tests have been added:
* IndexedDB lifecycle smoke tests
* Tests of `wasm` and `TS` logging outputs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> RecordScanner `register` now always uses the encrypted flow (behavior change for scanning integrations), and IndexedDB still stores keys in plaintext despite new documentation.
> 
> **Overview**
> Releases **v0.11.0** for `@provablehq/sdk`, `@provablehq/wasm`, and `create-leo-app`, and bumps `^0.11.0` across templates, e2e, website, and lockfile entries.
> 
> **IndexedDB keystore** now fails fast with a clear error when `indexedDB` is missing (Node/SSR), documents browser-only use and plaintext XSS risk, and avoids caching a permanent rejection so a later polyfill can retry. **ProgramManager** routes prior `console.*` import/key paths through the shared **`logger`**. **RecordScanner** restores **`register(viewKey, startBlock)`** as an alias that delegates to **`registerEncrypted`**, so existing callers hit the encrypted registration endpoint without API churn.
> 
> Adds **`sdk/tests/indexeddb-keystore.test.ts`** for environment guards, locator validation, and open/retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e43c9246557e5d4c3ac4575f7726f09cdfe16680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->