### PR TITLE
[Feature] Support for sending signed requests to DPS

### DIFF
--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1869,6 +1869,14 @@ class AleoNetworkClient {
             ? options.provingRequest.toString()
             : options.provingRequest;
 
+        // Determine the variant for endpoint routing. Only inspect `kind()`
+        // when the caller passed a `ProvingRequest` object — string inputs
+        // are deferred to the encrypted path's parse (preserves prior
+        // behavior for callers that pass opaque strings like JWT-refresh
+        // unit tests, which rely on the JWT fetch firing first).
+        const isRequestVariant = options.provingRequest instanceof ProvingRequest
+            && options.provingRequest.kind() === "request";
+
         // Try to get JWT data to access the Provable API.
         const apiKey = options.apiKey ?? this.apiKey;
         const consumerId = options.consumerId ?? this.consumerId;
@@ -1896,47 +1904,63 @@ class AleoNetworkClient {
             headers["Authorization"] = jwtData.jwt;
         }
 
+        // Send the proving request encrypted (libsodium sealed box). Used by
+        // both the /prove/encrypted (Authorization variant, opt-in) and
+        // /prove/request (Request variant, mandatory) paths.
+        const sendEncrypted = async (endpoint: string): Promise<ProvingResult> => {
+            // Get an ephemeral public key from the DPS.
+            const pubKeyResponse = await get(proverUri + "/pubkey", {
+                headers,
+                credentials: "include",
+            }, this.transport);
+
+            // Encrypt the provingRequest. Parse lazily — only the encrypted
+            // paths need a real `ProvingRequest` object; the plaintext path
+            // forwards the string verbatim.
+            const pubkey: CryptoBoxPubKey = parseJSON(
+                await pubKeyResponse.text(),
+            );
+            const provingRequestObj = options.provingRequest instanceof ProvingRequest
+                ? options.provingRequest
+                : ProvingRequest.fromString(provingRequestString);
+            const ciphertext = encryptProvingRequest(
+                pubkey.public_key,
+                provingRequestObj,
+            );
+
+            const payload: EncryptedProvingRequest = {
+                key_id: pubkey.key_id,
+                ciphertext: ciphertext,
+            };
+
+            // We're in node, attempt to set the cookie manually.
+            const cookie = isNode() ? pubKeyResponse.headers.get("set-cookie"): undefined;
+
+            const res = await this.transport(`${proverUri}${endpoint}`, {
+                method: "POST",
+                body: JSON.stringify(payload),
+                headers: {
+                    ...headers,
+                    ...(cookie ? { Cookie: cookie } : {})
+                },
+                credentials: "include",
+            });
+
+            return this.handleProvingResponse(res);
+        };
+
         // Encapsulate the requests in a locally scoped function that can be run with a retry closure.
         const runRequest = async (): Promise<ProvingResult> => {
-            // If DPS privacy is set, call invoke the encrypted flow.
+            // Request variant is encrypted-only and always routes to /prove/request.
+            // The DPS reads bytes via `read_request_le` on this route; `dpsPrivacy`
+            // is implicit because the route doesn't accept plaintext.
+            if (isRequestVariant) {
+                return sendEncrypted("/prove/request");
+            }
+
+            // Authorization variant: opt-in encrypted via /prove/encrypted.
             if (options.dpsPrivacy) {
-                // Get an ephemeral public key from a DPS service.
-                const pubKeyResponse = await get(proverUri + "/pubkey", {
-                    headers,
-                    credentials: "include",
-                }, this.transport);
-
-                // Encrypt the provingRequest.
-                const pubkey: CryptoBoxPubKey = parseJSON(
-                    await pubKeyResponse.text(),
-                );
-                const ciphertext = encryptProvingRequest(
-                    pubkey.public_key,
-                    ProvingRequest.fromString(provingRequestString),
-                );
-
-                // Form the expected query a DPS service expects (including the key_id).
-                const payload: EncryptedProvingRequest = {
-                    key_id: pubkey.key_id,
-                    ciphertext: ciphertext,
-                };
-
-                // We're in node, attempt to set the cookie manually.
-                const cookie = isNode() ? pubKeyResponse.headers.get("set-cookie"): undefined;
-
-                // Send the encrypted proving request to the DPS service.
-                const res = await this.transport(`${proverUri}/prove/encrypted`, {
-                    method: "POST",
-                    body: JSON.stringify(payload),
-                    headers: {
-                        ...headers,
-                        ...(cookie ? { Cookie: cookie } : {})
-                    },
-                    credentials: "include",
-                });
-
-                // Properly handle the proving response.
-                return this.handleProvingResponse(res);
+                return sendEncrypted("/prove/encrypted");
             }
 
             // If encrypted usage is not specified use the unencrypted endpoint.

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1870,23 +1870,13 @@ class AleoNetworkClient {
         // Attempt to get the Prover URI first from the options, then from any configured globally, or third try the main configured host.
         const proverUri = (options.url ?? this.proverUri) ?? this.host;
 
-        // Parse the proving request once, up front, so the variant the SDK
-        // routes on matches the bytes it will eventually send. Doing this
-        // lazily inside the encrypted path would let a Request-variant
-        // passed as a string be sent to `/prove/authorization` (the bytes
-        // are the Request layout — server-side `read_authorization_le`
-        // would reject them).
-        const provingRequestObj = options.provingRequest instanceof ProvingRequest
-            ? options.provingRequest
-            : ProvingRequest.fromString(options.provingRequest);
-        const isRequestVariant = provingRequestObj.kind() === "request";
-
         // Try to get JWT data to access the Provable API.
         const apiKey = options.apiKey ?? this.apiKey;
         const consumerId = options.consumerId ?? this.consumerId;
         let jwtData = options.jwtData ?? this.jwtData;
 
-        // Check to see if the JWT needs refreshing.
+        // Check to see if the JWT needs refreshing. Runs before parsing the
+        // proving request so JWT refresh errors propagate as they always have.
         const isExpired = jwtData && Date.now() >= jwtData.expiration - FIVE_MINUTES;
         if (!jwtData || isExpired) {
             if (apiKey && consumerId) {
@@ -1912,7 +1902,7 @@ class AleoNetworkClient {
         // Used by both `/prove/authorization` (Authorization variant) and
         // `/prove/request` (Request variant). The legacy plaintext `/prove`
         // route is no longer used.
-        const sendEncrypted = async (endpoint: string): Promise<ProvingResult> => {
+        const sendEncrypted = async (endpoint: string, provingRequestObj: ProvingRequest): Promise<ProvingResult> => {
             // Get an ephemeral public key from the DPS.
             const pubKeyResponse = await get(proverUri + "/pubkey", {
                 headers,
@@ -1949,13 +1939,25 @@ class AleoNetworkClient {
             return this.handleProvingResponse(res);
         };
 
-        // The legacy plaintext `/prove` route is deprecated and no longer dispatched
-        // to; every proving request is encrypted. `options.dpsPrivacy` is ignored.
-        const endpoint = isRequestVariant ? "/prove/request" : "/prove/authorization";
+        // Parse the proving request once, up front, so the variant the SDK
+        // routes on matches the bytes it will eventually send (a Request-
+        // variant string must hit /prove/request, not /prove/authorization).
+        // A malformed input string throws synchronously — the safe-API
+        // contract only promises to return `{ ok: false, ... }` for HTTP
+        // failures (400/500/503); a parse error is a caller-side bug and
+        // surfacing it as a fake 500 would mislead callers debugging it.
+        // `options.dpsPrivacy` is ignored; the legacy plaintext `/prove`
+        // route is deprecated.
+        const provingRequestObj = options.provingRequest instanceof ProvingRequest
+            ? options.provingRequest
+            : ProvingRequest.fromString(options.provingRequest);
+        const endpoint = provingRequestObj.kind() === "request"
+            ? "/prove/request"
+            : "/prove/authorization";
 
         try {
             return await retryWithBackoff(async () => {
-                const result = await sendEncrypted(endpoint);
+                const result = await sendEncrypted(endpoint, provingRequestObj);
                 if (result.ok) {
                     return result;
                 }
@@ -1969,7 +1971,7 @@ class AleoNetworkClient {
                 return result;
             });
         } catch (err) {
-            // If an error is returned, provide usable information to the caller.
+            // HTTP failure inside the retry loop — convert to a result object.
             const e = err as ProvingRequestError;
             return {
                 ok: false,

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -62,6 +62,10 @@ interface DelegatedProvingParams {
   apiKey?: string;
   consumerId?: string;
   jwtData?: JWTData;
+  /**
+   * @deprecated All proving requests are now encrypted. This flag is ignored
+   * and will be removed in a future release.
+   */
   dpsPrivacy?: boolean;
 }
 
@@ -1800,7 +1804,7 @@ class AleoNetworkClient {
 
 
     /**
-     * Parses a /prove or /prove/encrypted response. Returns a result object (never throws for 200/400/500/503).
+     * Parses a /prove/authorization or /prove/request response. Returns a result object (never throws for 200/400/500/503).
      */
     private async handleProvingResponse(response: Response): Promise<ProvingResult> {
         // Get the proving response text.
@@ -1904,9 +1908,10 @@ class AleoNetworkClient {
             headers["Authorization"] = jwtData.jwt;
         }
 
-        // Send the proving request encrypted (libsodium sealed box). Used by
-        // both the /prove/encrypted (Authorization variant, opt-in) and
-        // /prove/request (Request variant, mandatory) paths.
+        // Send the proving request encrypted (libsodium-compatible sealed box).
+        // Used by both `/prove/authorization` (Authorization variant) and
+        // `/prove/request` (Request variant). The legacy plaintext `/prove`
+        // route is no longer used.
         const sendEncrypted = async (endpoint: string): Promise<ProvingResult> => {
             // Get an ephemeral public key from the DPS.
             const pubKeyResponse = await get(proverUri + "/pubkey", {
@@ -1949,44 +1954,18 @@ class AleoNetworkClient {
             return this.handleProvingResponse(res);
         };
 
-        // Encapsulate the requests in a locally scoped function that can be run with a retry closure.
-        const runRequest = async (): Promise<ProvingResult> => {
-            // Request variant is encrypted-only and always routes to /prove/request.
-            // The DPS reads bytes via `read_request_le` on this route; `dpsPrivacy`
-            // is implicit because the route doesn't accept plaintext.
-            if (isRequestVariant) {
-                return sendEncrypted("/prove/request");
-            }
-
-            // Authorization variant: opt-in encrypted via /prove/encrypted.
-            if (options.dpsPrivacy) {
-                return sendEncrypted("/prove/encrypted");
-            }
-
-            // If encrypted usage is not specified use the unencrypted endpoint.
-            const proveEndpoint = (<string>proverUri).endsWith("/prove")
-                ? proverUri
-                : proverUri + "/prove";
-            const res = await this.transport(proveEndpoint, {
-                method: "POST",
-                body: provingRequestString,
-                headers,
-            });
-
-            // Properly handle the proving response.
-            return this.handleProvingResponse(res);
-        };
+        // The legacy plaintext `/prove` route is deprecated and no longer dispatched
+        // to; every proving request is encrypted. `options.dpsPrivacy` is ignored.
+        const endpoint = isRequestVariant ? "/prove/request" : "/prove/authorization";
 
         try {
-            // Run the request with retries.
             return await retryWithBackoff(async () => {
-                // Run the encrypted or non-encrypted flow as specified by the flags.
-                const result = await runRequest();
+                const result = await sendEncrypted(endpoint);
                 if (result.ok) {
                     return result;
                 }
 
-                // If 500s are hit responses are returned, attempt retries.
+                // Retry on 500/503; surface 400 verbatim.
                 if (result.status === 500 || result.status === 503) {
                     const err = new Error(result.error.message) as ProvingRequestError;
                     err.status = result.status;

--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -1869,17 +1869,17 @@ class AleoNetworkClient {
     async submitProvingRequestSafe(options: DelegatedProvingParams): Promise<ProvingResult> {
         // Attempt to get the Prover URI first from the options, then from any configured globally, or third try the main configured host.
         const proverUri = (options.url ?? this.proverUri) ?? this.host;
-        const provingRequestString = options.provingRequest instanceof ProvingRequest
-            ? options.provingRequest.toString()
-            : options.provingRequest;
 
-        // Determine the variant for endpoint routing. Only inspect `kind()`
-        // when the caller passed a `ProvingRequest` object — string inputs
-        // are deferred to the encrypted path's parse (preserves prior
-        // behavior for callers that pass opaque strings like JWT-refresh
-        // unit tests, which rely on the JWT fetch firing first).
-        const isRequestVariant = options.provingRequest instanceof ProvingRequest
-            && options.provingRequest.kind() === "request";
+        // Parse the proving request once, up front, so the variant the SDK
+        // routes on matches the bytes it will eventually send. Doing this
+        // lazily inside the encrypted path would let a Request-variant
+        // passed as a string be sent to `/prove/authorization` (the bytes
+        // are the Request layout — server-side `read_authorization_le`
+        // would reject them).
+        const provingRequestObj = options.provingRequest instanceof ProvingRequest
+            ? options.provingRequest
+            : ProvingRequest.fromString(options.provingRequest);
+        const isRequestVariant = provingRequestObj.kind() === "request";
 
         // Try to get JWT data to access the Provable API.
         const apiKey = options.apiKey ?? this.apiKey;
@@ -1919,15 +1919,10 @@ class AleoNetworkClient {
                 credentials: "include",
             }, this.transport);
 
-            // Encrypt the provingRequest. Parse lazily — only the encrypted
-            // paths need a real `ProvingRequest` object; the plaintext path
-            // forwards the string verbatim.
+            // Encrypt the provingRequest using the ephemeral pubkey.
             const pubkey: CryptoBoxPubKey = parseJSON(
                 await pubKeyResponse.text(),
             );
-            const provingRequestObj = options.provingRequest instanceof ProvingRequest
-                ? options.provingRequest
-                : ProvingRequest.fromString(provingRequestString);
             const ciphertext = encryptProvingRequest(
                 pubkey.public_key,
                 provingRequestObj,

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -1,5 +1,7 @@
 import sinon from "sinon";
 import { expect } from "chai";
+import { cryptoBoxKeyPair } from "@serenity-kit/noble-sodium";
+import { base64 } from "@scure/base";
 import {
     Account,
     BlockJSON,
@@ -16,6 +18,9 @@ import {
     PlaintextObject,
     Transition,
     TransitionObject,
+    ExecutionRequest,
+    PrivateKey,
+    ProvingRequest,
 } from "@provablehq/sdk/%%NETWORK%%.js";
 import { beaconPrivateKeyString } from "./data/account-data.js";
 import { retryWithBackoff } from "../src/utils/utils.js";
@@ -813,5 +818,98 @@ describe("AleoNetworkClient JWT refresh URL", () => {
             const firstCallUrl = fetchStub.firstCall.args[0]?.toString() ?? fetchStub.firstCall.args[0]?.url;
             expect(firstCallUrl).to.equal(`${expectedOrigin}/jwts/test-consumer-id`);
         });
+    });
+});
+
+describe("submitProvingRequestSafe variant routing", () => {
+    let fetchStub: sinon.SinonStub;
+
+    // Construct a single-public-Request-variant ProvingRequest for routing
+    // tests. The signed Request payload itself is not validated by the test —
+    // we only assert which endpoint the SDK hits.
+    function buildRequestVariant(): ProvingRequest {
+        const privateKey = PrivateKey.from_string(beaconPrivateKeyString);
+        const inputs = ["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px", "100u64"];
+        const inputTypes = ["address.public", "u64.public"];
+        const executionRequest = ExecutionRequest.sign(
+            privateKey,
+            "credits.aleo",
+            "transfer_public",
+            inputs,
+            inputTypes,
+            undefined,
+            undefined,
+            true,
+            false,
+        );
+        return ProvingRequest.fromRequest(executionRequest, undefined, false);
+    }
+
+    beforeEach(() => {
+        fetchStub = sinon.stub(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    // Build a stub /pubkey response containing a real ephemeral X25519 public
+    // key so `encryptProvingRequest` (which wraps `@serenity-kit/noble-sodium`'s
+    // `cryptoBoxSeal` — the same primitive `security.ts` uses) succeeds and
+    // the SDK actually reaches the prove POST. The test only asserts which
+    // URL is hit, not the ciphertext.
+    function pubKeyResponseBody(): string {
+        const { publicKey } = cryptoBoxKeyPair();
+        return JSON.stringify({ key_id: "test-key", public_key: base64.encode(publicKey) });
+    }
+
+    it("Request variant routes to /prove/request (encrypted-only) regardless of dpsPrivacy", async () => {
+        const client = new AleoNetworkClient("https://prover.example.com");
+
+        // First call is /pubkey (returns ephemeral key); second is the prove POST.
+        fetchStub.onFirstCall().resolves(new Response(
+            pubKeyResponseBody(),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+        fetchStub.onSecondCall().resolves(new Response(
+            JSON.stringify({ transaction: "stub", broadcast: null }),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+
+        const provingRequest = buildRequestVariant();
+        // dpsPrivacy explicitly false to verify it's ignored for Request variant.
+        await client.submitProvingRequestSafe({ provingRequest, dpsPrivacy: false });
+
+        const pubkeyCall = fetchStub.getCall(0).args[0]?.toString() ?? fetchStub.getCall(0).args[0]?.url;
+        const proveCall = fetchStub.getCall(1).args[0]?.toString() ?? fetchStub.getCall(1).args[0]?.url;
+        expect(pubkeyCall).to.equal("https://prover.example.com/testnet/pubkey");
+        expect(proveCall).to.equal("https://prover.example.com/testnet/prove/request");
+    });
+
+    it("Request variant routing takes precedence over dpsPrivacy=true", async () => {
+        const client = new AleoNetworkClient("https://prover.example.com");
+
+        fetchStub.onFirstCall().resolves(new Response(
+            pubKeyResponseBody(),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+        fetchStub.onSecondCall().resolves(new Response(
+            JSON.stringify({ transaction: "stub", broadcast: null }),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+
+        const provingRequest = buildRequestVariant();
+        // Even with dpsPrivacy=true (Authorization-variant encrypted path),
+        // a Request-variant ProvingRequest must still hit /prove/request,
+        // since that endpoint is the only one that accepts the Request layout.
+        await client.submitProvingRequestSafe({ provingRequest, dpsPrivacy: true });
+
+        const proveCall = fetchStub.getCall(1).args[0]?.toString() ?? fetchStub.getCall(1).args[0]?.url;
+        expect(proveCall).to.equal("https://prover.example.com/testnet/prove/request");
+    });
+
+    it("ProvingRequest.kind() returns 'request' for Request-variant constructions", () => {
+        const provingRequest = buildRequestVariant();
+        expect(provingRequest.kind()).to.equal("request");
     });
 });

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -882,8 +882,8 @@ describe("submitProvingRequestSafe variant routing", () => {
 
         const pubkeyCall = fetchStub.getCall(0).args[0]?.toString() ?? fetchStub.getCall(0).args[0]?.url;
         const proveCall = fetchStub.getCall(1).args[0]?.toString() ?? fetchStub.getCall(1).args[0]?.url;
-        expect(pubkeyCall).to.equal("https://prover.example.com/testnet/pubkey");
-        expect(proveCall).to.equal("https://prover.example.com/testnet/prove/request");
+        expect(pubkeyCall).to.equal("https://prover.example.com/%%NETWORK%%/pubkey");
+        expect(proveCall).to.equal("https://prover.example.com/%%NETWORK%%/prove/request");
     });
 
     it("Request variant routing takes precedence over dpsPrivacy=true", async () => {
@@ -905,7 +905,7 @@ describe("submitProvingRequestSafe variant routing", () => {
         await client.submitProvingRequestSafe({ provingRequest, dpsPrivacy: true });
 
         const proveCall = fetchStub.getCall(1).args[0]?.toString() ?? fetchStub.getCall(1).args[0]?.url;
-        expect(proveCall).to.equal("https://prover.example.com/testnet/prove/request");
+        expect(proveCall).to.equal("https://prover.example.com/%%NETWORK%%/prove/request");
     });
 
     it("ProvingRequest.kind() returns 'request' for Request-variant constructions", () => {
@@ -934,6 +934,6 @@ describe("submitProvingRequestSafe variant routing", () => {
         await client.submitProvingRequestSafe({ provingRequest: provingRequestString });
 
         const proveCall = fetchStub.getCall(1).args[0]?.toString() ?? fetchStub.getCall(1).args[0]?.url;
-        expect(proveCall).to.equal("https://prover.example.com/testnet/prove/request");
+        expect(proveCall).to.equal("https://prover.example.com/%%NETWORK%%/prove/request");
     });
 });

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -912,4 +912,28 @@ describe("submitProvingRequestSafe variant routing", () => {
         const provingRequest = buildRequestVariant();
         expect(provingRequest.kind()).to.equal("request");
     });
+
+    // Regression for the routing bug flagged by Cursor Bugbot / Copilot on PR
+    // #1329: a Request-variant ProvingRequest passed as a serialized string
+    // (e.g. `provingRequest.toString()`) must still route to /prove/request,
+    // not /prove/authorization. Variant detection has to look at the parsed
+    // ProvingRequest, not the input type.
+    it("Request variant passed as a serialized string still routes to /prove/request", async () => {
+        const client = new AleoNetworkClient("https://prover.example.com");
+
+        fetchStub.onFirstCall().resolves(new Response(
+            pubKeyResponseBody(),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+        fetchStub.onSecondCall().resolves(new Response(
+            JSON.stringify({ transaction: "stub", broadcast: null }),
+            { status: 200, headers: { "content-type": "application/json" } },
+        ));
+
+        const provingRequestString = buildRequestVariant().toString();
+        await client.submitProvingRequestSafe({ provingRequest: provingRequestString });
+
+        const proveCall = fetchStub.getCall(1).args[0]?.toString() ?? fetchStub.getCall(1).args[0]?.url;
+        expect(proveCall).to.equal("https://prover.example.com/testnet/prove/request");
+    });
 });

--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -214,7 +214,7 @@ mod tests {
         .await
         .unwrap();
 
-        let authorization = proving_request.authorization();
+        let authorization = proving_request.authorization().unwrap();
         assert_eq!(authorization.len(), 1, "transfer_public should have 1 request");
         assert_eq!(authorization.transitions().length(), 1, "transfer_public should have 1 transition");
         // No fee authorization when built from ExecutionRequest (fee is paid by fee master or handled separately).
@@ -255,7 +255,7 @@ mod tests {
         assert!(request_from_string.equals(&proving_request) && request_from_bytes.equals(&proving_request));
 
         // Get the main authorization from the proving request.
-        let authorization = proving_request.authorization();
+        let authorization = proving_request.authorization().unwrap();
 
         // Assert the number of requests is correct.
         assert_eq!(authorization.len(), 3);
@@ -308,7 +308,7 @@ mod tests {
         );
 
         // Main authorization is still present.
-        let authorization = proving_request.authorization();
+        let authorization = proving_request.authorization().unwrap();
         assert_eq!(authorization.len(), 3);
         assert_eq!(authorization.transitions().length(), 3);
     }

--- a/wasm/src/synthesizer/proving_request.rs
+++ b/wasm/src/synthesizer/proving_request.rs
@@ -15,10 +15,11 @@
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    ExecutionRequest,
     synthesizer::Authorization,
-    types::native::{AuthorizationNative, ProvingRequestNative},
+    types::native::{AuthorizationNative, ProvingRequestNative, RequestNative},
 };
-use snarkvm_wasm::utilities::{FromBytes, ToBytes};
+use snarkvm_wasm::utilities::ToBytes;
 
 use js_sys::Uint8Array;
 use std::{
@@ -29,12 +30,24 @@ use std::{
 use wasm_bindgen::prelude::*;
 
 /// Represents a proving request to a prover.
+///
+/// Carries one of two variants:
+/// - `Authorization` — a fully-constructed snarkVM `Authorization` (plus optional
+///   fee authorization). Submitted to `/prove` or `/prove/encrypted`.
+/// - `Request` — a single signed snarkVM `Request` (plus optional fee `Request`)
+///   that the prover authorizes server-side. Submitted to `/prove/request`
+///   (encrypted-only).
+///
+/// Use {@link ProvingRequest#kind} when handling a `ProvingRequest` of unknown
+/// variant (e.g. after deserialization). Variant-specific accessors throw if
+/// called on the wrong variant.
 #[wasm_bindgen]
 pub struct ProvingRequest(ProvingRequestNative);
 
 #[wasm_bindgen]
 impl ProvingRequest {
-    /// Creates a new ProvingRequest from a function Authorization and an optional fee Authorization.
+    /// Creates a new Authorization-variant `ProvingRequest` from a function
+    /// `Authorization` and an optional fee `Authorization`.
     ///
     /// @param {Authorization} authorization An Authorization for a function.
     /// @param {Authorization} fee_authorization The authorization for the `credits.aleo/fee_public` or `credits.aleo/fee_private` function that pays the fee for the execution of the main function.
@@ -43,47 +56,129 @@ impl ProvingRequest {
         ProvingRequest(ProvingRequestNative::new(authorization, fee_authorization, broadcast))
     }
 
-    /// Creates a ProvingRequest from a string representation.
+    /// Creates a new Request-variant `ProvingRequest` from a single signed
+    /// `ExecutionRequest` and an optional signed fee `ExecutionRequest`.
     ///
-    /// @param {Uint8Array} request String representation of the ProvingRequest.
+    /// The Request variant is processed by the DPS at the `/prove/request`
+    /// endpoint, which is encrypted-only. The server runs
+    /// `Process::authorize_request` to turn each `Request` into an
+    /// `Authorization` before proving.
+    ///
+    /// Only valid for single-public-request executions. Layered / nested
+    /// calls are not supported by `/prove/request` at this time.
+    ///
+    /// @param {ExecutionRequest} request The signed request for the function.
+    /// @param {ExecutionRequest} fee_request Optional signed request for the fee function. When omitted, the prover generates and pays the fee.
+    /// @param {boolean} broadcast Flag that indicates whether the remote proving service should attempt to submit the transaction on the caller's behalf.
+    #[wasm_bindgen(js_name = "fromRequest")]
+    pub fn from_request(
+        request: ExecutionRequest,
+        fee_request: Option<ExecutionRequest>,
+        broadcast: bool,
+    ) -> Self {
+        let request_native: RequestNative = request.into();
+        let fee_request_native: Option<RequestNative> = fee_request.map(Into::into);
+        ProvingRequest(ProvingRequestNative::new_request(request_native, fee_request_native, broadcast))
+    }
+
+    /// Returns the variant of this `ProvingRequest`: `"authorization"` or
+    /// `"request"`. Useful when handling a `ProvingRequest` whose variant
+    /// was determined at deserialization time.
+    pub fn kind(&self) -> String {
+        if self.0.is_request() { "request".to_string() } else { "authorization".to_string() }
+    }
+
+    /// Creates a `ProvingRequest` from a JSON string representation.
+    ///
+    /// The variant is determined automatically by the JSON shape:
+    /// `{ authorization, ... }` → Authorization variant; `{ request, ... }` →
+    /// Request variant. Use {@link ProvingRequest#kind} to inspect the
+    /// resulting variant.
+    ///
+    /// @param {string} request JSON string representation of the ProvingRequest.
     #[wasm_bindgen(js_name = "fromString")]
     pub fn from_string(request: String) -> Result<ProvingRequest, String> {
         Ok(ProvingRequest(ProvingRequestNative::from_str(&request).map_err(|e| e.to_string())?))
     }
 
-    /// Creates a string representation of the ProvingRequest.
+    /// Creates a JSON string representation of the ProvingRequest.
+    /// The shape carries enough information to recover the variant via
+    /// {@link ProvingRequest.fromString}.
     #[wasm_bindgen(js_name = "toString")]
     #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
         self.0.to_string()
     }
 
-    /// Creates a ProvingRequest from a left-endian byte representation of the ProvingRequest.
+    /// Reads bytes as an Authorization-variant `ProvingRequest`. For the
+    /// Request variant, use {@link ProvingRequest.fromBytesLeRequest}
+    /// explicitly — byte layout carries no variant discriminator.
     ///
-    /// @param {Uint8Array} bytes Left-endian bytes representing the proving request.
+    /// @param {Uint8Array} bytes Left-endian bytes representing an Authorization-variant proving request.
     #[wasm_bindgen(js_name = "fromBytesLe")]
     pub fn from_bytes_le(bytes: Uint8Array) -> Result<ProvingRequest, String> {
         let rust_bytes = bytes.to_vec();
-        let native = ProvingRequestNative::from_bytes_le(rust_bytes.as_slice()).map_err(|e| e.to_string())?;
+        let native = ProvingRequestNative::read_authorization_le(rust_bytes.as_slice()).map_err(|e| e.to_string())?;
         Ok(ProvingRequest(native))
     }
 
-    /// Creates a left-endian byte representation of the ProvingRequest.
+    /// Reads bytes as a Request-variant `ProvingRequest`. Byte layout is
+    /// disjoint from the Authorization variant; callers must pick the right
+    /// reader for the bytes they hold.
+    ///
+    /// @param {Uint8Array} bytes Left-endian bytes representing a Request-variant proving request.
+    #[wasm_bindgen(js_name = "fromBytesLeRequest")]
+    pub fn from_bytes_le_request(bytes: Uint8Array) -> Result<ProvingRequest, String> {
+        let rust_bytes = bytes.to_vec();
+        let native = ProvingRequestNative::read_request_le(rust_bytes.as_slice()).map_err(|e| e.to_string())?;
+        Ok(ProvingRequest(native))
+    }
+
+    /// Creates a left-endian byte representation of the ProvingRequest,
+    /// dispatching on the variant. The bytes are wire-compatible with the
+    /// matching DPS route (`/prove[/encrypted]` for Authorization,
+    /// `/prove/request` for Request).
     #[wasm_bindgen(js_name = "toBytesLe")]
     pub fn to_bytes_le(&self) -> Result<Uint8Array, String> {
         let bytes = self.0.to_bytes_le().map_err(|e| e.to_string())?;
         Ok(Uint8Array::from(bytes.as_slice()))
     }
 
-    /// Get the Authorization of the main function in the ProvingRequest.
-    pub fn authorization(&self) -> Authorization {
-        Authorization::from(self.0.authorization())
+    /// Returns the Authorization of the main function in the ProvingRequest.
+    ///
+    /// @throws If this `ProvingRequest` is a Request variant. Check
+    /// {@link ProvingRequest#kind} or use {@link ProvingRequest#request} instead.
+    pub fn authorization(&self) -> Result<Authorization, String> {
+        self.0
+            .authorization()
+            .map(Authorization::from)
+            .ok_or_else(|| "ProvingRequest is a Request variant; call `request()` instead of `authorization()`".to_string())
     }
 
-    /// Get the fee Authorization in the ProvingRequest.
+    /// Returns the fee Authorization in the ProvingRequest, or `undefined`
+    /// when no fee is set or this is a Request variant.
     #[wasm_bindgen(js_name = "feeAuthorization")]
     pub fn fee_authorization(&self) -> Option<Authorization> {
         self.0.fee_authorization().map(Authorization::from)
+    }
+
+    /// Returns the signed `ExecutionRequest` carried by the Request variant.
+    ///
+    /// @throws If this `ProvingRequest` is an Authorization variant. Check
+    /// {@link ProvingRequest#kind} or use {@link ProvingRequest#authorization}
+    /// instead.
+    pub fn request(&self) -> Result<ExecutionRequest, String> {
+        self.0
+            .request()
+            .map(ExecutionRequest::from)
+            .ok_or_else(|| "ProvingRequest is an Authorization variant; call `authorization()` instead of `request()`".to_string())
+    }
+
+    /// Returns the signed fee `ExecutionRequest` in the Request variant, or
+    /// `undefined` when no fee request is set or this is an Authorization variant.
+    #[wasm_bindgen(js_name = "feeRequest")]
+    pub fn fee_request(&self) -> Option<ExecutionRequest> {
+        self.0.fee_request().map(ExecutionRequest::from)
     }
 
     /// Get the broadcast flag set in the ProvingRequest.
@@ -159,12 +254,16 @@ impl Eq for ProvingRequest {}
 mod tests {
     use super::*;
     use crate::{
+        PrivateKey,
+        array,
         types::native::CurrentNetwork,
         utilities::test::{PUZZLE_SPINNER_V002_AUTHORIZATION, PUZZLE_SPINNER_V002_PROVING_REQUEST},
     };
     use snarkvm_wasm::console::network::Network;
 
     use wasm_bindgen_test::*;
+
+    // ---- Authorization variant (legacy) ----------------------------------
 
     #[wasm_bindgen_test]
     fn test_proving_request_serialization_roundtrip() {
@@ -191,9 +290,102 @@ mod tests {
 
             // Ensure the authorizations and broadcast flags match expected values.
             let authorization = Authorization::from_string(PUZZLE_SPINNER_V002_AUTHORIZATION.to_string()).unwrap();
-            assert!(proving_request.authorization().equals(&authorization));
+            assert!(proving_request.authorization().unwrap().equals(&authorization));
             assert!(proving_request.fee_authorization().unwrap().is_fee_public());
             assert_eq!(proving_request.broadcast, false);
+            assert_eq!(proving_request.kind(), "authorization");
+        }
+    }
+
+    // ---- Request variant -------------------------------------------------
+
+    /// Beacon private key — matches the existing wasm-side fixtures.
+    const BEACON_PRIVATE_KEY_STR: &str = "APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH";
+
+    fn sample_execution_request() -> ExecutionRequest {
+        let private_key = PrivateKey::from_string(BEACON_PRIVATE_KEY_STR).unwrap();
+        let inputs = array!["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px".to_string(), "100u64".to_string()];
+        let input_types = array!["address.public".to_string(), "u64.public".to_string()];
+        ExecutionRequest::sign(
+            private_key,
+            "credits.aleo".to_string(),
+            "transfer_public".to_string(),
+            inputs,
+            input_types,
+            None,
+            None,
+            true,
+            false,
+        )
+        .expect("sign should succeed")
+    }
+
+    #[wasm_bindgen_test]
+    fn test_request_variant_construction_and_kind() {
+        let request = sample_execution_request();
+        let proving_request = ProvingRequest::from_request(request, None, false);
+
+        assert_eq!(proving_request.kind(), "request");
+        assert!(proving_request.0.is_request());
+        assert!(!proving_request.0.is_authorization());
+        assert!(proving_request.request().is_ok());
+        assert!(proving_request.fee_request().is_none());
+        assert_eq!(proving_request.broadcast(), false);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_request_variant_byte_roundtrip() {
+        let request = sample_execution_request();
+        let proving_request = ProvingRequest::from_request(request, None, true);
+
+        // Roundtrip via the explicit Request reader. Using `fromBytesLe`
+        // (Authorization reader) on these bytes would fail or produce garbage,
+        // which is the intended behavior — the byte layout carries no
+        // discriminator.
+        let bytes = proving_request.to_bytes_le().expect("toBytesLe should succeed");
+        let roundtripped =
+            ProvingRequest::from_bytes_le_request(bytes).expect("fromBytesLeRequest should succeed");
+
+        assert!(proving_request.equals(&roundtripped));
+        assert_eq!(roundtripped.kind(), "request");
+        assert_eq!(roundtripped.broadcast(), true);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_request_variant_string_roundtrip_autodetects() {
+        let request = sample_execution_request();
+        let proving_request = ProvingRequest::from_request(request, None, false);
+
+        // JSON shape carries the variant — fromString picks the right one via
+        // serde's untagged dispatch on disjoint field names.
+        let s = proving_request.to_string();
+        let roundtripped = ProvingRequest::from_string(s).expect("fromString should succeed");
+
+        assert_eq!(roundtripped.kind(), "request");
+        assert!(proving_request.equals(&roundtripped));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_request_variant_accessors_throw_on_authorization_methods() {
+        let request = sample_execution_request();
+        let proving_request = ProvingRequest::from_request(request, None, false);
+
+        // `authorization()` on a Request variant should be a clear error.
+        let err = proving_request.authorization().expect_err("expected authorization() to error");
+        assert!(err.contains("Request variant"), "error should mention Request variant: {err}");
+
+        // `feeAuthorization()` returns None rather than throwing — matches
+        // the optional return shape callers already expect.
+        assert!(proving_request.fee_authorization().is_none());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_authorization_variant_throws_on_request_accessor() {
+        if CurrentNetwork::ID == 0 {
+            let proving_request = ProvingRequest::from_string(PUZZLE_SPINNER_V002_PROVING_REQUEST.to_string()).unwrap();
+            let err = proving_request.request().expect_err("expected request() to error");
+            assert!(err.contains("Authorization variant"), "error should mention Authorization variant: {err}");
+            assert!(proving_request.fee_request().is_none());
         }
     }
 }

--- a/wasm/src/synthesizer/proving_request.rs
+++ b/wasm/src/synthesizer/proving_request.rs
@@ -71,11 +71,7 @@ impl ProvingRequest {
     /// @param {ExecutionRequest} fee_request Optional signed request for the fee function. When omitted, the prover generates and pays the fee.
     /// @param {boolean} broadcast Flag that indicates whether the remote proving service should attempt to submit the transaction on the caller's behalf.
     #[wasm_bindgen(js_name = "fromRequest")]
-    pub fn from_request(
-        request: ExecutionRequest,
-        fee_request: Option<ExecutionRequest>,
-        broadcast: bool,
-    ) -> Self {
+    pub fn from_request(request: ExecutionRequest, fee_request: Option<ExecutionRequest>, broadcast: bool) -> Self {
         let request_native: RequestNative = request.into();
         let fee_request_native: Option<RequestNative> = fee_request.map(Into::into);
         ProvingRequest(ProvingRequestNative::new_request(request_native, fee_request_native, broadcast))
@@ -149,10 +145,9 @@ impl ProvingRequest {
     /// @throws If this `ProvingRequest` is a Request variant. Check
     /// {@link ProvingRequest#kind} or use {@link ProvingRequest#request} instead.
     pub fn authorization(&self) -> Result<Authorization, String> {
-        self.0
-            .authorization()
-            .map(Authorization::from)
-            .ok_or_else(|| "ProvingRequest is a Request variant; call `request()` instead of `authorization()`".to_string())
+        self.0.authorization().map(Authorization::from).ok_or_else(|| {
+            "ProvingRequest is a Request variant; call `request()` instead of `authorization()`".to_string()
+        })
     }
 
     /// Returns the fee Authorization in the ProvingRequest, or `undefined`
@@ -168,10 +163,9 @@ impl ProvingRequest {
     /// {@link ProvingRequest#kind} or use {@link ProvingRequest#authorization}
     /// instead.
     pub fn request(&self) -> Result<ExecutionRequest, String> {
-        self.0
-            .request()
-            .map(ExecutionRequest::from)
-            .ok_or_else(|| "ProvingRequest is an Authorization variant; call `authorization()` instead of `request()`".to_string())
+        self.0.request().map(ExecutionRequest::from).ok_or_else(|| {
+            "ProvingRequest is an Authorization variant; call `authorization()` instead of `request()`".to_string()
+        })
     }
 
     /// Returns the signed fee `ExecutionRequest` in the Request variant, or
@@ -292,7 +286,7 @@ mod tests {
             let authorization = Authorization::from_string(PUZZLE_SPINNER_V002_AUTHORIZATION.to_string()).unwrap();
             assert!(proving_request.authorization().unwrap().equals(&authorization));
             assert!(proving_request.fee_authorization().unwrap().is_fee_public());
-            assert_eq!(proving_request.broadcast, false);
+            assert_eq!(proving_request.broadcast(), false);
             assert_eq!(proving_request.kind(), "authorization");
         }
     }
@@ -304,7 +298,8 @@ mod tests {
 
     fn sample_execution_request() -> ExecutionRequest {
         let private_key = PrivateKey::from_string(BEACON_PRIVATE_KEY_STR).unwrap();
-        let inputs = array!["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px".to_string(), "100u64".to_string()];
+        let inputs =
+            array!["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px".to_string(), "100u64".to_string()];
         let input_types = array!["address.public".to_string(), "u64.public".to_string()];
         ExecutionRequest::sign(
             private_key,
@@ -343,8 +338,7 @@ mod tests {
         // which is the intended behavior — the byte layout carries no
         // discriminator.
         let bytes = proving_request.to_bytes_le().expect("toBytesLe should succeed");
-        let roundtripped =
-            ProvingRequest::from_bytes_le_request(bytes).expect("fromBytesLeRequest should succeed");
+        let roundtripped = ProvingRequest::from_bytes_le_request(bytes).expect("fromBytesLeRequest should succeed");
 
         assert!(proving_request.equals(&roundtripped));
         assert_eq!(roundtripped.kind(), "request");
@@ -383,7 +377,9 @@ mod tests {
     fn test_authorization_variant_throws_on_request_accessor() {
         if CurrentNetwork::ID == 0 {
             let proving_request = ProvingRequest::from_string(PUZZLE_SPINNER_V002_PROVING_REQUEST.to_string()).unwrap();
-            let err = proving_request.request().expect_err("expected request() to error");
+            // `expect_err` requires `T: Debug`; `ExecutionRequest` doesn't impl
+            // it, so use `.err().expect(...)` to extract the error message.
+            let err = proving_request.request().err().expect("expected request() to error");
             assert!(err.contains("Authorization variant"), "error should mention Authorization variant: {err}");
             assert!(proving_request.fee_request().is_none());
         }

--- a/wasm/src/synthesizer/proving_request.rs
+++ b/wasm/src/synthesizer/proving_request.rs
@@ -33,7 +33,7 @@ use wasm_bindgen::prelude::*;
 ///
 /// Carries one of two variants:
 /// - `Authorization` — a fully-constructed snarkVM `Authorization` (plus optional
-///   fee authorization). Submitted to `/prove` or `/prove/encrypted`.
+///   fee authorization). Submitted to `/prove/authorization` (encrypted-only).
 /// - `Request` — a single signed snarkVM `Request` (plus optional fee `Request`)
 ///   that the prover authorizes server-side. Submitted to `/prove/request`
 ///   (encrypted-only).

--- a/wasm/src/types/native/request/bytes.rs
+++ b/wasm/src/types/native/request/bytes.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Provable SDK library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::types::native::{AuthorizationNative, ProvingRequestNative};
+use crate::types::native::{AuthorizationNative, ProvingRequestNative, RequestNative};
 use snarkvm_wasm::utilities::{FromBytes, ToBytes};
 
 use std::{
@@ -23,43 +23,76 @@ use std::{
 };
 
 impl ToBytes for ProvingRequestNative {
+    /// Variant-aware byte serialization matching the DPS layout exactly.
+    /// No discriminator byte is written — the reader must know the variant
+    /// out-of-band (route context on the server; explicit method on clients).
     fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        // Write required authorization.
-        self.authorization.write_le(&mut writer)?;
-
-        // Write the optional fee_authorization.
-        match &self.fee_authorization {
-            Some(auth) => {
-                true.write_le(&mut writer)?; // flag for Some
-                auth.write_le(&mut writer)?;
+        match self {
+            Self::Authorization { authorization, fee_authorization, broadcast } => {
+                authorization.write_le(&mut writer)?;
+                match fee_authorization {
+                    Some(auth) => {
+                        true.write_le(&mut writer)?;
+                        auth.write_le(&mut writer)?;
+                    }
+                    None => {
+                        false.write_le(&mut writer)?;
+                    }
+                }
+                broadcast.write_le(&mut writer)?;
             }
-            None => {
-                false.write_le(&mut writer)?; // flag for None
+            Self::Request { request, fee_request, broadcast } => {
+                request.write_le(&mut writer)?;
+                match fee_request {
+                    Some(req) => {
+                        true.write_le(&mut writer)?;
+                        req.write_le(&mut writer)?;
+                    }
+                    None => {
+                        false.write_le(&mut writer)?;
+                    }
+                }
+                broadcast.write_le(&mut writer)?;
             }
         }
-
-        // Write broadcast flag.
-        self.broadcast.write_le(&mut writer)?;
-
         Ok(())
     }
 }
 
 impl FromBytes for ProvingRequestNative {
-    fn read_le<R: Read>(mut reader: R) -> io::Result<Self> {
-        // Read required authorization.
-        let authorization = AuthorizationNative::read_le(&mut reader)?;
+    /// Reads bytes as the Authorization variant for back-compat — historically
+    /// the only variant that existed. To read the Request variant, callers
+    /// must use [`ProvingRequestNative::read_request_le`] explicitly because
+    /// the byte layout carries no discriminator.
+    fn read_le<R: Read>(reader: R) -> io::Result<Self> {
+        Self::read_authorization_le(reader)
+    }
+}
 
-        // Read the option flag and then the fee_authorization if present.
+impl ProvingRequestNative {
+    /// Reads bytes as the Authorization variant.
+    /// Layout: `authorization | bool | maybe(fee_authorization) | bool(broadcast)`.
+    pub fn read_authorization_le<R: Read>(mut reader: R) -> io::Result<Self> {
+        let authorization = AuthorizationNative::read_le(&mut reader)?;
         let has_fee_auth = bool::read_le(&mut reader)?;
         let fee_authorization = match has_fee_auth {
             false => None,
             true => Some(AuthorizationNative::read_le(&mut reader)?),
         };
-
-        // Read broadcast flag.
         let broadcast = bool::read_le(&mut reader)?;
+        Ok(Self::Authorization { authorization, fee_authorization, broadcast })
+    }
 
-        Ok(Self { authorization, fee_authorization, broadcast })
+    /// Reads bytes as the Request variant.
+    /// Layout: `request | bool | maybe(fee_request) | bool(broadcast)`.
+    pub fn read_request_le<R: Read>(mut reader: R) -> io::Result<Self> {
+        let request = RequestNative::read_le(&mut reader)?;
+        let has_fee_request = bool::read_le(&mut reader)?;
+        let fee_request = match has_fee_request {
+            false => None,
+            true => Some(RequestNative::read_le(&mut reader)?),
+        };
+        let broadcast = bool::read_le(&mut reader)?;
+        Ok(Self::Request { request, fee_request, broadcast })
     }
 }

--- a/wasm/src/types/native/request/mod.rs
+++ b/wasm/src/types/native/request/mod.rs
@@ -21,48 +21,112 @@ use super::*;
 
 use serde::{Deserialize, Serialize};
 
+/// A proving request submitted to the Delegated Proving Service.
+///
+/// Mirrors the variant layout used by the DPS in `utils::types::ProvingRequest`:
+/// `Authorization` carries a fully-constructed `Authorization` (and optional fee
+/// `Authorization`); `Request` carries a single signed `Request` (and optional
+/// fee `Request`) that the server turns into an `Authorization` via
+/// `Process::authorize_request`. JSON is serialized untagged — the field shape
+/// (`authorization`/`fee_authorization` vs. `request`/`fee_request`) determines
+/// the variant. Bytes carry no discriminator; the reader must know the variant
+/// out-of-band (see `bytes.rs`).
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ProvingRequestNative {
-    pub authorization: AuthorizationNative,
-    pub fee_authorization: Option<AuthorizationNative>,
-    pub broadcast: bool,
+#[serde(untagged)]
+pub enum ProvingRequestNative {
+    Authorization {
+        authorization: AuthorizationNative,
+        fee_authorization: Option<AuthorizationNative>,
+        broadcast: bool,
+    },
+    Request {
+        request: RequestNative,
+        fee_request: Option<RequestNative>,
+        broadcast: bool,
+    },
 }
 
 impl ProvingRequestNative {
-    /// Creates a new `ProvingRequestNative` from the given authorization and fee authorization.
+    /// Creates a new Authorization-variant `ProvingRequestNative` from the
+    /// given authorization and optional fee authorization.
     pub fn new(
         authorization: crate::Authorization,
         fee_authorization: Option<crate::Authorization>,
         broadcast: bool,
     ) -> Self {
-        Self {
+        Self::Authorization {
             authorization: AuthorizationNative::from(authorization),
             fee_authorization: fee_authorization.map(AuthorizationNative::from),
             broadcast,
         }
     }
 
-    /// Creates a new `ProvingRequest` from native authorization types.
+    /// Creates a new Authorization-variant `ProvingRequestNative` from native
+    /// `AuthorizationNative` values.
     pub fn new_from_native(
         authorization: AuthorizationNative,
         fee_authorization: Option<AuthorizationNative>,
         broadcast: bool,
     ) -> Self {
-        Self { authorization, fee_authorization, broadcast }
+        Self::Authorization { authorization, fee_authorization, broadcast }
     }
 
-    /// Gets the authorization of the function the `signer` is attempting to call.
-    pub fn authorization(&self) -> &AuthorizationNative {
-        &self.authorization
+    /// Creates a new Request-variant `ProvingRequestNative` from a single
+    /// signed `Request` and optional fee `Request`.
+    pub fn new_request(request: RequestNative, fee_request: Option<RequestNative>, broadcast: bool) -> Self {
+        Self::Request { request, fee_request, broadcast }
     }
 
-    /// Gets the fee authorization of the proving request.
+    /// Returns the Authorization variant's inner authorization, or `None` if
+    /// this is a Request variant.
+    pub fn authorization(&self) -> Option<&AuthorizationNative> {
+        match self {
+            Self::Authorization { authorization, .. } => Some(authorization),
+            Self::Request { .. } => None,
+        }
+    }
+
+    /// Returns the Authorization variant's fee authorization, or `None` if this
+    /// is a Request variant or no fee authorization is set.
     pub fn fee_authorization(&self) -> Option<&AuthorizationNative> {
-        self.fee_authorization.as_ref()
+        match self {
+            Self::Authorization { fee_authorization, .. } => fee_authorization.as_ref(),
+            Self::Request { .. } => None,
+        }
     }
 
-    /// Returns the broadcast flag.
+    /// Returns the Request variant's inner request, or `None` if this is an
+    /// Authorization variant.
+    pub fn request(&self) -> Option<&RequestNative> {
+        match self {
+            Self::Request { request, .. } => Some(request),
+            Self::Authorization { .. } => None,
+        }
+    }
+
+    /// Returns the Request variant's fee request, or `None` if this is an
+    /// Authorization variant or no fee request is set.
+    pub fn fee_request(&self) -> Option<&RequestNative> {
+        match self {
+            Self::Request { fee_request, .. } => fee_request.as_ref(),
+            Self::Authorization { .. } => None,
+        }
+    }
+
+    /// Returns the broadcast flag regardless of variant.
     pub fn broadcast(&self) -> bool {
-        self.broadcast
+        match self {
+            Self::Authorization { broadcast, .. } | Self::Request { broadcast, .. } => *broadcast,
+        }
+    }
+
+    /// Returns `true` if this is the Authorization variant.
+    pub fn is_authorization(&self) -> bool {
+        matches!(self, Self::Authorization { .. })
+    }
+
+    /// Returns `true` if this is the Request variant.
+    pub fn is_request(&self) -> bool {
+        matches!(self, Self::Request { .. })
     }
 }


### PR DESCRIPTION
## Motivation

The delegated proving endpoints now support sending signed SnarkVM `Request` objects for proving. This PR provides the SDK functionality for using them.

## Test Plan

- This PR adds several tests of the new functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default delegated-proving wire path (encryption-only, new endpoint routing) and tightens ProvingRequest WASM APIs; mistakes in variant detection could send payloads to the wrong DPS handler.
> 
> **Overview**
> Adds a **Request** variant to `ProvingRequest` (signed `ExecutionRequest` + optional fee request) alongside the existing **Authorization** variant, with `kind()`, `fromRequest()`, variant-specific accessors, and separate byte readers (`fromBytesLe` vs `fromBytesLeRequest`).
> 
> **Delegated proving in the SDK** always uses encrypted submission now: plaintext `/prove` is removed, `dpsPrivacy` is deprecated, and `submitProvingRequestSafe` picks **`/prove/request`** vs **`/prove/authorization`** from the parsed variant (including when the input is a JSON string). `authorization()` on the WASM type is now a **Result** and errors on the wrong variant.
> 
> Tests cover Request-variant routing (including serialized strings) and WASM roundtrips/accessor behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe08c028079b0d546398a800a69380f16e740159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->