### PR TITLE
[Feature] Support sending signed requests to DPS

### DIFF
--- a/create-leo-app/package.json
+++ b/create-leo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-leo-app",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "type": "module",
   "license": "GPL-3.0",
   "collaborators": [

--- a/create-leo-app/template-build-and-execute-authorization-ts/package.json
+++ b/create-leo-app/template-build-and-execute-authorization-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-devnode-js/package.json
+++ b/create-leo-app/template-devnode-js/package.json
@@ -7,6 +7,6 @@
     "dev": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/create-leo-app/template-extension/package.json
+++ b/create-leo-app/template-extension/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf static/js && rollup --config"
   },
   "devDependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@web/rollup-plugin-import-meta-assets": "^2.2.1",
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-nextjs-ts/package.json
+++ b/create-leo-app/template-nextjs-ts/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "next": "15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/create-leo-app/template-node-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-node-credits-aleo-functions-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6"
+        "@provablehq/sdk": "^0.11.0"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
+++ b/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6"
+        "@provablehq/sdk": "^0.11.0"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-loyalty-program-ts/package.json
+++ b/create-leo-app/template-node-loyalty-program-ts/package.json
@@ -15,7 +15,7 @@
         "start:caching": "npm run build && node dist/index.js key_caching"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "dotenv": "^16.4.5"
     },
     "devDependencies": {

--- a/create-leo-app/template-node-ts/package.json
+++ b/create-leo-app/template-node-ts/package.json
@@ -10,7 +10,7 @@
     "test": "npm run build && node dist/index.js && node dist/dynamic-dispatch.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-node/package.json
+++ b/create-leo-app/template-node/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/create-leo-app/template-offline-public-transaction-ts/package.json
+++ b/create-leo-app/template-offline-public-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node --trace-uncaught dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-private-transaction-ts/package.json
+++ b/create-leo-app/template-private-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-react-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-react-credits-aleo-functions-ts/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "comlink": "^4.4.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-leo/package.json
+++ b/create-leo-app/template-react-leo/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-loyalty-program-ts/package.json
+++ b/create-leo-app/template-react-loyalty-program-ts/package.json
@@ -13,7 +13,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-managed-worker/package.json
+++ b/create-leo-app/template-react-managed-worker/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/create-leo-app/template-react-ts/package.json
+++ b/create-leo-app/template-react-ts/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6",
+    "@provablehq/sdk": "^0.11.0",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-vanilla/package.json
+++ b/create-leo-app/template-vanilla/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "tslib": "^2.8.1",
         "vite": "^6.4.2"
     }

