### PR TITLE
Add test showcasing external signing for multiple requests for a single transaction

### DIFF
--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -215,7 +215,7 @@ interface ProvingRequestOptions {
     unchecked?: boolean;
     edition?: number;
     useFeeMaster?: boolean;
-    executionRequest?: ExecutionRequest;
+    executionRequests?: ExecutionRequest[];
 }
 
 /**
@@ -1819,7 +1819,7 @@ class ProgramManager {
         let imports = options.programImports;
         let edition = options.edition;
 
-        if (!inputs && !options.executionRequest) {
+        if (!inputs && (!options.executionRequests || options.executionRequests.length === 0)) {
             throw new Error("Either function inputs or an execution request must be provided to form a proving request");
         }
 
@@ -1851,7 +1851,7 @@ class ProgramManager {
         if (
             typeof privateKey === "undefined" &&
             typeof this.account !== "undefined" &&
-            typeof options.executionRequest === "undefined"
+            (!options.executionRequests || options.executionRequests.length === 0)
         ) {
             executionPrivateKey = this.account.privateKey();
         }
@@ -1872,7 +1872,7 @@ class ProgramManager {
 
         // Get the fee record from the account if it is not provided in the parameters
         try {
-            if (privateFee && !useFeeMaster && !options.executionRequest) {
+            if (privateFee && !useFeeMaster && (!options.executionRequests || options.executionRequests.length === 0)) {
                 let fee = priorityFee;
                 // If a fee record wasn't provided, estimate the fee that needs to be paid.
                 if (!feeRecord) {
@@ -1919,16 +1919,11 @@ class ProgramManager {
             imports = merged;
         }
 
-        if (options.executionRequest instanceof ExecutionRequest) {
-            return await WasmProgramManager.buildProvingRequestFromExecutionRequest(
-                options.executionRequest,
-                program,
-                unchecked,
+        if (options.executionRequests && options.executionRequests.length > 0) {
+            return WasmProgramManager.buildProvingRequestFromExecutionRequest(
+                options.executionRequests,
+                undefined,  // fee_request — handled separately if needed
                 broadcast,
-                edition,
-                imports, // kept for fee estimation in Rust
-                executionPrivateKey,
-                hasImports ? builder?.clone() : undefined,
             );
         } else {
             // Ensure the private key exists.

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -215,7 +215,7 @@ interface ProvingRequestOptions {
     unchecked?: boolean;
     edition?: number;
     useFeeMaster?: boolean;
-    executionRequests?: ExecutionRequest[];
+    executionRequest?: ExecutionRequest | ExecutionRequest[];
 }
 
 /**
@@ -1819,7 +1819,14 @@ class ProgramManager {
         let imports = options.programImports;
         let edition = options.edition;
 
-        if (!inputs && (!options.executionRequests || options.executionRequests.length === 0)) {
+        // Accept either a single execution request or an array; normalize to an array.
+        const executionRequests = options.executionRequest === undefined
+            ? []
+            : Array.isArray(options.executionRequest)
+                ? options.executionRequest
+                : [options.executionRequest];
+
+        if (!inputs && executionRequests.length === 0) {
             throw new Error("Either function inputs or an execution request must be provided to form a proving request");
         }
 
@@ -1851,7 +1858,7 @@ class ProgramManager {
         if (
             typeof privateKey === "undefined" &&
             typeof this.account !== "undefined" &&
-            (!options.executionRequests || options.executionRequests.length === 0)
+            executionRequests.length === 0
         ) {
             executionPrivateKey = this.account.privateKey();
         }
@@ -1872,7 +1879,7 @@ class ProgramManager {
 
         // Get the fee record from the account if it is not provided in the parameters
         try {
-            if (privateFee && !useFeeMaster && (!options.executionRequests || options.executionRequests.length === 0)) {
+            if (privateFee && !useFeeMaster && executionRequests.length === 0) {
                 let fee = priorityFee;
                 // If a fee record wasn't provided, estimate the fee that needs to be paid.
                 if (!feeRecord) {
@@ -1919,9 +1926,9 @@ class ProgramManager {
             imports = merged;
         }
 
-        if (options.executionRequests && options.executionRequests.length > 0) {
+        if (executionRequests.length > 0) {
             return WasmProgramManager.buildProvingRequestFromExecutionRequest(
-                options.executionRequests,
+                executionRequests,
                 undefined,  // fee_request — handled separately if needed
                 broadcast,
             );

--- a/sdk/tests/external-signing.test.ts
+++ b/sdk/tests/external-signing.test.ts
@@ -1,11 +1,15 @@
 import { expect } from "chai";
 import {
     Address,
+    Authorization,
     ExecutionRequest,
     Field,
     Group,
     Plaintext,
     PrivateKey,
+    Program,
+    ProgramImportsBuilder,
+    ProgramManagerBase,
     RecordPlaintext,
     Signature,
     ViewKey,
@@ -34,6 +38,7 @@ import {
     addressString,
     beaconPrivateKeyString,
 } from "./data/account-data.js";
+import { MULTIPLY_PROGRAM, DOUBLE_PROGRAM } from "./data/test-programs.js";
 
 const message = Uint8Array.from([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]);
 
@@ -553,6 +558,123 @@ describe('External Signing ExecutionRequest integration', () => {
             signedRequest.input_ids(),
         );
         expect(externallySignedFromInputIds.toString()).to.equal(signedRequest.toString());
+    });
+
+    it('Should match ExecutionRequest.sign for nested transfer', async () => {
+        // Deploy scenario: double_test.aleo (parent) calls multiply_test.aleo/multiply (child).
+
+        const privateKey = PrivateKey.from_string(privateKeyStr);
+        const viewKey = ViewKey.from_private_key(privateKey);
+        const address = Address.from_private_key(privateKey);
+
+        // --- Part 1: mocked nested authorization via sampleAuthorization ---
+        const ChildProgramName = "multiply_test.aleo";
+        const ParentProgramName = "double_test.aleo";
+        const imports = new ProgramImportsBuilder();
+        imports.addProgram(ChildProgramName, MULTIPLY_PROGRAM);
+        imports.addProgram(ParentProgramName, DOUBLE_PROGRAM);
+
+        const parentInputs = ["5u32"];
+        const parentInputTypes = ["u32.private"];
+        const parentFunctionName = "double_it";
+
+        // sampleAuthorization traverses the call graph without a private key and produces one
+        // mocked request per transition: double_it (root) + multiply (child) = 2 requests.
+        const authorization = await ProgramManagerBase.sampleAuthorization(
+            address,
+            DOUBLE_PROGRAM,
+            parentFunctionName,
+            parentInputs,
+            undefined,  // legacy imports object (unused when program_imports is provided)
+            undefined,  // edition (defaults to 1)
+            imports,
+        );
+
+        // The authorization must contain exactly two requests: one for each transition.
+        expect(authorization.len()).to.equal(2);
+        expect(authorization.isEmpty()).to.equal(false);
+        expect(authorization.functionName()).to.equal(parentFunctionName);
+
+        // Round-trip through string serialization.
+        const roundTripped = Authorization.fromString(authorization.toString());
+        expect(roundTripped.len()).to.equal(2);
+        expect(roundTripped.equals(authorization)).to.equal(true);
+
+        // --- Part 2: verify the external-signing pipeline ---
+
+        // computeExternalSigningInputs returns the per-input data an external signer needs
+        // to construct a matching request without running the full WASM stack locally.
+        const externalInputs = await computeExternalSigningInputs({
+            programName: ParentProgramName,
+            functionName: parentFunctionName,
+            inputs: parentInputs,
+            inputTypes: parentInputTypes,
+            isRoot: true,
+            checksum: null,
+        });
+        expect(externalInputs.isRoot).to.equal(true);
+        let signedParentRequest = authorization.requests()[0];
+        let signedParentRequest_2 = authorization.requests()[1];
+        expect(externalInputs.requestInputs.length).to.equal(signedParentRequest.inputs().length);
+
+        // fromExternallySignedDataWithViewKey reconstructs the full request from the
+        // signature + tvk + view key and must produce a request identical to the original.
+        const externallySignedParentRequest = ExecutionRequest.fromExternallySignedDataWithViewKey(
+            ParentProgramName,
+            parentFunctionName,
+            parentInputs,
+            parentInputTypes,
+            signedParentRequest.signature(),
+            signedParentRequest.tvk(),
+            signedParentRequest.signer(),
+            signedParentRequest.sk_tag(),
+            viewKey,
+        );
+    
+        // NOTE: the input_ids, tcm and scm will be different from the
+        // signedParentRequest because stack.sample_authorization sampled a
+        // random view_key.
+        expect(externallySignedParentRequest.signer().toString()).to.equal(signedParentRequest.signer().toString());
+        expect(externallySignedParentRequest.signature().toString()).to.equal(signedParentRequest.signature().toString());
+        expect(externallySignedParentRequest.tvk().toString()).to.equal(signedParentRequest.tvk().toString());
+        expect(externallySignedParentRequest.sk_tag().toString()).to.equal(signedParentRequest.sk_tag().toString());
+        expect(externallySignedParentRequest.inputs().length).to.equal(signedParentRequest.inputs().length);
+
+        // --- Part 3: reconstruct the child request (multiply_test.aleo/multiply) ---
+        // Resolve child inputs directly from the mocked request — Request::sample preserves
+        // the actual computed values passed by the parent call instruction.
+        const childInputs = Array.from(signedParentRequest_2.inputs() as ArrayLike<any>)
+            .map((v: any) => v.toString());
+
+        // Derive input types from the child program's function definition so the test
+        // stays correct even if the program signature changes.
+        const childProgram = Program.fromString(MULTIPLY_PROGRAM);
+        const childFunctionInputDefs = Array.from(childProgram.getFunctionInputs("multiply")) as any[];
+        const childInputTypes = childFunctionInputDefs.map((def: any) => `${def.type}.${def.visibility}`);
+
+        // ViewKey is taken by value (consumed) in Part 2; create a fresh instance for Part 3.
+        const viewKeyForChild = ViewKey.from_private_key(privateKey);
+
+        const externallySignedChildRequest = ExecutionRequest.fromExternallySignedDataWithViewKey(
+            ChildProgramName,
+            "multiply",
+            childInputs,
+            childInputTypes,
+            signedParentRequest_2.signature(),
+            signedParentRequest_2.tvk(),      // child's own tvk
+            signedParentRequest_2.signer(),
+            signedParentRequest_2.sk_tag(),
+            viewKeyForChild,
+            undefined,                        // no record inputs → no gammas
+            signedParentRequest.tvk(),        // root_tvk = parent's tvk
+        );
+
+        // Signer, tvk, sk_tag, and signature come directly from the mocked request and
+        // must be reproduced verbatim by the reconstruction.
+        expect(externallySignedChildRequest.signer().toString()).to.equal(signedParentRequest_2.signer().toString());
+        expect(externallySignedChildRequest.tvk().toString()).to.equal(signedParentRequest_2.tvk().toString());
+        expect(externallySignedChildRequest.sk_tag().toString()).to.equal(signedParentRequest_2.sk_tag().toString());
+        expect(externallySignedChildRequest.signature().toString()).to.equal(signedParentRequest_2.signature().toString());
     });
 
     it('Should match ExecutionRequest.sign for transfer_private', async () => {

--- a/sdk/tests/external-signing.test.ts
+++ b/sdk/tests/external-signing.test.ts
@@ -10,6 +10,7 @@ import {
     Program,
     ProgramImportsBuilder,
     ProgramManagerBase,
+    ProvingRequest,
     RecordPlaintext,
     Signature,
     ViewKey,
@@ -614,7 +615,7 @@ describe('External Signing ExecutionRequest integration', () => {
         });
         expect(externalInputs.isRoot).to.equal(true);
         let signedParentRequest = authorization.requests()[0];
-        let signedParentRequest_2 = authorization.requests()[1];
+        let signedChildRequest = authorization.requests()[1];
         expect(externalInputs.requestInputs.length).to.equal(signedParentRequest.inputs().length);
 
         // fromExternallySignedDataWithViewKey reconstructs the full request from the
@@ -643,7 +644,7 @@ describe('External Signing ExecutionRequest integration', () => {
         // --- Part 3: reconstruct the child request (multiply_test.aleo/multiply) ---
         // Resolve child inputs directly from the mocked request — Request::sample preserves
         // the actual computed values passed by the parent call instruction.
-        const childInputs = Array.from(signedParentRequest_2.inputs() as ArrayLike<any>)
+        const childInputs = Array.from(signedChildRequest.inputs() as ArrayLike<any>)
             .map((v: any) => v.toString());
 
         // Derive input types from the child program's function definition so the test
@@ -660,21 +661,49 @@ describe('External Signing ExecutionRequest integration', () => {
             "multiply",
             childInputs,
             childInputTypes,
-            signedParentRequest_2.signature(),
-            signedParentRequest_2.tvk(),      // child's own tvk
-            signedParentRequest_2.signer(),
-            signedParentRequest_2.sk_tag(),
+            signedChildRequest.signature(),
+            signedChildRequest.tvk(),      // child's own tvk
+            signedChildRequest.signer(),
+            signedChildRequest.sk_tag(),
             viewKeyForChild,
             undefined,                        // no record inputs → no gammas
             signedParentRequest.tvk(),        // root_tvk = parent's tvk
         );
 
-        // Signer, tvk, sk_tag, and signature come directly from the mocked request and
-        // must be reproduced verbatim by the reconstruction.
-        expect(externallySignedChildRequest.signer().toString()).to.equal(signedParentRequest_2.signer().toString());
-        expect(externallySignedChildRequest.tvk().toString()).to.equal(signedParentRequest_2.tvk().toString());
-        expect(externallySignedChildRequest.sk_tag().toString()).to.equal(signedParentRequest_2.sk_tag().toString());
-        expect(externallySignedChildRequest.signature().toString()).to.equal(signedParentRequest_2.signature().toString());
+        // Signer, tvk, sk_tag, and signature come directly from the passed parameters and
+        // must be reproduced verbatim by the reconstruction regardless of tcm/scm.
+        //
+        // NOTE: sampleAuthorization uses Request::sample which randomises tcm and scm
+        // independently of tvk, so tcm/scm equality cannot be asserted here.  The
+        // root_tvk parameter is needed for REAL child requests (signed via
+        // ExecutionRequest.sign with is_root:false) where scm = hash(signer, root_tvk).
+        expect(externallySignedChildRequest.signer().toString()).to.equal(signedChildRequest.signer().toString());
+        expect(externallySignedChildRequest.tvk().toString()).to.equal(signedChildRequest.tvk().toString());
+        expect(externallySignedChildRequest.sk_tag().toString()).to.equal(signedChildRequest.sk_tag().toString());
+        expect(externallySignedChildRequest.signature().toString()).to.equal(signedChildRequest.signature().toString());
+
+        // --- Part 4: bundle both signed requests into a ProvingRequest (Request variant) ---
+        //
+        // The root (double_it) and child (multiply) requests are passed together so the DPS
+        // server can authorize the full nested call graph in one shot.
+        const provingRequest = ProgramManagerBase.buildProvingRequestFromExecutionRequest(
+            [signedParentRequest, signedChildRequest],
+            undefined,  // no fee request
+            false,      // don't broadcast
+        );
+
+        expect(provingRequest.kind()).to.equal("request");
+        const prRequests = provingRequest.requests();
+        expect(prRequests.length).to.equal(2);
+
+        // Requests are returned in the same order they were passed in.
+        expect(Array.from(prRequests as ArrayLike<any>)[0].program_id()).to.equal(ParentProgramName);
+        expect(Array.from(prRequests as ArrayLike<any>)[1].program_id()).to.equal(ChildProgramName);
+
+        // Serialization round-trip preserves both requests.
+        const roundTrippedPR = ProvingRequest.fromString(provingRequest.toString());
+        expect(roundTrippedPR.kind()).to.equal("request");
+        expect(roundTrippedPR.requests().length).to.equal(2);
     });
 
     it('Should match ExecutionRequest.sign for transfer_private', async () => {

--- a/sdk/tests/network-client.test.ts
+++ b/sdk/tests/network-client.test.ts
@@ -842,7 +842,7 @@ describe("submitProvingRequestSafe variant routing", () => {
             true,
             false,
         );
-        return ProvingRequest.fromRequest(executionRequest, undefined, false);
+        return ProvingRequest.fromRequests([executionRequest], undefined, false);
     }
 
     beforeEach(() => {

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -343,7 +343,7 @@ describe('Program Manager', async () => {
                 priorityFee: 0,
                 privateFee: false,
                 broadcast: false,
-                executionRequests: [executionRequest],
+                executionRequest: executionRequest,
             });
 
             expect(provingRequest.kind()).equal("request");

--- a/sdk/tests/program-manager.test.ts
+++ b/sdk/tests/program-manager.test.ts
@@ -343,13 +343,12 @@ describe('Program Manager', async () => {
                 priorityFee: 0,
                 privateFee: false,
                 broadcast: false,
-                executionRequest,
+                executionRequests: [executionRequest],
             });
 
-            const authorization = provingRequest.authorization();
-            expect(authorization.len()).equal(1);
-            expect(authorization.transitions().length).equal(1);
-            expect(provingRequest.feeAuthorization()).equal(undefined);
+            expect(provingRequest.kind()).equal("request");
+            expect(provingRequest.requests().length).equal(1);
+            expect(provingRequest.feeRequest()).equal(undefined);
         });
 
         it('Should build correct authorizations', async () => {

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -629,9 +629,9 @@ describe('WASM Objects', () => {
     describe('Set development consensus version heights', () => {
         it('Consensus version heights can be set externally', async () => {
             if (process.env["RUN_SKIPPED"]) {
-                const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14");
+                const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15");
                 console.log(heights);
-                expect(heights).to.deep.equal([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14]);
+                expect(heights).to.deep.equal([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]);
             }
         });
     });

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@provablehq/wasm",
   "version": "0.11.1",
-  "type": "module",
+  
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [
     "The Provable Team"

--- a/wasm/src/programs/manager/authorize.rs
+++ b/wasm/src/programs/manager/authorize.rs
@@ -17,6 +17,7 @@
 use super::*;
 
 use crate::{
+    Address,
     Authorization,
     ExecutionRequest,
     PrivateKey,
@@ -26,6 +27,7 @@ use crate::{
     log,
     process_inputs,
     types::native::{
+        AddressNative,
         AuthorizationNative,
         CallStackNative,
         CurrentAleo,
@@ -204,6 +206,71 @@ impl ProgramManager {
             }
             None => process.authorize_request::<CurrentAleo, _>(request_native, rng).map_err(|e| e.to_string())?,
         };
+
+        Ok(Authorization::from(authorization))
+    }
+
+    /// Produce a mocked `Authorization` for a program function call without needing a private key.
+    ///
+    /// The resulting Authorization has the same structure as a real one — the call graph is fully
+    /// traversed and a request is created for every transition (root + all nested calls). The
+    /// individual input IDs may be incorrect (they are sampled, not signed), but the authorization
+    /// is sufficient for computing execution cost or testing nested call structures.
+    ///
+    /// @param {Address} address The address used as the signer in the mocked requests.
+    /// @param {string} program The program source code containing the entry function.
+    /// @param {string} function_name The entry function to authorize.
+    /// @param {Array} inputs A javascript array of inputs to the function.
+    /// @param {Object | undefined} imports The imports to the program in `{"name.aleo":"source"}` format.
+    /// @param {number | undefined} edition The program edition (defaults to 1).
+    /// @param {ProgramImports | undefined} program_imports Pre-loaded imports builder.
+    #[wasm_bindgen(js_name = sampleAuthorization)]
+    pub async fn sample_authorization(
+        address: &Address,
+        program: &str,
+        function_name: &str,
+        inputs: Array,
+        imports: Option<Object>,
+        edition: Option<u16>,
+        program_imports: Option<ProgramImports>,
+    ) -> Result<Authorization, String> {
+        let edition = edition.unwrap_or(1);
+
+        let mut resolved = ResolvedProcess::resolve(&program_imports, program, edition, imports)?;
+        let program_native = resolved.program().clone();
+        let process = resolved.process_mut();
+
+        let rng = &mut rand::rng();
+
+        // Parse inputs as strings (same pattern as the authorize! macro).
+        let inputs_native = process_inputs!(inputs);
+
+        // Parse the function name.
+        let function_name_native = IdentifierNative::from_str(function_name)
+            .map_err(|_| "The function name provided was invalid".to_string())?;
+
+        // Ensure the top-level program is in the process.
+        if program_native.id().to_string() != "credits.aleo" && !process.contains_program(program_native.id()) {
+            log("Adding program to the process");
+            process.lock().add_program_with_edition(&program_native, edition).map_err(|e| e.to_string())?;
+        }
+
+        // Get the stack for the top-level program.
+        let stack = process.get_stack(program_native.id()).map_err(|e| e.to_string())?;
+
+        let address_native = AddressNative::from(address);
+        let program_id = *program_native.id();
+
+        // Traverse the call graph and produce one mocked request per transition.
+        let authorization = stack
+            .sample_authorization::<CurrentAleo, _>(
+                address_native,
+                program_id,
+                function_name_native,
+                inputs_native.into_iter(),
+                rng,
+            )
+            .map_err(|e| e.to_string())?;
 
         Ok(Authorization::from(authorization))
     }

--- a/wasm/src/programs/manager/execute.rs
+++ b/wasm/src/programs/manager/execute.rs
@@ -53,7 +53,7 @@ use snarkvm_console::{
     program::{Value, ValueType},
 };
 use snarkvm_ledger_query::QueryTrait;
-use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost, execution_cost_for_authorization};
+use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost, execution_cost_for_authorization, execution_cost_for_call};
 
 use crate::types::native::{PrivateKeyNative, ViewKeyNative};
 use core::ops::Add;

--- a/wasm/src/programs/manager/execute.rs
+++ b/wasm/src/programs/manager/execute.rs
@@ -53,7 +53,7 @@ use snarkvm_console::{
     program::{Value, ValueType},
 };
 use snarkvm_ledger_query::QueryTrait;
-use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost, execution_cost_for_authorization, execution_cost_for_call};
+use snarkvm_synthesizer::prelude::{InclusionVersion, execution_cost, execution_cost_for_authorization};
 
 use crate::types::native::{PrivateKeyNative, ViewKeyNative};
 use core::ops::Add;

--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -25,7 +25,7 @@ use crate::{
     authorize_fee,
     log,
     process_inputs,
-    types::native::{AuthorizationNative, CurrentAleo, IdentifierNative, ProgramNative, RecordPlaintextNative},
+    types::native::{CurrentAleo, IdentifierNative, ProgramNative, RecordPlaintextNative},
 };
 
 use js_sys::{Array, Object};
@@ -149,7 +149,6 @@ mod tests {
     use crate::{
         ExecutionRequest,
         PrivateKey,
-        Program,
         array,
         test::{PUZZLE_SPINNER_V002, generate_puzzle_imports, generate_puzzle_inputs, get_env},
     };
@@ -181,8 +180,7 @@ mod tests {
         let request = transfer_public_execution_request();
         let requests = array![request];
 
-        let proving_request =
-            ProgramManager::proving_request_from_execution_request(requests, None, false).unwrap();
+        let proving_request = ProgramManager::proving_request_from_execution_request(requests, None, false).unwrap();
 
         assert_eq!(proving_request.kind(), "request");
         let reqs = proving_request.requests().unwrap();

--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -122,40 +122,24 @@ impl ProgramManager {
         Ok(ProvingRequest::from((authorization, fee_authorization, broadcast)))
     }
 
-    /// Build a proving request from a `Request` object. By default this method currently uses the feemaster.
+    /// Build a `ProvingRequest` (Request variant) directly from one or more signed
+    /// `ExecutionRequest` objects without performing local authorization.
     ///
-    /// @param {ExecutionRequest} request The execution request to build the authorization from.
-    /// @param {string} program The program source code containing the function to authorize.
-    /// @param {boolean} unchecked Whether or not to generate an unchecked authorization.
-    /// @param {boolean} broadcast Whether or not to broadcast the transaction.
-    /// @param {number | undefined} edition The edition of the program.
-    /// @param {object | undefined} imports The imports to the program in the format {"programname.aleo":"aleo instructions source code"}.
-    /// @param {PrivateKey | undefined} [private_key] Optional private key of the signer. If not provided, functions which call other programs may not succeed.
+    /// The resulting `ProvingRequest` is in the `Request` variant — the DPS server
+    /// will call `Process::authorize_request` server-side before proving.  Pass all
+    /// requests for a call graph in order (root first, then children) to support
+    /// nested calls.
+    ///
+    /// @param {ExecutionRequest[]} requests JS array of signed requests (root first).
+    /// @param {ExecutionRequest | undefined} fee_request Optional signed fee request.
+    /// @param {boolean} broadcast Whether to broadcast the transaction after proving.
     #[wasm_bindgen(js_name = buildProvingRequestFromExecutionRequest)]
-    pub async fn proving_request_from_execution_request(
-        request: &ExecutionRequest,
-        program: &str,
-        unchecked: bool,
+    pub fn proving_request_from_execution_request(
+        requests: Array,
+        fee_request: Option<ExecutionRequest>,
         broadcast: bool,
-        edition: Option<u16>,
-        imports: Option<Object>,
-        private_key: Option<PrivateKey>,
-        program_imports: Option<ProgramImports>,
     ) -> Result<ProvingRequest, String> {
-        let authorization = ProgramManager::authorize_request(
-            request,
-            program,
-            unchecked,
-            edition,
-            imports,
-            private_key,
-            program_imports,
-        )
-        .await
-        .map_err(|e| e.to_string())?;
-
-        // Return the proving request.
-        Ok(ProvingRequest::from((AuthorizationNative::from(authorization), None, broadcast)))
+        ProvingRequest::from_requests(requests, fee_request, broadcast)
     }
 }
 
@@ -193,31 +177,19 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    async fn test_proving_request_from_execution_request() {
+    fn test_proving_request_from_execution_request() {
         let request = transfer_public_execution_request();
-        let private_key =
-            PrivateKey::from_string("APrivateKey1zkp7Vc4xJt8HqW9U7VhY6h32d8Z9Xi5C6ZZX3gtXxbBSJmj").unwrap();
-        let program = Program::get_credits_program();
-        let program_str = program.to_string();
+        let requests = array![request];
 
-        let proving_request = ProgramManager::proving_request_from_execution_request(
-            &request,
-            &program_str,
-            false,
-            false,
-            Some(1),
-            None,
-            Some(private_key),
-            None,
-        )
-        .await
-        .unwrap();
+        let proving_request =
+            ProgramManager::proving_request_from_execution_request(requests, None, false).unwrap();
 
-        let authorization = proving_request.authorization().unwrap();
-        assert_eq!(authorization.len(), 1, "transfer_public should have 1 request");
-        assert_eq!(authorization.transitions().length(), 1, "transfer_public should have 1 transition");
-        // No fee authorization when built from ExecutionRequest (fee is paid by fee master or handled separately).
-        assert!(proving_request.fee_authorization().is_none());
+        assert_eq!(proving_request.kind(), "request");
+        let reqs = proving_request.requests().unwrap();
+        assert_eq!(reqs.length(), 1, "should wrap exactly one request");
+        // No fee request when none is provided.
+        assert!(proving_request.fee_request().is_none());
+        assert_eq!(proving_request.broadcast(), false);
     }
 
     #[wasm_bindgen_test]

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -302,11 +302,12 @@ impl ExecutionRequest {
     /// @param {string[]} inputs The inputs to the function.
     /// @param {string[]} input_types The input types of the function.
     /// @param {Signature} signature The externally-computed signature.
-    /// @param {Field} tvk The transition view key.
+    /// @param {Field} tvk The transition's own view key.
     /// @param {Address} signer The signer address.
     /// @param {Field} sk_tag The tag secret key.
     /// @param {Field[] | undefined} record_view_keys Pre-computed record view keys (required when there are record inputs).
     /// @param {Group[] | undefined} gammas An array of gammas (required when there are record inputs).
+    /// @param {Field | undefined} root_tvk The tvk of the root (top-level) transition. Pass `undefined` for root requests; required for child (non-root) requests to correctly compute scm.
     #[wasm_bindgen(js_name = "fromExternallySignedData")]
     #[allow(clippy::too_many_arguments)]
     pub fn from_externally_signed_data(
@@ -320,9 +321,10 @@ impl ExecutionRequest {
         sk_tag: Field,
         record_view_keys: Option<Array>,
         gammas: Option<Array>,
+        root_tvk: Option<Field>,
     ) -> Result<ExecutionRequest, String> {
         let (program_id, function_name, inputs_native, input_types_native, scm, tcm, network_id, function_id) =
-            Self::parse_common_args(&program_id, &function_name, &inputs, &input_types, &signer, &tvk)?;
+            Self::parse_common_args(&program_id, &function_name, &inputs, &input_types, &signer, &tvk, root_tvk.as_ref())?;
 
         let mut record_view_keys_native =
             native_type_from_wasm_object_array!(record_view_keys.unwrap_or(Array::new()), Field, FieldNative)?;
@@ -365,11 +367,12 @@ impl ExecutionRequest {
     /// @param {string[]} inputs The inputs to the function.
     /// @param {string[]} input_types The input types of the function.
     /// @param {Signature} signature The externally-computed signature.
-    /// @param {Field} tvk The transition view key.
+    /// @param {Field} tvk The transition's own view key.
     /// @param {Address} signer The signer address.
     /// @param {Field} sk_tag The tag secret key.
     /// @param {ViewKey} view_key The view key of the signer.
     /// @param {Group[] | undefined} gammas An array of gammas (required when there are record inputs).
+    /// @param {Field | undefined} root_tvk The tvk of the root (top-level) transition. Pass `undefined` for root requests; required for child (non-root) requests to correctly compute scm.
     #[wasm_bindgen(js_name = "fromExternallySignedDataWithViewKey")]
     #[allow(clippy::too_many_arguments)]
     pub fn from_externally_signed_data_with_view_key(
@@ -383,9 +386,10 @@ impl ExecutionRequest {
         sk_tag: Field,
         view_key: ViewKey,
         gammas: Option<Array>,
+        root_tvk: Option<Field>,
     ) -> Result<ExecutionRequest, String> {
         let (program_id, function_name, inputs_native, input_types_native, scm, tcm, network_id, function_id) =
-            Self::parse_common_args(&program_id, &function_name, &inputs, &input_types, &signer, &tvk)?;
+            Self::parse_common_args(&program_id, &function_name, &inputs, &input_types, &signer, &tvk, root_tvk.as_ref())?;
 
         // Derive record_view_keys from the view key for each record input.
         let mut record_view_keys_native = Vec::new();
@@ -441,10 +445,11 @@ impl ExecutionRequest {
     /// @param {string[]} inputs The inputs to the function.
     /// @param {string[]} input_types The input types of the function.
     /// @param {Signature} signature The externally-computed signature.
-    /// @param {Field} tvk The transition view key.
+    /// @param {Field} tvk The transition's own view key.
     /// @param {Address} signer The signer address.
     /// @param {Field} sk_tag The tag secret key.
     /// @param {(Field | [Field, Group, Field, Field, Field])[]} input_ids Pre-computed input IDs.
+    /// @param {Field | undefined} root_tvk The tvk of the root (top-level) transition. Pass `undefined` for root requests; required for child (non-root) requests to correctly compute scm.
     #[wasm_bindgen(js_name = "fromExternallySignedDataWithInputIds")]
     #[allow(clippy::too_many_arguments)]
     pub fn from_externally_signed_data_with_input_ids(
@@ -457,9 +462,10 @@ impl ExecutionRequest {
         signer: Address,
         sk_tag: Field,
         input_ids: Array,
+        root_tvk: Option<Field>,
     ) -> Result<ExecutionRequest, String> {
         let (program_id, function_name, inputs_native, input_types_native, scm, tcm, network_id, _function_id) =
-            Self::parse_common_args(&program_id, &function_name, &inputs, &input_types, &signer, &tvk)?;
+            Self::parse_common_args(&program_id, &function_name, &inputs, &input_types, &signer, &tvk, root_tvk.as_ref())?;
 
         if input_ids.length() as usize != inputs_native.len() {
             return Err(format!(
@@ -779,6 +785,13 @@ impl ExecutionRequest {
 /// Private helper methods shared by the three `fromExternallySignedData*` methods.
 impl ExecutionRequest {
     /// Parses and validates the common arguments shared by all three externally-signed methods.
+    ///
+    /// `root_tvk` controls the `scm` computation.  In snarkVM, `Request::sign` always computes:
+    ///   - `tcm = hash_psd2([own_tvk])`          — uses the transition's *own* tvk
+    ///   - `scm = hash_psd2([signer_x, root_tvk])` — uses the root tvk (= own tvk for root requests)
+    ///
+    /// When `root_tvk` is `None` it defaults to `tvk`, which is correct for root requests.
+    /// For child (non-root) requests, pass the parent's tvk as `root_tvk`.
     fn parse_common_args(
         program_id: &str,
         function_name: &str,
@@ -786,6 +799,7 @@ impl ExecutionRequest {
         input_types: &Array,
         signer: &Address,
         tvk: &Field,
+        root_tvk: Option<&Field>,
     ) -> Result<
         (
             ProgramIDNative,
@@ -825,8 +839,10 @@ impl ExecutionRequest {
             input_types_native.push(input_type);
         }
 
-        let scm =
-            CurrentNetwork::hash_psd2(&[*signer.to_group().to_x_coordinate(), **tvk]).map_err(|e| e.to_string())?;
+        // tcm uses the transition's own tvk; scm uses root_tvk (defaults to own tvk for root requests).
+        let root_tvk_for_scm = root_tvk.unwrap_or(tvk);
+        let scm = CurrentNetwork::hash_psd2(&[*signer.to_group().to_x_coordinate(), **root_tvk_for_scm])
+            .map_err(|e| e.to_string())?;
         let tcm = CurrentNetwork::hash_psd2(&[**tvk]).map_err(|e| e.to_string())?;
 
         let network_id = U16Native::new(CurrentNetwork::ID);

--- a/wasm/src/programs/request.rs
+++ b/wasm/src/programs/request.rs
@@ -324,7 +324,15 @@ impl ExecutionRequest {
         root_tvk: Option<Field>,
     ) -> Result<ExecutionRequest, String> {
         let (program_id, function_name, inputs_native, input_types_native, scm, tcm, network_id, function_id) =
-            Self::parse_common_args(&program_id, &function_name, &inputs, &input_types, &signer, &tvk, root_tvk.as_ref())?;
+            Self::parse_common_args(
+                &program_id,
+                &function_name,
+                &inputs,
+                &input_types,
+                &signer,
+                &tvk,
+                root_tvk.as_ref(),
+            )?;
 
         let mut record_view_keys_native =
             native_type_from_wasm_object_array!(record_view_keys.unwrap_or(Array::new()), Field, FieldNative)?;
@@ -389,7 +397,15 @@ impl ExecutionRequest {
         root_tvk: Option<Field>,
     ) -> Result<ExecutionRequest, String> {
         let (program_id, function_name, inputs_native, input_types_native, scm, tcm, network_id, function_id) =
-            Self::parse_common_args(&program_id, &function_name, &inputs, &input_types, &signer, &tvk, root_tvk.as_ref())?;
+            Self::parse_common_args(
+                &program_id,
+                &function_name,
+                &inputs,
+                &input_types,
+                &signer,
+                &tvk,
+                root_tvk.as_ref(),
+            )?;
 
         // Derive record_view_keys from the view key for each record input.
         let mut record_view_keys_native = Vec::new();
@@ -465,7 +481,15 @@ impl ExecutionRequest {
         root_tvk: Option<Field>,
     ) -> Result<ExecutionRequest, String> {
         let (program_id, function_name, inputs_native, input_types_native, scm, tcm, network_id, _function_id) =
-            Self::parse_common_args(&program_id, &function_name, &inputs, &input_types, &signer, &tvk, root_tvk.as_ref())?;
+            Self::parse_common_args(
+                &program_id,
+                &function_name,
+                &inputs,
+                &input_types,
+                &signer,
+                &tvk,
+                root_tvk.as_ref(),
+            )?;
 
         if input_ids.length() as usize != inputs_native.len() {
             return Err(format!(
@@ -1098,6 +1122,7 @@ mod tests {
             signed_request.sk_tag(),
             view_key,
             None, // no record inputs
+            None,
         )
         .expect("from_externally_signed_data_with_view_key should succeed");
 
@@ -1149,6 +1174,7 @@ mod tests {
             signed_request.sk_tag(),
             view_key,
             Some(gammas),
+            None,
         )
         .expect("from_externally_signed_data_with_view_key should succeed");
 
@@ -1415,6 +1441,7 @@ mod tests {
             signed.sk_tag(),
             None, // no record_view_keys
             None, // no gammas
+            None,
         )
         .expect("fromExternallySignedData with no records should succeed");
 
@@ -1453,6 +1480,7 @@ mod tests {
             signed.sk_tag(),
             Some(record_view_keys),
             Some(gammas),
+            None,
         )
         .expect("fromExternallySignedData with records should succeed");
 
@@ -1482,6 +1510,7 @@ mod tests {
             signed.sk_tag(),
             view_key,
             None, // no record inputs
+            None,
         )
         .expect("fromExternallySignedDataWithViewKey with no records should succeed");
 
@@ -1514,6 +1543,7 @@ mod tests {
             signed.sk_tag(),
             view_key,
             Some(gammas),
+            None,
         )
         .expect("fromExternallySignedDataWithViewKey with records should succeed");
 
@@ -1565,6 +1595,7 @@ mod tests {
             signed.signer(),
             signed.sk_tag(),
             input_ids,
+            None,
         )
         .expect("fromExternallySignedDataWithInputIds with public inputs should succeed");
 
@@ -1644,6 +1675,7 @@ mod tests {
             signed.signer(),
             signed.sk_tag(),
             input_ids,
+            None,
         )
         .expect("fromExternallySignedDataWithInputIds with records should succeed");
 
@@ -1677,6 +1709,7 @@ mod tests {
             signed.sk_tag(),
             None, // missing record_view_keys
             Some(gammas),
+            None,
         );
         assert!(result.is_err(), "Should fail when record_view_keys missing for record inputs");
     }
@@ -1704,6 +1737,7 @@ mod tests {
             signed.signer(),
             signed.sk_tag(),
             input_ids,
+            None,
         );
         assert!(result.is_err(), "Should fail when input_ids length doesn't match inputs length");
     }
@@ -1738,6 +1772,7 @@ mod tests {
             signed.signer(),
             signed.sk_tag(),
             input_ids,
+            None,
         );
         assert!(result.is_err(), "Should fail when scalar Field passed for record input type");
         let err = match result {

--- a/wasm/src/record/record_ciphertext.rs
+++ b/wasm/src/record/record_ciphertext.rs
@@ -48,14 +48,13 @@ impl RecordCiphertext {
         // Bech32 is case-insensitive in the sense that mixed-case is rejected, but the canonical
         // form is all-lowercase. Some upstream sources hand us all-uppercase strings, which the
         // strict parser rejects, so we normalize to lowercase here before parsing.
-        let normalized = if record.chars().any(|c| c.is_ascii_uppercase()) && !record.chars().any(|c| c.is_ascii_lowercase()) {
-            record.to_ascii_lowercase()
-        } else {
-            record.to_string()
-        };
-        Self::from_str(&normalized).map_err(|_| {
-            format!("The record ciphertext string provided was invalid: {record}")
-        })
+        let normalized =
+            if record.chars().any(|c| c.is_ascii_uppercase()) && !record.chars().any(|c| c.is_ascii_lowercase()) {
+                record.to_ascii_lowercase()
+            } else {
+                record.to_string()
+            };
+        Self::from_str(&normalized).map_err(|_| format!("The record ciphertext string provided was invalid: {record}"))
     }
 
     /// Return the string representation of the record ciphertext
@@ -247,10 +246,7 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_invalid_strings() {
         let invalid_bech32 = "record2qqj3a67efazf0awe09grqqg44htnh9vaw7l729vl309c972x7ldquqq2k2cax8s7qsqqyqtpgvqqyqsq4seyrzvfa98fkggzccqr68af8e9m0q8rzeqh8a8aqql3a854v58sgrygdv4jn9s8ckwfd48vujrmv0rtfasqh8ygn88ch34ftck8szspvfpsqqszqzvxx9t8s9g66teeepgxmvnw5ymgapcwt2lpy9d5eus580k08wpq544jcl437wjv206u5pxst6few9ll4yhufwldgpx80rlwq8nhssqywmfsd85skg564vqhm3gxsp8q6r30udmqxrxmxx2v8xycdg8pn5ps3dhfvv";
-        assert_eq!(
-            RecordCiphertext::from_string("garbage").err(),
-            Some("The record ciphertext string provided was invalid".to_string())
-        );
+        assert!(RecordCiphertext::from_string("garbage").is_err());
         assert!(RecordCiphertext::from_string(invalid_bech32).is_err());
     }
 

--- a/wasm/src/record/record_ciphertext.rs
+++ b/wasm/src/record/record_ciphertext.rs
@@ -44,7 +44,18 @@ impl RecordCiphertext {
     /// @returns {RecordCiphertext} Record ciphertext
     #[wasm_bindgen(js_name = fromString)]
     pub fn from_string(record: &str) -> Result<RecordCiphertext, String> {
-        Self::from_str(record).map_err(|_| "The record ciphertext string provided was invalid".to_string())
+        // Self::from_str(record).map_err(|_| format!("The record ciphertext string provided was invalid: {}, backtrace: {}", record, std::backtrace::Backtrace::force_capture()))
+        // Bech32 is case-insensitive in the sense that mixed-case is rejected, but the canonical
+        // form is all-lowercase. Some upstream sources hand us all-uppercase strings, which the
+        // strict parser rejects, so we normalize to lowercase here before parsing.
+        let normalized = if record.chars().any(|c| c.is_ascii_uppercase()) && !record.chars().any(|c| c.is_ascii_lowercase()) {
+            record.to_ascii_lowercase()
+        } else {
+            record.to_string()
+        };
+        Self::from_str(&normalized).map_err(|_| {
+            format!("The record ciphertext string provided was invalid: {record}")
+        })
     }
 
     /// Return the string representation of the record ciphertext

--- a/wasm/src/synthesizer/authorization.rs
+++ b/wasm/src/synthesizer/authorization.rs
@@ -139,6 +139,19 @@ impl Authorization {
         self.0.insert_transition(transition).map_err(|e| e.to_string())
     }
 
+    /// Returns all `ExecutionRequest`s in the Authorization as a JS array.
+    ///
+    /// The requests are returned in order (index 0 is always the root request).
+    ///
+    /// @returns {Array<ExecutionRequest>}
+    pub fn requests(&self) -> Array {
+        self.0
+            .to_vec_deque()
+            .into_iter()
+            .map(|request| JsValue::from(ExecutionRequest::from(request)))
+            .collect::<Array>()
+    }
+
     /// Get the transitions in an Authorization.
     ///
     /// @returns {Array<Transition>} Array of transition objects

--- a/wasm/src/synthesizer/proving_request.rs
+++ b/wasm/src/synthesizer/proving_request.rs
@@ -21,7 +21,8 @@ use crate::{
 };
 use snarkvm_wasm::utilities::ToBytes;
 
-use js_sys::Uint8Array;
+use js_sys::{Array, Uint8Array};
+use wasm_bindgen::{JsValue, convert::TryFromJsValue};
 use std::{
     fmt::{Debug, Display},
     ops::Deref,
@@ -56,25 +57,31 @@ impl ProvingRequest {
         ProvingRequest(ProvingRequestNative::new(authorization, fee_authorization, broadcast))
     }
 
-    /// Creates a new Request-variant `ProvingRequest` from a single signed
-    /// `ExecutionRequest` and an optional signed fee `ExecutionRequest`.
+    /// Creates a new Request-variant `ProvingRequest` from a JS array of signed
+    /// `ExecutionRequest`s and an optional signed fee `ExecutionRequest`.
     ///
     /// The Request variant is processed by the DPS at the `/prove/request`
     /// endpoint, which is encrypted-only. The server runs
-    /// `Process::authorize_request` to turn each `Request` into an
-    /// `Authorization` before proving.
+    /// `Process::authorize_request` to turn the requests into an `Authorization`
+    /// before proving. Supports nested calls by bundling all signed requests
+    /// (root + children) into a single `ProvingRequest`.
     ///
-    /// Only valid for single-public-request executions. Layered / nested
-    /// calls are not supported by `/prove/request` at this time.
-    ///
-    /// @param {ExecutionRequest} request The signed request for the function.
+    /// @param {ExecutionRequest[]} requests JS array of signed requests (root first, then children in call-graph order).
     /// @param {ExecutionRequest} fee_request Optional signed request for the fee function. When omitted, the prover generates and pays the fee.
     /// @param {boolean} broadcast Flag that indicates whether the remote proving service should attempt to submit the transaction on the caller's behalf.
-    #[wasm_bindgen(js_name = "fromRequest")]
-    pub fn from_request(request: ExecutionRequest, fee_request: Option<ExecutionRequest>, broadcast: bool) -> Self {
-        let request_native: RequestNative = request.into();
+    #[wasm_bindgen(js_name = "fromRequests")]
+    pub fn from_requests(requests: Array, fee_request: Option<ExecutionRequest>, broadcast: bool) -> Result<Self, String> {
+        let requests_native: Vec<RequestNative> = requests
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                ExecutionRequest::try_from_js_value(v)
+                    .map(RequestNative::from)
+                    .map_err(|_| format!("requests[{i}] is not a valid ExecutionRequest"))
+            })
+            .collect::<Result<Vec<_>, String>>()?;
         let fee_request_native: Option<RequestNative> = fee_request.map(Into::into);
-        ProvingRequest(ProvingRequestNative::new_request(request_native, fee_request_native, broadcast))
+        Ok(ProvingRequest(ProvingRequestNative::new_requests(requests_native, fee_request_native, broadcast)))
     }
 
     /// Returns the variant of this `ProvingRequest`: `"authorization"` or
@@ -157,15 +164,19 @@ impl ProvingRequest {
         self.0.fee_authorization().map(Authorization::from)
     }
 
-    /// Returns the signed `ExecutionRequest` carried by the Request variant.
+    /// Returns the signed `ExecutionRequest`s carried by the Request variant as
+    /// a JS array.
     ///
     /// @throws If this `ProvingRequest` is an Authorization variant. Check
     /// {@link ProvingRequest#kind} or use {@link ProvingRequest#authorization}
     /// instead.
-    pub fn request(&self) -> Result<ExecutionRequest, String> {
-        self.0.request().map(ExecutionRequest::from).ok_or_else(|| {
-            "ProvingRequest is an Authorization variant; call `authorization()` instead of `request()`".to_string()
-        })
+    pub fn requests(&self) -> Result<Array, String> {
+        self.0
+            .requests()
+            .map(|reqs| reqs.iter().map(|r| JsValue::from(ExecutionRequest::from(r))).collect::<Array>())
+            .ok_or_else(|| {
+                "ProvingRequest is an Authorization variant; call `authorization()` instead of `requests()`".to_string()
+            })
     }
 
     /// Returns the signed fee `ExecutionRequest` in the Request variant, or
@@ -318,12 +329,14 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_request_variant_construction_and_kind() {
         let request = sample_execution_request();
-        let proving_request = ProvingRequest::from_request(request, None, false);
+        let requests = array![request];
+        let proving_request = ProvingRequest::from_requests(requests, None, false).unwrap();
 
         assert_eq!(proving_request.kind(), "request");
         assert!(proving_request.0.is_request());
         assert!(!proving_request.0.is_authorization());
-        assert!(proving_request.request().is_ok());
+        let reqs = proving_request.requests().unwrap();
+        assert_eq!(reqs.length(), 1);
         assert!(proving_request.fee_request().is_none());
         assert_eq!(proving_request.broadcast(), false);
     }
@@ -331,7 +344,8 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_request_variant_byte_roundtrip() {
         let request = sample_execution_request();
-        let proving_request = ProvingRequest::from_request(request, None, true);
+        let requests = array![request];
+        let proving_request = ProvingRequest::from_requests(requests, None, true).unwrap();
 
         // Roundtrip via the explicit Request reader. Using `fromBytesLe`
         // (Authorization reader) on these bytes would fail or produce garbage,
@@ -348,7 +362,8 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_request_variant_string_roundtrip_autodetects() {
         let request = sample_execution_request();
-        let proving_request = ProvingRequest::from_request(request, None, false);
+        let requests = array![request];
+        let proving_request = ProvingRequest::from_requests(requests, None, false).unwrap();
 
         // JSON shape carries the variant — fromString picks the right one via
         // serde's untagged dispatch on disjoint field names.
@@ -362,7 +377,8 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_request_variant_accessors_throw_on_authorization_methods() {
         let request = sample_execution_request();
-        let proving_request = ProvingRequest::from_request(request, None, false);
+        let requests = array![request];
+        let proving_request = ProvingRequest::from_requests(requests, None, false).unwrap();
 
         // `authorization()` on a Request variant should be a clear error.
         let err = proving_request.authorization().expect_err("expected authorization() to error");
@@ -379,7 +395,7 @@ mod tests {
             let proving_request = ProvingRequest::from_string(PUZZLE_SPINNER_V002_PROVING_REQUEST.to_string()).unwrap();
             // `expect_err` requires `T: Debug`; `ExecutionRequest` doesn't impl
             // it, so use `.err().expect(...)` to extract the error message.
-            let err = proving_request.request().err().expect("expected request() to error");
+            let err = proving_request.requests().err().expect("expected requests() to error");
             assert!(err.contains("Authorization variant"), "error should mention Authorization variant: {err}");
             assert!(proving_request.fee_request().is_none());
         }

--- a/wasm/src/synthesizer/proving_request.rs
+++ b/wasm/src/synthesizer/proving_request.rs
@@ -22,13 +22,12 @@ use crate::{
 use snarkvm_wasm::utilities::ToBytes;
 
 use js_sys::{Array, Uint8Array};
-use wasm_bindgen::{JsValue, convert::TryFromJsValue};
 use std::{
     fmt::{Debug, Display},
     ops::Deref,
     str::FromStr,
 };
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{JsValue, convert::TryFromJsValue, prelude::*};
 
 /// Represents a proving request to a prover.
 ///
@@ -70,7 +69,11 @@ impl ProvingRequest {
     /// @param {ExecutionRequest} fee_request Optional signed request for the fee function. When omitted, the prover generates and pays the fee.
     /// @param {boolean} broadcast Flag that indicates whether the remote proving service should attempt to submit the transaction on the caller's behalf.
     #[wasm_bindgen(js_name = "fromRequests")]
-    pub fn from_requests(requests: Array, fee_request: Option<ExecutionRequest>, broadcast: bool) -> Result<Self, String> {
+    pub fn from_requests(
+        requests: Array,
+        fee_request: Option<ExecutionRequest>,
+        broadcast: bool,
+    ) -> Result<Self, String> {
         let requests_native: Vec<RequestNative> = requests
             .iter()
             .enumerate()

--- a/wasm/src/types/native/request/bytes.rs
+++ b/wasm/src/types/native/request/bytes.rs
@@ -41,8 +41,11 @@ impl ToBytes for ProvingRequestNative {
                 }
                 broadcast.write_le(&mut writer)?;
             }
-            Self::Request { request, fee_request, broadcast } => {
-                request.write_le(&mut writer)?;
+            Self::Request { requests, fee_request, broadcast } => {
+                (requests.len() as u32).write_le(&mut writer)?;
+                for request in requests {
+                    request.write_le(&mut writer)?;
+                }
                 match fee_request {
                     Some(req) => {
                         true.write_le(&mut writer)?;
@@ -84,15 +87,19 @@ impl ProvingRequestNative {
     }
 
     /// Reads bytes as the Request variant.
-    /// Layout: `request | bool | maybe(fee_request) | bool(broadcast)`.
+    /// Layout: `u32(len) | len*request | bool | maybe(fee_request) | bool(broadcast)`.
     pub fn read_request_le<R: Read>(mut reader: R) -> io::Result<Self> {
-        let request = RequestNative::read_le(&mut reader)?;
+        let len = u32::read_le(&mut reader)?;
+        let mut requests = Vec::with_capacity(len as usize);
+        for _ in 0..len {
+            requests.push(RequestNative::read_le(&mut reader)?);
+        }
         let has_fee_request = bool::read_le(&mut reader)?;
         let fee_request = match has_fee_request {
             false => None,
             true => Some(RequestNative::read_le(&mut reader)?),
         };
         let broadcast = bool::read_le(&mut reader)?;
-        Ok(Self::Request { request, fee_request, broadcast })
+        Ok(Self::Request { requests, fee_request, broadcast })
     }
 }

--- a/wasm/src/types/native/request/mod.rs
+++ b/wasm/src/types/native/request/mod.rs
@@ -40,7 +40,7 @@ pub enum ProvingRequestNative {
         broadcast: bool,
     },
     Request {
-        request: RequestNative,
+        requests: Vec<RequestNative>,
         fee_request: Option<RequestNative>,
         broadcast: bool,
     },
@@ -71,10 +71,10 @@ impl ProvingRequestNative {
         Self::Authorization { authorization, fee_authorization, broadcast }
     }
 
-    /// Creates a new Request-variant `ProvingRequestNative` from a single
-    /// signed `Request` and optional fee `Request`.
-    pub fn new_request(request: RequestNative, fee_request: Option<RequestNative>, broadcast: bool) -> Self {
-        Self::Request { request, fee_request, broadcast }
+    /// Creates a new Request-variant `ProvingRequestNative` from a vector of
+    /// signed `Request`s and an optional fee `Request`.
+    pub fn new_requests(requests: Vec<RequestNative>, fee_request: Option<RequestNative>, broadcast: bool) -> Self {
+        Self::Request { requests, fee_request, broadcast }
     }
 
     /// Returns the Authorization variant's inner authorization, or `None` if
@@ -95,11 +95,11 @@ impl ProvingRequestNative {
         }
     }
 
-    /// Returns the Request variant's inner request, or `None` if this is an
+    /// Returns the Request variant's requests slice, or `None` if this is an
     /// Authorization variant.
-    pub fn request(&self) -> Option<&RequestNative> {
+    pub fn requests(&self) -> Option<&[RequestNative]> {
         match self {
-            Self::Request { request, .. } => Some(request),
+            Self::Request { requests, .. } => Some(requests),
             Self::Authorization { .. } => None,
         }
     }
@@ -118,6 +118,12 @@ impl ProvingRequestNative {
         match self {
             Self::Authorization { broadcast, .. } | Self::Request { broadcast, .. } => *broadcast,
         }
+    }
+
+    /// Returns the first request in the Request variant, or `None`. Convenience
+    /// accessor for the single-request case (e.g. simple public transfers).
+    pub fn first_request(&self) -> Option<&RequestNative> {
+        self.requests()?.first()
     }
 
     /// Returns `true` if this is the Authorization variant.


### PR DESCRIPTION
## Motivation

The high level workflow:
1. `sampleAuthorization` samples inputs for the full call graph
2. `computeExternalSigningInputs` is called for every request
3. Signing and gamma computation in MPC can happen. This is left out of the test.
4. `fromExternallySignedDataWithViewKey` is called for every request
5. `buildProvingRequestFromExecutionRequest` prepares a submission to the delegated prover.