--- a/e2e/dynamic/package.json
+++ b/e2e/dynamic/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/e2e/mainnet/package.json
+++ b/e2e/mainnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/e2e/nodenext/package.json
+++ b/e2e/nodenext/package.json
@@ -2,7 +2,7 @@
     "name": "nodenext",
     "type": "module",
     "dependencies": {
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "typescript": "^5.7.3"
     },
     "scripts": {

--- a/e2e/testnet/package.json
+++ b/e2e/testnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.10.6"
+    "@provablehq/sdk": "^0.11.0"
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/sdk",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Provable Team"
@@ -91,7 +91,7 @@
   },
   "homepage": "https://github.com/ProvableHQ/sdk#readme",
   "dependencies": {
-    "@provablehq/wasm": "^0.10.6",
+    "@provablehq/wasm": "^0.11.0",
     "@scure/base": "^2.0.0",
     "@serenity-kit/noble-sodium": "0.2.3",
     "comlink": "^4.4.2",

--- a/sdk/src/keys/keystore/indexeddb.ts
+++ b/sdk/src/keys/keystore/indexeddb.ts
@@ -64,17 +64,18 @@ export class IndexedDBKeyStore implements KeyStore {
     /** Opens (or creates) the database, returning a cached promise. */
     private openDB(): Promise<IDBDatabase> {
         if (this.dbPromise) return this.dbPromise;
+        // Env check sits outside the Promise constructor so a failure doesn't
+        // poison the cache; a later call (e.g. after a polyfill loads) can retry.
+        if (typeof indexedDB === "undefined") {
+            return Promise.reject(
+                new Error(
+                    "IndexedDBKeyStore requires a browser or Web Worker environment: " +
+                        "`indexedDB` is not defined. If you are in Node.js or an SSR " +
+                        "context, use LocalFileKeyStore or an in-memory key provider instead.",
+                ),
+            );
+        }
         this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
-            if (typeof indexedDB === "undefined") {
-                reject(
-                    new Error(
-                        "IndexedDBKeyStore requires a browser or Web Worker environment: " +
-                            "`indexedDB` is not defined. If you are in Node.js or an SSR " +
-                            "context, use LocalFileKeyStore or an in-memory key provider instead.",
-                    ),
-                );
-                return;
-            }
             const request = indexedDB.open(this.dbName, 1);
             request.onupgradeneeded = () => {
                 const db = request.result;

--- a/sdk/src/keys/keystore/indexeddb.ts
+++ b/sdk/src/keys/keystore/indexeddb.ts
@@ -22,6 +22,17 @@ interface StoredKey {
  * It persists proving and verifying keys across page reloads and browser sessions using the
  * IndexedDB API available in all modern browsers and Web Workers.
  *
+ * **Environment**: Browser / Web Worker only. Instantiating this class is safe in any
+ * environment, but the first IndexedDB operation will reject with a clear error when
+ * `globalThis.indexedDB` is not available (e.g., Node.js, SSR contexts). Guard your
+ * imports accordingly if you bundle for server-side rendering.
+ *
+ * **Security**: Keys are stored as plaintext `Uint8Array` in IndexedDB. Any script
+ * running on the same origin — including scripts injected via XSS — can read the stored
+ * proving and verifying keys. Do **not** use this keystore for data that must remain
+ * confidential under an XSS-capable adversary; encrypt sensitive material at the
+ * application layer before persisting, or use an in-memory store.
+ *
  * @example
  * ```ts
  * import { IndexedDBKeyStore, ProgramManager } from "@provablehq/sdk";
@@ -54,6 +65,16 @@ export class IndexedDBKeyStore implements KeyStore {
     private openDB(): Promise<IDBDatabase> {
         if (this.dbPromise) return this.dbPromise;
         this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+            if (typeof indexedDB === "undefined") {
+                reject(
+                    new Error(
+                        "IndexedDBKeyStore requires a browser or Web Worker environment: " +
+                            "`indexedDB` is not defined. If you are in Node.js or an SSR " +
+                            "context, use LocalFileKeyStore or an in-memory key provider instead.",
+                    ),
+                );
+                return;
+            }
             const request = indexedDB.open(this.dbName, 1);
             request.onupgradeneeded = () => {
                 const db = request.result;

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1869,6 +1869,14 @@ class AleoNetworkClient {
             ? options.provingRequest.toString()
             : options.provingRequest;
 
+        // Determine the variant for endpoint routing. Only inspect `kind()`
+        // when the caller passed a `ProvingRequest` object — string inputs
+        // are deferred to the encrypted path's parse (preserves prior
+        // behavior for callers that pass opaque strings like JWT-refresh
+        // unit tests, which rely on the JWT fetch firing first).
+        const isRequestVariant = options.provingRequest instanceof ProvingRequest
+            && options.provingRequest.kind() === "request";
+
         // Try to get JWT data to access the Provable API.
         const apiKey = options.apiKey ?? this.apiKey;
         const consumerId = options.consumerId ?? this.consumerId;
@@ -1896,47 +1904,63 @@ class AleoNetworkClient {
             headers["Authorization"] = jwtData.jwt;
         }
 
+        // Send the proving request encrypted (libsodium sealed box). Used by
+        // both the /prove/encrypted (Authorization variant, opt-in) and
+        // /prove/request (Request variant, mandatory) paths.
+        const sendEncrypted = async (endpoint: string): Promise<ProvingResult> => {
+            // Get an ephemeral public key from the DPS.
+            const pubKeyResponse = await get(proverUri + "/pubkey", {
+                headers,
+                credentials: "include",
+            }, this.transport);
+
+            // Encrypt the provingRequest. Parse lazily — only the encrypted
+            // paths need a real `ProvingRequest` object; the plaintext path
+            // forwards the string verbatim.
+            const pubkey: CryptoBoxPubKey = parseJSON(
+                await pubKeyResponse.text(),
+            );
+            const provingRequestObj = options.provingRequest instanceof ProvingRequest
+                ? options.provingRequest
+                : ProvingRequest.fromString(provingRequestString);
+            const ciphertext = encryptProvingRequest(
+                pubkey.public_key,
+                provingRequestObj,
+            );
+
+            const payload: EncryptedProvingRequest = {
+                key_id: pubkey.key_id,
+                ciphertext: ciphertext,
+            };
+
+            // We're in node, attempt to set the cookie manually.
+            const cookie = isNode() ? pubKeyResponse.headers.get("set-cookie"): undefined;
+
+            const res = await this.transport(`${proverUri}${endpoint}`, {
+                method: "POST",
+                body: JSON.stringify(payload),
+                headers: {
+                    ...headers,
+                    ...(cookie ? { Cookie: cookie } : {})
+                },
+                credentials: "include",
+            });
+
+            return this.handleProvingResponse(res);
+        };
+
         // Encapsulate the requests in a locally scoped function that can be run with a retry closure.
         const runRequest = async (): Promise<ProvingResult> => {
-            // If DPS privacy is set, call invoke the encrypted flow.
+            // Request variant is encrypted-only and always routes to /prove/request.
+            // The DPS reads bytes via `read_request_le` on this route; `dpsPrivacy`
+            // is implicit because the route doesn't accept plaintext.
+            if (isRequestVariant) {
+                return sendEncrypted("/prove/request");
+            }
+
+            // Authorization variant: opt-in encrypted via /prove/encrypted.
             if (options.dpsPrivacy) {
-                // Get an ephemeral public key from a DPS service.
-                const pubKeyResponse = await get(proverUri + "/pubkey", {
-                    headers,
-                    credentials: "include",
-                }, this.transport);
-
-                // Encrypt the provingRequest.
-                const pubkey: CryptoBoxPubKey = parseJSON(
-                    await pubKeyResponse.text(),
-                );
-                const ciphertext = encryptProvingRequest(
-                    pubkey.public_key,
-                    ProvingRequest.fromString(provingRequestString),
-                );
-
-                // Form the expected query a DPS service expects (including the key_id).
-                const payload: EncryptedProvingRequest = {
-                    key_id: pubkey.key_id,
-                    ciphertext: ciphertext,
-                };
-
-                // We're in node, attempt to set the cookie manually.
-                const cookie = isNode() ? pubKeyResponse.headers.get("set-cookie"): undefined;
-
-                // Send the encrypted proving request to the DPS service.
-                const res = await this.transport(`${proverUri}/prove/encrypted`, {
-                    method: "POST",
-                    body: JSON.stringify(payload),
-                    headers: {
-                        ...headers,
-                        ...(cookie ? { Cookie: cookie } : {})
-                    },
-                    credentials: "include",
-                });
-
-                // Properly handle the proving response.
-                return this.handleProvingResponse(res);
+                return sendEncrypted("/prove/encrypted");
             }
 
             // If encrypted usage is not specified use the unencrypted endpoint.

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -423,7 +423,7 @@ class ProgramManager {
             try {
                 resolvedImports = await this.networkClient.getProgramImports(programSource);
             } catch (e) {
-                console.warn(`Failed to resolve program imports from network: ${e}.`);
+                logger.warn(`Failed to resolve program imports from network: ${e}.`);
             }
         }
 
@@ -480,7 +480,7 @@ class ProgramManager {
                     }
                 }
             } catch (e) {
-                console.warn(`Failed to resolve transitive imports for ${name}: ${e}`);
+                logger.warn(`Failed to resolve transitive imports for ${name}: ${e}`);
             }
         }
 
@@ -522,7 +522,7 @@ class ProgramManager {
                         }
                     }
                 } catch (e) {
-                    console.warn(`Failed to trace call graph for ${name}: ${e}`);
+                    logger.warn(`Failed to trace call graph for ${name}: ${e}`);
                 }
             }
         }
@@ -540,7 +540,7 @@ class ProgramManager {
             try {
                 builder.addProgram(name, source, importEdition);
             } catch (e) {
-                console.warn(`Failed to add import ${name} to builder: ${e}`);
+                logger.warn(`Failed to add import ${name} to builder: ${e}`);
                 continue;
             }
 
@@ -600,7 +600,7 @@ class ProgramManager {
             const info = await this.networkClient.getProgramAmendmentCount(programName);
             return { edition: info.edition, amendment: info.amendment_count };
         } catch (e: any) {
-            console.warn(`Error finding edition/amendment for ${programName}. Network response: '${e.message}'. Defaulting to edition ${fallbackEdition ?? 1}, amendment 0.`);
+            logger.warn(`Error finding edition/amendment for ${programName}. Network response: '${e.message}'. Defaulting to edition ${fallbackEdition ?? 1}, amendment 0.`);
             return { edition: fallbackEdition ?? 1, amendment: 0 };
         }
     }
@@ -640,7 +640,7 @@ class ProgramManager {
                 const vk = await keyStore.getVerifyingKey(vkLocator);
                 if (vk) builder.addVerifyingKey(programName, fnName, vk);
             } catch (e) {
-                console.debug(`Failed to load keys for ${programName}/${fnName}: ${e}`);
+                logger.debug(`Failed to load keys for ${programName}/${fnName}: ${e}`);
             }
         }
     }
@@ -678,7 +678,7 @@ class ProgramManager {
             try {
                 fns = Array.from(builder.functionKeysAvailable(programName));
             } catch (e) {
-                console.debug(`Failed to query keys for ${programName}: ${e}`);
+                logger.debug(`Failed to query keys for ${programName}: ${e}`);
                 continue;
             }
 
@@ -698,7 +698,7 @@ class ProgramManager {
                         await keyStore.setKeys(pkLocator, vkLocator, [pk, vk]);
                     }
                 } catch (e) {
-                    console.debug(`Failed to persist key for ${programName}/${fnName}: ${e}`);
+                    logger.debug(`Failed to persist key for ${programName}/${fnName}: ${e}`);
                 }
             }
         }
@@ -1319,7 +1319,7 @@ class ProgramManager {
             if (keys) {
                 [provingKey, verifyingKey] = keys;
             } else {
-                console.log(
+                logger.log(
                     "Function keys not found in KeyStore or KeyProvider. The function keys will be synthesized",
                 );
             }
@@ -1386,7 +1386,7 @@ class ProgramManager {
         try {
             await this.persistExtractedKeys(programImportsBuilder, importEditions);
         } catch (e) {
-            console.debug(`Failed to persist extracted keys: ${e}`);
+            logger.debug(`Failed to persist extracted keys: ${e}`);
         }
 
         return result;
@@ -1522,7 +1522,7 @@ class ProgramManager {
             if (keys) {
                 [provingKey, verifyingKey] = keys;
             } else {
-                console.log(
+                logger.log(
                     "Function keys not found in KeyStore or KeyProvider. The function keys will be synthesized",
                 );
             }
@@ -1557,7 +1557,7 @@ class ProgramManager {
         try {
             await this.persistExtractedKeys(programImportsBuilder, importEditions);
         } catch (e) {
-            console.debug(`Failed to persist extracted keys: ${e}`);
+            logger.debug(`Failed to persist extracted keys: ${e}`);
         }
 
         return result;
@@ -2200,7 +2200,7 @@ class ProgramManager {
             if (keys) {
                 [provingKey, verifyingKey] = keys;
             } else {
-                console.log(
+                logger.log(
                     "Function keys not found in KeyStore or KeyProvider. The function keys will be synthesized",
                 );
             }
@@ -2238,7 +2238,7 @@ class ProgramManager {
         try {
             await this.persistExtractedKeys(builder, importEditions);
         } catch (e) {
-            console.debug(`Failed to persist extracted keys: ${e}`);
+            logger.debug(`Failed to persist extracted keys: ${e}`);
         }
 
         return result;

--- a/sdk/src/record-scanner.ts
+++ b/sdk/src/record-scanner.ts
@@ -365,6 +365,20 @@ class RecordScanner implements RecordProvider {
     }
 
     /**
+     * Registers the account with the record scanning service using the encrypted flow.
+     * Alias of {@link registerEncrypted} — preserved so existing callers using the
+     * previous unencrypted `register(viewKey, startBlock)` API continue to work
+     * unchanged while transparently using the encrypted endpoint.
+     *
+     * @param {ViewKey} viewKey The view key to register.
+     * @param {number} startBlock The block height to start scanning from.
+     * @returns {Promise<RegisterResult>} `{ ok: true, data }` on success, or `{ ok: false, status, error }` on failure.
+     */
+    async register(viewKey: ViewKey, startBlock: number): Promise<RegisterResult> {
+        return this.registerEncrypted(viewKey, startBlock);
+    }
+
+    /**
      * Registers the account with the record scanning service using the encrypted flow: 1. fetches an ephemeral public key from /pubkey - 2. encrypts the registration request (view key + start block) - 3. POSTs to /register/encrypted. Does not HTTP error on a proper error response from the record scanner; returns a result object instead.
      *
      * @param {ViewKey} viewKey The view key to register.

--- a/sdk/tests/indexeddb-keystore.test.ts
+++ b/sdk/tests/indexeddb-keystore.test.ts
@@ -63,6 +63,47 @@ describe("IndexedDBKeyStore", () => {
                 if (had) g.indexedDB = prior;
             }
         });
+
+        it("does not poison the cache: retries env check after indexedDB becomes defined", async () => {
+            const g = globalThis as any;
+            const had = "indexedDB" in g;
+            const prior = g.indexedDB;
+            if (had) delete g.indexedDB;
+            try {
+                const store = new IndexedDBKeyStore("late-polyfill-test");
+
+                // First call: indexedDB undefined → should reject.
+                let err1: Error | undefined;
+                try {
+                    await store.has(locator());
+                } catch (e) { err1 = e as Error; }
+                expect(err1, "first call should reject").to.exist;
+                expect(err1!.message).to.match(/indexedDB/i);
+
+                // Simulate a polyfill loading after the first failed call.
+                let openCallCount = 0;
+                g.indexedDB = {
+                    open(_name: string, _version: number) {
+                        openCallCount += 1;
+                        const req: any = { onerror: null, onsuccess: null, onupgradeneeded: null, onblocked: null };
+                        setTimeout(() => req.onblocked && req.onblocked(), 0);
+                        return req;
+                    },
+                };
+
+                // Second call: indexedDB now defined → should reach indexedDB.open
+                // rather than re-using the cached rejection.
+                try {
+                    await store.has(locator());
+                } catch {
+                    // expected — blocked stub fires AbortError
+                }
+                expect(openCallCount, "openDB should retry after env check now passes").to.equal(1);
+            } finally {
+                if (had) g.indexedDB = prior;
+                else delete g.indexedDB;
+            }
+        });
     });
 
     describe("locator validation (pre-IndexedDB)", () => {

--- a/sdk/tests/indexeddb-keystore.test.ts
+++ b/sdk/tests/indexeddb-keystore.test.ts
@@ -1,0 +1,209 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import {
+    IndexedDBKeyStore,
+    InvalidLocatorError,
+    ProvingKeyLocator,
+} from "../src/node.js";
+
+// Helper: build a minimal valid ProvingKeyLocator, allowing field overrides.
+function locator(overrides: Partial<ProvingKeyLocator> = {}): ProvingKeyLocator {
+    return {
+        program: "credits.aleo",
+        functionName: "transfer_private",
+        edition: 1,
+        amendment: 0,
+        network: "mainnet",
+        keyType: "prover",
+        ...overrides,
+    };
+}
+
+// Helper: install / uninstall a stub `indexedDB` on globalThis.
+function withIndexedDBStub(stub: any, fn: () => Promise<void>): Promise<void> {
+    const g = globalThis as any;
+    const had = "indexedDB" in g;
+    const prior = g.indexedDB;
+    g.indexedDB = stub;
+    return fn().finally(() => {
+        if (had) g.indexedDB = prior;
+        else delete g.indexedDB;
+    });
+}
+
+describe("IndexedDBKeyStore", () => {
+    afterEach(() => {
+        sinon.restore();
+        // Defensive cleanup in case a test threw before its finally.
+        const g = globalThis as any;
+        if (g.__indexedDBStubInstalled) {
+            delete g.indexedDB;
+            delete g.__indexedDBStubInstalled;
+        }
+    });
+
+    describe("environment guard", () => {
+        it("rejects with a clear error when indexedDB is undefined", async () => {
+            const g = globalThis as any;
+            const had = "indexedDB" in g;
+            const prior = g.indexedDB;
+            if (had) delete g.indexedDB;
+            try {
+                const store = new IndexedDBKeyStore("smoke-test");
+                let err: Error | undefined;
+                try {
+                    await store.getKeyBytes(locator());
+                } catch (e) {
+                    err = e as Error;
+                }
+                expect(err, "expected getKeyBytes to reject").to.exist;
+                expect(err!.message).to.match(/indexedDB/i);
+                expect(err!.message).to.match(/browser|Web Worker|SSR|Node/i);
+            } finally {
+                if (had) g.indexedDB = prior;
+            }
+        });
+    });
+
+    describe("locator validation (pre-IndexedDB)", () => {
+        // These tests don't need a real IndexedDB — validation throws before openDB.
+        let store: IndexedDBKeyStore;
+        beforeEach(() => {
+            store = new IndexedDBKeyStore("locator-test");
+        });
+
+        it("rejects empty program component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ program: "" }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("reserved_name");
+        });
+
+        it("rejects \".\" component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ functionName: "." }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("reserved_name");
+        });
+
+        it("rejects path-traversal component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ program: "../etc" }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("path_traversal");
+        });
+
+        it("rejects path separators in component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ functionName: "a/b" }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("path_separator");
+        });
+
+        it("rejects null byte in component", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ network: "main\0net" }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("path_separator");
+        });
+
+        it("rejects negative edition", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ edition: -1 }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("negative_value");
+        });
+
+        it("rejects non-integer amendment", async () => {
+            let err: any;
+            try {
+                await store.has(locator({ amendment: 0.5 }));
+            } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(InvalidLocatorError);
+            expect(err.reason).to.equal("negative_value");
+        });
+    });
+
+    describe("openDB error recovery", () => {
+        // Verifies the cached dbPromise is cleared on error/blocked so a subsequent
+        // call gets a fresh attempt rather than being permanently poisoned.
+        it("retries open after an initial error", async () => {
+            let callCount = 0;
+            const stub = {
+                open(_name: string, _version: number) {
+                    callCount += 1;
+                    const req: any = { onerror: null, onsuccess: null, onupgradeneeded: null, onblocked: null };
+                    // First call errors; subsequent calls succeed with a dummy DB.
+                    setTimeout(() => {
+                        if (callCount === 1) {
+                            req.error = new Error("simulated open error");
+                            req.onerror && req.onerror();
+                        } else {
+                            req.result = { transaction: () => { throw new Error("not used in this test"); } };
+                            req.onsuccess && req.onsuccess();
+                        }
+                    }, 0);
+                    return req;
+                },
+            };
+
+            await withIndexedDBStub(stub, async () => {
+                const store = new IndexedDBKeyStore("retry-test");
+
+                // First call should reject.
+                let err1: Error | undefined;
+                try {
+                    await store.has(locator());
+                } catch (e) {
+                    err1 = e as Error;
+                }
+                expect(err1, "first call should reject").to.exist;
+                expect(err1!.message).to.match(/simulated open error/);
+                expect(callCount).to.equal(1);
+
+                // Second call should reach indexedDB.open again (cache cleared).
+                // We expect a different error here (txn stub throws), but the key
+                // assertion is that callCount increments — proving the promise
+                // wasn't poisoned.
+                try {
+                    await store.has(locator());
+                } catch {
+                    // expected — txn stub is intentionally minimal
+                }
+                expect(callCount, "openDB should retry after error").to.equal(2);
+            });
+        });
+
+        it("rejects with AbortError when open is blocked", async () => {
+            const stub = {
+                open(_name: string, _version: number) {
+                    const req: any = { onerror: null, onsuccess: null, onupgradeneeded: null, onblocked: null };
+                    setTimeout(() => req.onblocked && req.onblocked(), 0);
+                    return req;
+                },
+            };
+
+            await withIndexedDBStub(stub, async () => {
+                const store = new IndexedDBKeyStore("blocked-test");
+                let err: any;
+                try {
+                    await store.has(locator());
+                } catch (e) { err = e; }
+                expect(err).to.exist;
+                expect(err.name).to.equal("AbortError");
+            });
+        });
+    });
+});

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -1,5 +1,7 @@
 import sinon from "sinon";
 import { expect } from "chai";
+import { cryptoBoxKeyPair } from "@serenity-kit/noble-sodium";
+import { base64 } from "@scure/base";
 import {
     Account,
     BlockJSON,
@@ -16,6 +18,9 @@ import {
     PlaintextObject,
     Transition,
     TransitionObject,
+    ExecutionRequest,
+    PrivateKey,
+    ProvingRequest,
 } from "@provablehq/sdk/%%NETWORK%%.js";
 import { beaconPrivateKeyString } from "./data/account-data.js";
 import { retryWithBackoff } from "../src/utils/utils.js";
@@ -813,5 +818,98 @@ describe("AleoNetworkClient JWT refresh URL", () => {
             const firstCallUrl = fetchStub.firstCall.args[0]?.toString() ?? fetchStub.firstCall.args[0]?.url;
             expect(firstCallUrl).to.equal(`${expectedOrigin}/jwts/test-consumer-id`);
         });
+    });
+});
+
+describe("submitProvingRequestSafe variant routing", () => {
+    let fetchStub: sinon.SinonStub;
+
+    // Construct a single-public-Request-variant ProvingRequest for routing
+    // tests. The signed Request payload itself is not validated by the test —
+    // we only assert which endpoint the SDK hits.
+    function buildRequestVariant(): ProvingRequest {
+        const privateKey = PrivateKey.from_string(beaconPrivateKeyString);
+        const inputs = ["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px", "100u64"];
+        const inputTypes = ["address.public", "u64.public"];
+        const executionRequest = ExecutionRequest.sign(
+            privateKey,
+            "credits.aleo",
+            "transfer_public",
+            inputs,
+            inputTypes,
+            undefined,
+            undefined,
+            true,
+            false,
+        );
+        return ProvingRequest.fromRequest(executionRequest, undefined, false);
+    }
+
+    beforeEach(() => {
+        fetchStub = sinon.stub(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    // Build a stub /pubkey response containing a real ephemeral X25519 public
+    // key so `encryptProvingRequest` (which wraps `@serenity-kit/noble-sodium`'s
+    // `cryptoBoxSeal` — the same primitive `security.ts` uses) succeeds and
+    // the SDK actually reaches the prove POST. The test only asserts which
+    // URL is hit, not the ciphertext.
+    function pubKeyResponseBody(): string {
+        const { publicKey } = cryptoBoxKeyPair();
+        return JSON.stringify({ key_id: "test-key", public_key: base64.encode(publicKey) });
+    }
+
+    it("Request variant routes to /prove/request (encrypted-only) regardless of dpsPrivacy", async () => {
+        const client = new AleoNetworkClient("https://prover.example.com");
+
+        // First call is /pubkey (returns ephemeral key); second is the prove POST.
+        fetchStub.onFirstCall().resolves(new Response(
+            pubKeyResponseBody(),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+        fetchStub.onSecondCall().resolves(new Response(
+            JSON.stringify({ transaction: "stub", broadcast: null }),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+
+        const provingRequest = buildRequestVariant();
+        // dpsPrivacy explicitly false to verify it's ignored for Request variant.
+        await client.submitProvingRequestSafe({ provingRequest, dpsPrivacy: false });
+
+        const pubkeyCall = fetchStub.getCall(0).args[0]?.toString() ?? fetchStub.getCall(0).args[0]?.url;
+        const proveCall = fetchStub.getCall(1).args[0]?.toString() ?? fetchStub.getCall(1).args[0]?.url;
+        expect(pubkeyCall).to.equal("https://prover.example.com/testnet/pubkey");
+        expect(proveCall).to.equal("https://prover.example.com/testnet/prove/request");
+    });
+
+    it("Request variant routing takes precedence over dpsPrivacy=true", async () => {
+        const client = new AleoNetworkClient("https://prover.example.com");
+
+        fetchStub.onFirstCall().resolves(new Response(
+            pubKeyResponseBody(),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+        fetchStub.onSecondCall().resolves(new Response(
+            JSON.stringify({ transaction: "stub", broadcast: null }),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+
+        const provingRequest = buildRequestVariant();
+        // Even with dpsPrivacy=true (Authorization-variant encrypted path),
+        // a Request-variant ProvingRequest must still hit /prove/request,
+        // since that endpoint is the only one that accepts the Request layout.
+        await client.submitProvingRequestSafe({ provingRequest, dpsPrivacy: true });
+
+        const proveCall = fetchStub.getCall(1).args[0]?.toString() ?? fetchStub.getCall(1).args[0]?.url;
+        expect(proveCall).to.equal("https://prover.example.com/testnet/prove/request");
+    });
+
+    it("ProvingRequest.kind() returns 'request' for Request-variant constructions", () => {
+        const provingRequest = buildRequestVariant();
+        expect(provingRequest.kind()).to.equal("request");
     });
 });

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "12aca1021aef2c476bad30d2f681e891b2be4f07dbc230a96df09cb693bfb3cb"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.10.6"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-wasm"
-version = "0.10.6"
+version = "0.11.0"
 authors = [ "The Provable Team" ]
 description = "WebAssembly based toolkit for developing zero-knowledge applications with Aleo"
 homepage = "https://provable.com"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/wasm",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [

--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -214,7 +214,7 @@ mod tests {
         .await
         .unwrap();
 
-        let authorization = proving_request.authorization();
+        let authorization = proving_request.authorization().unwrap();
         assert_eq!(authorization.len(), 1, "transfer_public should have 1 request");
         assert_eq!(authorization.transitions().length(), 1, "transfer_public should have 1 transition");
         // No fee authorization when built from ExecutionRequest (fee is paid by fee master or handled separately).
@@ -255,7 +255,7 @@ mod tests {
         assert!(request_from_string.equals(&proving_request) && request_from_bytes.equals(&proving_request));
 
         // Get the main authorization from the proving request.
-        let authorization = proving_request.authorization();
+        let authorization = proving_request.authorization().unwrap();
 
         // Assert the number of requests is correct.
         assert_eq!(authorization.len(), 3);
@@ -308,7 +308,7 @@ mod tests {
         );
 
         // Main authorization is still present.
-        let authorization = proving_request.authorization();
+        let authorization = proving_request.authorization().unwrap();
         assert_eq!(authorization.len(), 3);
         assert_eq!(authorization.transitions().length(), 3);
     }

--- a/wasm/src/synthesizer/proving_request.rs
+++ b/wasm/src/synthesizer/proving_request.rs
@@ -15,10 +15,11 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    ExecutionRequest,
     synthesizer::Authorization,
-    types::native::{AuthorizationNative, ProvingRequestNative},
+    types::native::{AuthorizationNative, ProvingRequestNative, RequestNative},
 };
-use snarkvm_wasm::utilities::{FromBytes, ToBytes};
+use snarkvm_wasm::utilities::ToBytes;
 
 use js_sys::Uint8Array;
 use std::{
@@ -29,12 +30,24 @@ use std::{
 use wasm_bindgen::prelude::*;
 
 /// Represents a proving request to a prover.
+///
+/// Carries one of two variants:
+/// - `Authorization` — a fully-constructed snarkVM `Authorization` (plus optional
+///   fee authorization). Submitted to `/prove` or `/prove/encrypted`.
+/// - `Request` — a single signed snarkVM `Request` (plus optional fee `Request`)
+///   that the prover authorizes server-side. Submitted to `/prove/request`
+///   (encrypted-only).
+///
+/// Use {@link ProvingRequest#kind} when handling a `ProvingRequest` of unknown
+/// variant (e.g. after deserialization). Variant-specific accessors throw if
+/// called on the wrong variant.
 #[wasm_bindgen]
 pub struct ProvingRequest(ProvingRequestNative);
 
 #[wasm_bindgen]
 impl ProvingRequest {
-    /// Creates a new ProvingRequest from a function Authorization and an optional fee Authorization.
+    /// Creates a new Authorization-variant `ProvingRequest` from a function
+    /// `Authorization` and an optional fee `Authorization`.
     ///
     /// @param {Authorization} authorization An Authorization for a function.
     /// @param {Authorization} fee_authorization The authorization for the `credits.aleo/fee_public` or `credits.aleo/fee_private` function that pays the fee for the execution of the main function.
@@ -43,47 +56,129 @@ impl ProvingRequest {
         ProvingRequest(ProvingRequestNative::new(authorization, fee_authorization, broadcast))
     }
 
-    /// Creates a ProvingRequest from a string representation.
+    /// Creates a new Request-variant `ProvingRequest` from a single signed
+    /// `ExecutionRequest` and an optional signed fee `ExecutionRequest`.
     ///
-    /// @param {Uint8Array} request String representation of the ProvingRequest.
+    /// The Request variant is processed by the DPS at the `/prove/request`
+    /// endpoint, which is encrypted-only. The server runs
+    /// `Process::authorize_request` to turn each `Request` into an
+    /// `Authorization` before proving.
+    ///
+    /// Only valid for single-public-request executions. Layered / nested
+    /// calls are not supported by `/prove/request` at this time.
+    ///
+    /// @param {ExecutionRequest} request The signed request for the function.
+    /// @param {ExecutionRequest} fee_request Optional signed request for the fee function. When omitted, the prover generates and pays the fee.
+    /// @param {boolean} broadcast Flag that indicates whether the remote proving service should attempt to submit the transaction on the caller's behalf.
+    #[wasm_bindgen(js_name = "fromRequest")]
+    pub fn from_request(
+        request: ExecutionRequest,
+        fee_request: Option<ExecutionRequest>,
+        broadcast: bool,
+    ) -> Self {
+        let request_native: RequestNative = request.into();
+        let fee_request_native: Option<RequestNative> = fee_request.map(Into::into);
+        ProvingRequest(ProvingRequestNative::new_request(request_native, fee_request_native, broadcast))
+    }
+
+    /// Returns the variant of this `ProvingRequest`: `"authorization"` or
+    /// `"request"`. Useful when handling a `ProvingRequest` whose variant
+    /// was determined at deserialization time.
+    pub fn kind(&self) -> String {
+        if self.0.is_request() { "request".to_string() } else { "authorization".to_string() }
+    }
+
+    /// Creates a `ProvingRequest` from a JSON string representation.
+    ///
+    /// The variant is determined automatically by the JSON shape:
+    /// `{ authorization, ... }` → Authorization variant; `{ request, ... }` →
+    /// Request variant. Use {@link ProvingRequest#kind} to inspect the
+    /// resulting variant.
+    ///
+    /// @param {string} request JSON string representation of the ProvingRequest.
     #[wasm_bindgen(js_name = "fromString")]
     pub fn from_string(request: String) -> Result<ProvingRequest, String> {
         Ok(ProvingRequest(ProvingRequestNative::from_str(&request).map_err(|e| e.to_string())?))
     }
 
-    /// Creates a string representation of the ProvingRequest.
+    /// Creates a JSON string representation of the ProvingRequest.
+    /// The shape carries enough information to recover the variant via
+    /// {@link ProvingRequest.fromString}.
     #[wasm_bindgen(js_name = "toString")]
     #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
     }
 
-    /// Creates a ProvingRequest from a left-endian byte representation of the ProvingRequest.
+    /// Reads bytes as an Authorization-variant `ProvingRequest`. For the
+    /// Request variant, use {@link ProvingRequest.fromBytesLeRequest}
+    /// explicitly — byte layout carries no variant discriminator.
     ///
-    /// @param {Uint8Array} bytes Left-endian bytes representing the proving request.
+    /// @param {Uint8Array} bytes Left-endian bytes representing an Authorization-variant proving request.
     #[wasm_bindgen(js_name = "fromBytesLe")]
     pub fn from_bytes_le(bytes: Uint8Array) -> Result<ProvingRequest, String> {
         let rust_bytes = bytes.to_vec();
-        let native = ProvingRequestNative::from_bytes_le(rust_bytes.as_slice()).map_err(|e| e.to_string())?;
+        let native = ProvingRequestNative::read_authorization_le(rust_bytes.as_slice()).map_err(|e| e.to_string())?;
         Ok(ProvingRequest(native))
     }
 
-    /// Creates a left-endian byte representation of the ProvingRequest.
+    /// Reads bytes as a Request-variant `ProvingRequest`. Byte layout is
+    /// disjoint from the Authorization variant; callers must pick the right
+    /// reader for the bytes they hold.
+    ///
+    /// @param {Uint8Array} bytes Left-endian bytes representing a Request-variant proving request.
+    #[wasm_bindgen(js_name = "fromBytesLeRequest")]
+    pub fn from_bytes_le_request(bytes: Uint8Array) -> Result<ProvingRequest, String> {
+        let rust_bytes = bytes.to_vec();
+        let native = ProvingRequestNative::read_request_le(rust_bytes.as_slice()).map_err(|e| e.to_string())?;
+        Ok(ProvingRequest(native))
+    }
+
+    /// Creates a left-endian byte representation of the ProvingRequest,
+    /// dispatching on the variant. The bytes are wire-compatible with the
+    /// matching DPS route (`/prove[/encrypted]` for Authorization,
+    /// `/prove/request` for Request).
     #[wasm_bindgen(js_name = "toBytesLe")]
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
         let bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
         Ok(Uint8Array::from(bytes.as_slice()))
     }
 
-    /// Get the Authorization of the main function in the ProvingRequest.
-    pub fn authorization(&self) -> Authorization {
-        Authorization::from(self.0.authorization())
+    /// Returns the Authorization of the main function in the ProvingRequest.
+    ///
+    /// @throws If this `ProvingRequest` is a Request variant. Check
+    /// {@link ProvingRequest#kind} or use {@link ProvingRequest#request} instead.
+    pub fn authorization(&self) -> Result<Authorization, String> {
+        self.0
+            .authorization()
+            .map(Authorization::from)
+            .ok_or_else(|| "ProvingRequest is a Request variant; call `request()` instead of `authorization()`".to_string())
     }
 
-    /// Get the fee Authorization in the ProvingRequest.
+    /// Returns the fee Authorization in the ProvingRequest, or `undefined`
+    /// when no fee is set or this is a Request variant.
     #[wasm_bindgen(js_name = "feeAuthorization")]
     pub fn fee_authorization(&self) -> Option<Authorization> {
         self.0.fee_authorization().map(Authorization::from)
+    }
+
+    /// Returns the signed `ExecutionRequest` carried by the Request variant.
+    ///
+    /// @throws If this `ProvingRequest` is an Authorization variant. Check
+    /// {@link ProvingRequest#kind} or use {@link ProvingRequest#authorization}
+    /// instead.
+    pub fn request(&self) -> Result<ExecutionRequest, String> {
+        self.0
+            .request()
+            .map(ExecutionRequest::from)
+            .ok_or_else(|| "ProvingRequest is an Authorization variant; call `authorization()` instead of `request()`".to_string())
+    }
+
+    /// Returns the signed fee `ExecutionRequest` in the Request variant, or
+    /// `undefined` when no fee request is set or this is an Authorization variant.
+    #[wasm_bindgen(js_name = "feeRequest")]
+    pub fn fee_request(&self) -> Option<ExecutionRequest> {
+        self.0.fee_request().map(ExecutionRequest::from)
     }
 
     /// Get the broadcast flag set in the ProvingRequest.
@@ -159,12 +254,16 @@ impl Eq for ProvingRequest {}
 mod tests {
     use super::*;
     use crate::{
+        PrivateKey,
+        array,
         types::native::CurrentNetwork,
         utilities::test::{PUZZLE_SPINNER_V002_AUTHORIZATION, PUZZLE_SPINNER_V002_PROVING_REQUEST},
     };
     use snarkvm_wasm::console::network::Network;
 
     use wasm_bindgen_test::*;
+
+    // ---- Authorization variant (legacy) ----------------------------------
 
     #[wasm_bindgen_test]
     fn test_proving_request_serialization_roundtrip() {
@@ -191,9 +290,102 @@ mod tests {
 
             // Ensure the authorizations and broadcast flags match expected values.
             let authorization = Authorization::from_string(PUZZLE_SPINNER_V002_AUTHORIZATION.to_string()).unwrap();
-            assert!(proving_request.authorization().equals(&authorization));
+            assert!(proving_request.authorization().unwrap().equals(&authorization));
             assert!(proving_request.fee_authorization().unwrap().is_fee_public());
             assert_eq!(proving_request.broadcast, false);
+            assert_eq!(proving_request.kind(), "authorization");
+        }
+    }
+
+    // ---- Request variant -------------------------------------------------
+
+    /// Beacon private key — matches the existing wasm-side fixtures.
+    const BEACON_PRIVATE_KEY_STR: &str = "APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH";
+
+    fn sample_execution_request() -> ExecutionRequest {
+        let private_key = PrivateKey::from_string(BEACON_PRIVATE_KEY_STR).unwrap();
+        let inputs = array!["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px".to_string(), "100u64".to_string()];
+        let input_types = array!["address.public".to_string(), "u64.public".to_string()];
+        ExecutionRequest::sign(
+            private_key,
+            "credits.aleo".to_string(),
+            "transfer_public".to_string(),
+            inputs,
+            input_types,
+            None,
+            None,
+            true,
+            false,
+        )
+        .expect("sign should succeed")
+    }
+
+    #[wasm_bindgen_test]
+    fn test_request_variant_construction_and_kind() {
+        let request = sample_execution_request();
+        let proving_request = ProvingRequest::from_request(request, None, false);
+
+        assert_eq!(proving_request.kind(), "request");
+        assert!(proving_request.0.is_request());
+        assert!(!proving_request.0.is_authorization());
+        assert!(proving_request.request().is_ok());
+        assert!(proving_request.fee_request().is_none());
+        assert_eq!(proving_request.broadcast(), false);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_request_variant_byte_roundtrip() {
+        let request = sample_execution_request();
+        let proving_request = ProvingRequest::from_request(request, None, true);
+
+        // Roundtrip via the explicit Request reader. Using `fromBytesLe`
+        // (Authorization reader) on these bytes would fail or produce garbage,
+        // which is the intended behavior — the byte layout carries no
+        // discriminator.
+        let bytes = proving_request.to_bytes_le().expect("toBytesLe should succeed");
+        let roundtripped =
+            ProvingRequest::from_bytes_le_request(bytes).expect("fromBytesLeRequest should succeed");
+
+        assert!(proving_request.equals(&roundtripped));
+        assert_eq!(roundtripped.kind(), "request");
+        assert_eq!(roundtripped.broadcast(), true);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_request_variant_string_roundtrip_autodetects() {
+        let request = sample_execution_request();
+        let proving_request = ProvingRequest::from_request(request, None, false);
+
+        // JSON shape carries the variant — fromString picks the right one via
+        // serde's untagged dispatch on disjoint field names.
+        let s = proving_request.to_string();
+        let roundtripped = ProvingRequest::from_string(s).expect("fromString should succeed");
+
+        assert_eq!(roundtripped.kind(), "request");
+        assert!(proving_request.equals(&roundtripped));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_request_variant_accessors_throw_on_authorization_methods() {
+        let request = sample_execution_request();
+        let proving_request = ProvingRequest::from_request(request, None, false);
+
+        // `authorization()` on a Request variant should be a clear error.
+        let err = proving_request.authorization().expect_err("expected authorization() to error");
+        assert!(err.contains("Request variant"), "error should mention Request variant: {err}");
+
+        // `feeAuthorization()` returns None rather than throwing — matches
+        // the optional return shape callers already expect.
+        assert!(proving_request.fee_authorization().is_none());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_authorization_variant_throws_on_request_accessor() {
+        if CurrentNetwork::ID == 0 {
+            let proving_request = ProvingRequest::from_string(PUZZLE_SPINNER_V002_PROVING_REQUEST.to_string()).unwrap();
+            let err = proving_request.request().expect_err("expected request() to error");
+            assert!(err.contains("Authorization variant"), "error should mention Authorization variant: {err}");
+            assert!(proving_request.fee_request().is_none());
         }
     }
 }

--- a/wasm/src/types/native/request/bytes.rs
+++ b/wasm/src/types/native/request/bytes.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::types::native::{AuthorizationNative, ProvingRequestNative};
+use crate::types::native::{AuthorizationNative, ProvingRequestNative, RequestNative};
 use snarkvm_wasm::utilities::{FromBytes, ToBytes};
 
 use std::{
@@ -23,43 +23,76 @@ use std::{
 };
 
 impl ToBytes for ProvingRequestNative {
+    /// Variant-aware byte serialization matching the DPS layout exactly.
+    /// No discriminator byte is written — the reader must know the variant
+    /// out-of-band (route context on the server; explicit method on clients).
     fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        // Write required authorization.
-        self.authorization.write_le(&mut writer)?;
-
-        // Write the optional fee_authorization.
-        match &self.fee_authorization {
-            Some(auth) => {
-                true.write_le(&mut writer)?; // flag for Some
-                auth.write_le(&mut writer)?;
+        match self {
+            Self::Authorization { authorization, fee_authorization, broadcast } => {
+                authorization.write_le(&mut writer)?;
+                match fee_authorization {
+                    Some(auth) => {
+                        true.write_le(&mut writer)?;
+                        auth.write_le(&mut writer)?;
+                    }
+                    None => {
+                        false.write_le(&mut writer)?;
+                    }
+                }
+                broadcast.write_le(&mut writer)?;
             }
-            None => {
-                false.write_le(&mut writer)?; // flag for None
+            Self::Request { request, fee_request, broadcast } => {
+                request.write_le(&mut writer)?;
+                match fee_request {
+                    Some(req) => {
+                        true.write_le(&mut writer)?;
+                        req.write_le(&mut writer)?;
+                    }
+                    None => {
+                        false.write_le(&mut writer)?;
+                    }
+                }
+                broadcast.write_le(&mut writer)?;
             }
         }
-
-        // Write broadcast flag.
-        self.broadcast.write_le(&mut writer)?;
-
         Ok(())
     }
 }
 
 impl FromBytes for ProvingRequestNative {
-    fn read_le<R: Read>(mut reader: R) -> io::Result<Self> {
-        // Read required authorization.
-        let authorization = AuthorizationNative::read_le(&mut reader)?;
+    /// Reads bytes as the Authorization variant for back-compat — historically
+    /// the only variant that existed. To read the Request variant, callers
+    /// must use [`ProvingRequestNative::read_request_le`] explicitly because
+    /// the byte layout carries no discriminator.
+    fn read_le<R: Read>(reader: R) -> io::Result<Self> {
+        Self::read_authorization_le(reader)
+    }
+}
 
-        // Read the option flag and then the fee_authorization if present.
+impl ProvingRequestNative {
+    /// Reads bytes as the Authorization variant.
+    /// Layout: `authorization | bool | maybe(fee_authorization) | bool(broadcast)`.
+    pub fn read_authorization_le<R: Read>(mut reader: R) -> io::Result<Self> {
+        let authorization = AuthorizationNative::read_le(&mut reader)?;
         let has_fee_auth = bool::read_le(&mut reader)?;
         let fee_authorization = match has_fee_auth {
             false => None,
             true => Some(AuthorizationNative::read_le(&mut reader)?),
         };
-
-        // Read broadcast flag.
         let broadcast = bool::read_le(&mut reader)?;
+        Ok(Self::Authorization { authorization, fee_authorization, broadcast })
+    }
 
-        Ok(Self { authorization, fee_authorization, broadcast })
+    /// Reads bytes as the Request variant.
+    /// Layout: `request | bool | maybe(fee_request) | bool(broadcast)`.
+    pub fn read_request_le<R: Read>(mut reader: R) -> io::Result<Self> {
+        let request = RequestNative::read_le(&mut reader)?;
+        let has_fee_request = bool::read_le(&mut reader)?;
+        let fee_request = match has_fee_request {
+            false => None,
+            true => Some(RequestNative::read_le(&mut reader)?),
+        };
+        let broadcast = bool::read_le(&mut reader)?;
+        Ok(Self::Request { request, fee_request, broadcast })
     }
 }

--- a/wasm/src/types/native/request/mod.rs
+++ b/wasm/src/types/native/request/mod.rs
@@ -21,48 +21,112 @@ use super::*;
 
 use serde::{Deserialize, Serialize};
 
+/// A proving request submitted to the Delegated Proving Service.
+///
+/// Mirrors the variant layout used by the DPS in `utils::types::ProvingRequest`:
+/// `Authorization` carries a fully-constructed `Authorization` (and optional fee
+/// `Authorization`); `Request` carries a single signed `Request` (and optional
+/// fee `Request`) that the server turns into an `Authorization` via
+/// `Process::authorize_request`. JSON is serialized untagged — the field shape
+/// (`authorization`/`fee_authorization` vs. `request`/`fee_request`) determines
+/// the variant. Bytes carry no discriminator; the reader must know the variant
+/// out-of-band (see `bytes.rs`).
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ProvingRequestNative {
-    pub authorization: AuthorizationNative,
-    pub fee_authorization: Option<AuthorizationNative>,
-    pub broadcast: bool,
+#[serde(untagged)]
+pub enum ProvingRequestNative {
+    Authorization {
+        authorization: AuthorizationNative,
+        fee_authorization: Option<AuthorizationNative>,
+        broadcast: bool,
+    },
+    Request {
+        request: RequestNative,
+        fee_request: Option<RequestNative>,
+        broadcast: bool,
+    },
 }
 
 impl ProvingRequestNative {
-    /// Creates a new `ProvingRequestNative` from the given authorization and fee authorization.
+    /// Creates a new Authorization-variant `ProvingRequestNative` from the
+    /// given authorization and optional fee authorization.
     pub fn new(
         authorization: crate::Authorization,
         fee_authorization: Option<crate::Authorization>,
         broadcast: bool,
     ) -> Self {
-        Self {
+        Self::Authorization {
             authorization: AuthorizationNative::from(authorization),
             fee_authorization: fee_authorization.map(AuthorizationNative::from),
             broadcast,
         }
     }
 
-    /// Creates a new `ProvingRequest` from native authorization types.
+    /// Creates a new Authorization-variant `ProvingRequestNative` from native
+    /// `AuthorizationNative` values.
     pub fn new_from_native(
         authorization: AuthorizationNative,
         fee_authorization: Option<AuthorizationNative>,
         broadcast: bool,
     ) -> Self {
-        Self { authorization, fee_authorization, broadcast }
+        Self::Authorization { authorization, fee_authorization, broadcast }
     }
 
-    /// Gets the authorization of the function the `signer` is attempting to call.
-    pub fn authorization(&self) -> &AuthorizationNative {
-        &self.authorization
+    /// Creates a new Request-variant `ProvingRequestNative` from a single
+    /// signed `Request` and optional fee `Request`.
+    pub fn new_request(request: RequestNative, fee_request: Option<RequestNative>, broadcast: bool) -> Self {
+        Self::Request { request, fee_request, broadcast }
     }
 
-    /// Gets the fee authorization of the proving request.
+    /// Returns the Authorization variant's inner authorization, or `None` if
+    /// this is a Request variant.
+    pub fn authorization(&self) -> Option<&AuthorizationNative> {
+        match self {
+            Self::Authorization { authorization, .. } => Some(authorization),
+            Self::Request { .. } => None,
+        }
+    }
+
+    /// Returns the Authorization variant's fee authorization, or `None` if this
+    /// is a Request variant or no fee authorization is set.
     pub fn fee_authorization(&self) -> Option<&AuthorizationNative> {
-        self.fee_authorization.as_ref()
+        match self {
+            Self::Authorization { fee_authorization, .. } => fee_authorization.as_ref(),
+            Self::Request { .. } => None,
+        }
     }
 
-    /// Returns the broadcast flag.
+    /// Returns the Request variant's inner request, or `None` if this is an
+    /// Authorization variant.
+    pub fn request(&self) -> Option<&RequestNative> {
+        match self {
+            Self::Request { request, .. } => Some(request),
+            Self::Authorization { .. } => None,
+        }
+    }
+
+    /// Returns the Request variant's fee request, or `None` if this is an
+    /// Authorization variant or no fee request is set.
+    pub fn fee_request(&self) -> Option<&RequestNative> {
+        match self {
+            Self::Request { fee_request, .. } => fee_request.as_ref(),
+            Self::Authorization { .. } => None,
+        }
+    }
+
+    /// Returns the broadcast flag regardless of variant.
     pub fn broadcast(&self) -> bool {
-        self.broadcast
+        match self {
+            Self::Authorization { broadcast, .. } | Self::Request { broadcast, .. } => *broadcast,
+        }
+    }
+
+    /// Returns `true` if this is the Authorization variant.
+    pub fn is_authorization(&self) -> bool {
+        matches!(self, Self::Authorization { .. })
+    }
+
+    /// Returns `true` if this is the Request variant.
+    pub fn is_request(&self) -> bool {
+        matches!(self, Self::Request { .. })
     }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
         "@codemirror/language": "^6.10.8",
         "@codemirror/legacy-modes": "^6.4.2",
         "@codemirror/stream-parser": "^0.19.9",
-        "@provablehq/sdk": "^0.10.6",
+        "@provablehq/sdk": "^0.11.0",
         "@uiw/codemirror-theme-noctis-lilac": "^4.23.7",
         "@uiw/codemirror-theme-okaidia": "^4.23.7",
         "@uiw/react-codemirror": "^4.23.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2872,12 +2872,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@provablehq/sdk@npm:^0.10.0, @provablehq/sdk@npm:^0.10.6, @provablehq/sdk@workspace:sdk":
+"@provablehq/sdk@npm:^0.10.0":
+  version: 0.10.5
+  resolution: "@provablehq/sdk@npm:0.10.5"
+  dependencies:
+    "@provablehq/wasm": "npm:^0.10.5"
+    "@scure/base": "npm:^2.0.0"
+    "@serenity-kit/noble-sodium": "npm:0.2.3"
+    comlink: "npm:^4.4.2"
+    core-js: "npm:^3.40.0"
+    mime: "npm:^4.0.6"
+    xmlhttprequest-ssl: "npm:^4.0.0"
+  checksum: 10c0/1b72f0650ba4e571616527bd47eaf2a886db8a12a2d87e8d656e5d5dcf58b10e60d0ab6c1efa1b5b03cf952f60b6483ed1a6b383a0478906eb63eea753181d77
+  languageName: node
+  linkType: hard
+
+"@provablehq/sdk@npm:^0.11.0, @provablehq/sdk@workspace:sdk":
   version: 0.0.0-use.local
   resolution: "@provablehq/sdk@workspace:sdk"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.18.2"
-    "@provablehq/wasm": "npm:^0.10.6"
+    "@provablehq/wasm": "npm:^0.11.0"
     "@rollup/plugin-replace": "npm:^6.0.2"
     "@scure/base": "npm:^2.0.0"
     "@serenity-kit/noble-sodium": "npm:0.2.3"
@@ -2911,7 +2926,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@provablehq/wasm@npm:^0.10.6, @provablehq/wasm@workspace:wasm":
+"@provablehq/wasm@npm:^0.10.5":
+  version: 0.10.5
+  resolution: "@provablehq/wasm@npm:0.10.5"
+  checksum: 10c0/97e4c3e28a1cfcb76af9d35f6d48e44650cf43bc70e683011067515e65b707f16c53bdba476b24604b19f5f962819b6d128870c74e603d06ee86bcf53c58acaf
+  languageName: node
+  linkType: hard
+
+"@provablehq/wasm@npm:^0.11.0, @provablehq/wasm@workspace:wasm":
   version: 0.0.0-use.local
   resolution: "@provablehq/wasm@workspace:wasm"
   dependencies:
@@ -4630,7 +4652,7 @@ __metadata:
     "@babel/core": "npm:^7.26.7"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4663,7 +4685,7 @@ __metadata:
     "@babel/core": "npm:^7.26.7"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4695,7 +4717,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -4729,7 +4751,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aleo-starter@workspace:create-leo-app/template-vanilla"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     tslib: "npm:^2.8.1"
     vite: "npm:^6.4.2"
   languageName: unknown
@@ -4747,7 +4769,7 @@ __metadata:
     "@codemirror/language": "npm:^6.10.8"
     "@codemirror/legacy-modes": "npm:^6.4.2"
     "@codemirror/stream-parser": "npm:^0.19.9"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@uiw/codemirror-theme-noctis-lilac": "npm:^4.23.7"
@@ -6574,7 +6596,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "devnode-starter@workspace:create-leo-app/template-devnode-js"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -6752,7 +6774,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-dynamic@workspace:e2e/dynamic"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -6760,7 +6782,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-mainnet@workspace:e2e/mainnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -6768,7 +6790,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-testnet@workspace:e2e/testnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -7509,7 +7531,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "extension-starter@workspace:create-leo-app/template-extension"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@rollup/plugin-node-resolve": "npm:^16.0.0"
     "@web/rollup-plugin-import-meta-assets": "npm:^2.2.1"
     rimraf: "npm:^6.0.1"
@@ -10167,7 +10189,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-build-and-execute-authorization-ts-starter@workspace:create-leo-app/template-build-and-execute-authorization-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10238,7 +10260,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-offline-transaction-example@workspace:create-leo-app/template-offline-public-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10257,7 +10279,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-starter@workspace:create-leo-app/template-node"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
   languageName: unknown
   linkType: soft
 
@@ -10265,7 +10287,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-starter@workspace:create-leo-app/template-node-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10277,7 +10299,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-transfer-private-starter@workspace:create-leo-app/template-private-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10289,7 +10311,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nodenext@workspace:e2e/nodenext"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
@@ -13653,7 +13675,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-nextjs@workspace:create-leo-app/template-nextjs-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
@@ -13669,7 +13691,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-credits-aleo-functions-ts@workspace:create-leo-app/template-node-credits-aleo-functions-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13681,7 +13703,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-dynamic-dispatch-proving-ts@workspace:create-leo-app/template-node-dynamic-dispatch-proving-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13705,7 +13727,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-loyalty-program-ts@workspace:create-leo-app/template-node-loyalty-program-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     dotenv: "npm:^16.4.5"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
@@ -13722,7 +13744,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -13760,7 +13782,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.10.6"
+    "@provablehq/sdk": "npm:^0.11.0"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"


### PR DESCRIPTION
## Motivation

The delegated proving endpoints now support sending signed SnarkVM `Request` objects for proving. This PR provides the SDK functionality for using them.

## Test Plan

- This PR adds several tests of the new functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegated proving routing and ProvingRequest wire/API semantics (breaking for callers expecting `authorization()` to always succeed); risk is mitigated by tests but affects prover integration and deserialization.
> 
> **Overview**
> Releases **0.11.0** for `@provablehq/sdk`, `@provablehq/wasm`, and `create-leo-app`, and bumps those dependencies across templates, e2e, and the website.
> 
> **Delegated proving (Request variant):** WASM/SDK `ProvingRequest` now supports two shapes—existing **Authorization** payloads and a new **Request** variant built from signed `ExecutionRequest` via `ProvingRequest.fromRequest`, with `kind()` and variant-specific accessors. Byte/JSON handling is split so Request bytes use `fromBytesLeRequest` / `read_request_le`; `authorization()` is now fallible on the wrong variant. `AleoNetworkClient.submitProvingRequestSafe` routes Request variants to encrypted **`/prove/request`** (always, ignoring `dpsPrivacy`), shares a `sendEncrypted` helper with the Authorization **`/prove/encrypted`** path, and only inspects `kind()` for real `ProvingRequest` objects so string payloads keep prior JWT-first behavior.
> 
> **Other SDK changes:** `RecordScanner.register` delegates to `registerEncrypted`; `ProgramManager` warnings/logs use `logger` instead of `console`; `IndexedDBKeyStore` documents browser-only/plaintext risks, rejects missing `indexedDB` without poisoning the open cache, and adds tests for env guard, locators, and open retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f282d85429bae82382bb1c42403033c01001766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->