### PR TITLE
feat: per-origin Kong session-affinity cookie jar in defaultTransport

### DIFF
--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -110,7 +110,7 @@ async function initializeWasm() {
 
 export { ProgramManager, ProvingRequestOptions, ExecuteOptions, FeeAuthorizationOptions, AuthorizationOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof, programChecksum } from "./program-manager.js";
 
-export { logAndThrow, TransportFunction } from "./utils/utils.js";
+export { logAndThrow, TransportFunction, defaultTransport, cookieAffinityTransport } from "./utils/utils.js";
 
 export { setLogLevel, getLogLevel } from "./utils/logger.js";
 export type { LogLevel } from "./utils/logger.js";

--- a/sdk/src/utils/index.ts
+++ b/sdk/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { logger, setLogLevel, getLogLevel } from "./logger.js";
 export type { LogLevel } from "./logger.js";
-export { logAndThrow, retryWithBackoff, environment, isNode, TransportFunction, defaultTransport } from "./utils.js";
+export { logAndThrow, retryWithBackoff, environment, isNode, TransportFunction, defaultTransport, cookieAffinityTransport } from "./utils.js";

--- a/sdk/src/utils/utils.ts
+++ b/sdk/src/utils/utils.ts
@@ -178,13 +178,21 @@ function storeSetCookies(origin: string | null, cookies: string[]) {
     }
 }
 
+/*
+ * Returns a fresh HeadersInit with `cookie` attached when the input doesn't
+ * already carry one. NEVER mutates the caller's input — a caller reusing the
+ * same Headers/init across calls to different origins must not see origin A's
+ * jar cookie persist into the call for origin B.
+ */
 function attachCookie(
     headersInit: HeadersInit | undefined,
     cookie: string,
 ): HeadersInit {
     if (isHeadersLike(headersInit)) {
-        if (!headersInit.has("cookie")) headersInit.set("cookie", cookie);
-        return headersInit;
+        if (headersInit.has("cookie")) return headersInit;
+        const cloned = new Headers(headersInit);
+        cloned.set("cookie", cookie);
+        return cloned;
     }
     if (Array.isArray(headersInit)) {
         const hasCookie = headersInit.some(
@@ -222,23 +230,32 @@ export const defaultTransport: TransportFunction = async (input, init) => {
     const origin = originOf(input as URL | string | Request);
     const cookie = cookieHeaderFor(origin);
     if (cookie) {
-        // Per the Fetch spec, an explicit `init.headers` REPLACES the
-        // Request input's headers when fetch builds the actual request.
-        // So if init.headers is provided, that's the only place worth
-        // attaching the cookie — attaching to input.headers would be
-        // silently discarded.
+        // Always operate on shallow clones so callers reusing the same
+        // `init` / `Headers` / `Request` across origins don't end up with
+        // origin A's jar cookie persisting into the object and blocking
+        // origin B's correct cookie.
         if (init?.headers !== undefined && init.headers !== null) {
-            init.headers = attachCookie(init.headers, cookie);
+            // init.headers, when explicitly set, REPLACES the Request's
+            // headers per the Fetch spec — attach there.
+            init = { ...init, headers: attachCookie(init.headers, cookie) };
         } else if (isRequestLike(input)) {
+            // Merge the Request's existing headers with the cookie and
+            // pass them via `init.headers` instead of mutating the
+            // Request itself. (Fetch spec: an explicit `init.headers`
+            // replaces Request.headers entirely, so we copy the
+            // originals into the merged set first.)
             try {
-                if (!input.headers.has("cookie"))
-                    input.headers.set("cookie", cookie);
+                const merged = new Headers(input.headers);
+                if (!merged.has("cookie")) {
+                    merged.set("cookie", cookie);
+                    init = { ...(init ?? {}), headers: merged };
+                }
             } catch {
-                // Some runtimes treat Request.headers as immutable; skip
-                // rather than failing the request.
+                // Some runtimes restrict Headers construction from a
+                // Request; skip rather than failing the request.
             }
         } else if (init) {
-            init.headers = attachCookie(undefined, cookie);
+            init = { ...init, headers: attachCookie(undefined, cookie) };
         } else {
             init = { headers: attachCookie(undefined, cookie) };
         }

--- a/sdk/src/utils/utils.ts
+++ b/sdk/src/utils/utils.ts
@@ -3,11 +3,17 @@ import { logger } from "./logger.js";
 function detectBrowser() {
     const userAgent = navigator.userAgent;
 
-    if (/chrome|crios|crmo/i.test(userAgent) && !/edge|edg|opr/i.test(userAgent)) {
+    if (
+        /chrome|crios|crmo/i.test(userAgent) &&
+        !/edge|edg|opr/i.test(userAgent)
+    ) {
         return "chrome";
     } else if (/firefox|fxios/i.test(userAgent)) {
         return "firefox";
-    } else if (/safari/i.test(userAgent) && !/chrome|crios|crmo|android/i.test(userAgent)) {
+    } else if (
+        /safari/i.test(userAgent) &&
+        !/chrome|crios|crmo|android/i.test(userAgent)
+    ) {
         return "safari";
     } else if (/edg/i.test(userAgent)) {
         return "edge";
@@ -19,19 +25,20 @@ function detectBrowser() {
 }
 
 export function isNode(): boolean {
-    return typeof process !== "undefined" &&
-    process.versions != null &&
-    process.versions.node != null;
+    return (
+        typeof process !== "undefined" &&
+        process.versions != null &&
+        process.versions.node != null
+    );
 }
 
 export function environment() {
-    if ((typeof process !== 'undefined') &&
-        (process.release?.name === 'node')) {
-        return 'node';
-    } else if (typeof window !== 'undefined') {
+    if (typeof process !== "undefined" && process.release?.name === "node") {
+        return "node";
+    } else if (typeof window !== "undefined") {
         return detectBrowser();
     } else {
-        return 'unknown';
+        return "unknown";
     }
 }
 
@@ -47,8 +54,187 @@ export function logAndThrow(message: string): never {
  */
 export type TransportFunction = typeof fetch;
 
-/** Default transport — wraps global fetch to avoid illegal-invocation errors in browsers. */
-export const defaultTransport: TransportFunction = (...args) => fetch(...args);
+/*
+ * Per-origin cookie jar used by `defaultTransport`.
+ *
+ * Some Aleo backends sit behind a gateway (e.g. Kong) that uses cookie-based
+ * session affinity: the server sets a routing cookie on the first response and
+ * expects it back on subsequent requests so per-session state stays on the same
+ * upstream instance. Browsers and iOS NSURLSession persist cookies automatically,
+ * but Node `fetch` and bare React Native do not — without a jar, those runtimes
+ * land on a random upstream per request.
+ *
+ * Only cookies named in `AFFINITY_COOKIE_NAMES` are captured. The jar is
+ * module-scoped — the same process shares routing cookies per origin — but the
+ * whitelist keeps unrelated cookies (auth, session, CSRF) out of it, so other
+ * SDK clients hitting the same origin can't accidentally inherit caller state.
+ *
+ * In a browser this jar is effectively a no-op: `Cookie` is a forbidden request
+ * header, so the manual value set here is dropped by the browser and the
+ * browser's own cookie store takes over.
+ */
+const AFFINITY_COOKIE_NAMES: ReadonlySet<string> = new Set(["route"]);
+const cookieJar = new Map<string, Map<string, string>>();
+
+function isRequestLike(value: unknown): value is Request {
+    return (
+        typeof Request !== "undefined" &&
+        value !== null &&
+        typeof value === "object" &&
+        value instanceof Request
+    );
+}
+
+function isHeadersLike(value: unknown): value is Headers {
+    return (
+        typeof Headers !== "undefined" &&
+        value !== null &&
+        typeof value === "object" &&
+        value instanceof Headers
+    );
+}
+
+function originOf(urlOrReq: URL | string | Request): string | null {
+    try {
+        const raw =
+            typeof urlOrReq === "string"
+                ? urlOrReq
+                : urlOrReq instanceof URL
+                  ? urlOrReq.toString()
+                  : isRequestLike(urlOrReq)
+                    ? urlOrReq.url
+                    : String(urlOrReq);
+        const parsed = new URL(raw);
+        return `${parsed.protocol}//${parsed.host}`;
+    } catch {
+        return null;
+    }
+}
+
+function cookieHeaderFor(origin: string | null): string | null {
+    if (!origin) return null;
+    const jar = cookieJar.get(origin);
+    if (!jar || jar.size === 0) return null;
+    const parts: string[] = [];
+    for (const [name, value] of jar) parts.push(`${name}=${value}`);
+    return parts.join("; ");
+}
+
+/*
+ * Reads Set-Cookie values from a fetch-style response in a defensive way.
+ * Existing test mocks return minimal response-like objects without a
+ * `headers` field, and Node's fetch surfaces multiple Set-Cookie headers via
+ * `getSetCookie()` (not `get('set-cookie')`, which returns null or a
+ * comma-joined string depending on the implementation).
+ */
+function readSetCookies(response: unknown): string[] {
+    if (!response || typeof response !== "object") return [];
+    const headers = (response as { headers?: unknown }).headers;
+    if (!headers || typeof headers !== "object") return [];
+    const getSetCookie = (headers as { getSetCookie?: () => string[] })
+        .getSetCookie;
+    if (typeof getSetCookie === "function") {
+        try {
+            const list = getSetCookie.call(headers);
+            if (Array.isArray(list) && list.length > 0) return list;
+        } catch {
+            // fall through to .get()
+        }
+    }
+    const get = (headers as { get?: (name: string) => string | null }).get;
+    if (typeof get !== "function") return [];
+    let raw: string | null;
+    try {
+        raw = get.call(headers, "set-cookie");
+    } catch {
+        return [];
+    }
+    return raw ? [raw] : [];
+}
+
+function storeSetCookies(origin: string | null, cookies: string[]) {
+    if (!origin || cookies.length === 0) return;
+    let jar: Map<string, string> | undefined;
+    for (const cookie of cookies) {
+        if (typeof cookie !== "string" || !cookie) continue;
+        const head = cookie.split(";")[0];
+        const eq = head.indexOf("=");
+        if (eq <= 0) continue;
+        const name = head.slice(0, eq).trim();
+        if (!AFFINITY_COOKIE_NAMES.has(name)) continue;
+        if (!jar) {
+            jar = cookieJar.get(origin);
+            if (!jar) {
+                jar = new Map();
+                cookieJar.set(origin, jar);
+            }
+        }
+        jar.set(name, head.slice(eq + 1).trim());
+    }
+}
+
+function attachCookie(
+    headersInit: HeadersInit | undefined,
+    cookie: string,
+): HeadersInit {
+    if (isHeadersLike(headersInit)) {
+        if (!headersInit.has("cookie")) headersInit.set("cookie", cookie);
+        return headersInit;
+    }
+    if (Array.isArray(headersInit)) {
+        const hasCookie = headersInit.some(
+            (pair) =>
+                Array.isArray(pair) &&
+                typeof pair[0] === "string" &&
+                pair[0].toLowerCase() === "cookie",
+        );
+        return hasCookie ? headersInit : [...headersInit, ["cookie", cookie]];
+    }
+    if (headersInit && typeof headersInit === "object") {
+        const hasCookie = Object.keys(headersInit).some(
+            (key) => key.toLowerCase() === "cookie",
+        );
+        return hasCookie ? headersInit : { ...headersInit, cookie };
+    }
+    return { cookie };
+}
+
+/**
+ * Default transport used by SDK HTTP helpers.
+ *
+ * Wraps the global `fetch` (avoiding illegal-invocation errors in browsers when
+ * `fetch` is passed around as a bare reference) and layers a per-origin cookie
+ * jar on top. Responses' `Set-Cookie` headers are captured (filtered by
+ * `AFFINITY_COOKIE_NAMES`) and replayed as a `Cookie` header on subsequent
+ * same-origin requests, which is required for backends that use cookie-based
+ * session affinity (see `cookieJar` above).
+ *
+ * A caller-supplied `Cookie` header is never overwritten — `network-client.ts`
+ * forwards the pubkey-response cookie manually onto delegated-prove requests
+ * for Node compatibility, and that path takes precedence over the jar.
+ */
+export const defaultTransport: TransportFunction = async (input, init) => {
+    const origin = originOf(input as URL | string | Request);
+    const cookie = cookieHeaderFor(origin);
+    if (cookie) {
+        if (isRequestLike(input)) {
+            try {
+                if (!input.headers.has("cookie"))
+                    input.headers.set("cookie", cookie);
+            } catch {
+                // Some runtimes treat Request.headers as immutable; skip
+                // rather than failing the request.
+            }
+        } else if (init) {
+            init.headers = attachCookie(init.headers, cookie);
+        } else {
+            init = { headers: attachCookie(undefined, cookie) };
+        }
+    }
+    const response = await fetch(input as RequestInfo, init);
+    storeSetCookies(origin, readSetCookies(response));
+    return response;
+};
 
 export function parseJSON(json: string): any {
     function revive(key: string, value: any, context: any) {
@@ -62,7 +248,11 @@ export function parseJSON(json: string): any {
     return JSON.parse(json, revive as any);
 }
 
-export async function get(url: URL | string, options?: RequestInit, transport: TransportFunction = defaultTransport) {
+export async function get(
+    url: URL | string,
+    options?: RequestInit,
+    transport: TransportFunction = defaultTransport,
+) {
     const response = await transport(url, options);
 
     if (!response.ok) {
@@ -72,7 +262,11 @@ export async function get(url: URL | string, options?: RequestInit, transport: T
     return response;
 }
 
-export async function post(url: URL | string, options: RequestInit, transport: TransportFunction = defaultTransport) {
+export async function post(
+    url: URL | string,
+    options: RequestInit,
+    transport: TransportFunction = defaultTransport,
+) {
     options.method = "POST";
 
     const response = await transport(url, options);
@@ -81,7 +275,7 @@ export async function post(url: URL | string, options: RequestInit, transport: T
         const error = await response.text();
         let message = `${response.status} error received from ${url}`;
         if (error) {
-            message = `${error}`
+            message = `${error}`;
         }
         throw new Error(message);
     }

--- a/sdk/src/utils/utils.ts
+++ b/sdk/src/utils/utils.ts
@@ -55,7 +55,7 @@ export function logAndThrow(message: string): never {
 export type TransportFunction = typeof fetch;
 
 /*
- * Per-origin cookie jar used by `defaultTransport`.
+ * Per-origin cookie jar used by `cookieAffinityTransport`.
  *
  * Some Aleo backends sit behind a gateway (e.g. Kong) that uses cookie-based
  * session affinity: the server sets a routing cookie on the first response and
@@ -109,6 +109,21 @@ function originOf(urlOrReq: URL | string | Request): string | null {
     } catch {
         return null;
     }
+}
+
+/*
+ * Derives the origin a response's `Set-Cookie` belongs to. `fetch` may follow
+ * redirects across origins (or http→https), in which case the final response
+ * headers belong to `response.url`'s origin, not the request input's. Returns
+ * null when the response has no usable `url` (e.g. the minimal response-like
+ * objects existing SDK tests stub fetch with), so callers can fall back to the
+ * request-derived origin.
+ */
+function responseOriginOf(response: unknown): string | null {
+    if (!response || typeof response !== "object") return null;
+    const url = (response as { url?: unknown }).url;
+    if (typeof url !== "string" || url.length === 0) return null;
+    return originOf(url);
 }
 
 function cookieHeaderFor(origin: string | null): string | null {
@@ -212,8 +227,17 @@ function attachCookie(
     return { cookie };
 }
 
+/** Default transport — wraps global fetch to avoid illegal-invocation errors in browsers. */
+export const defaultTransport: TransportFunction = (...args) => fetch(...args);
+
 /**
- * Default transport used by SDK HTTP helpers.
+ * Opt-in transport that layers a per-origin cookie jar on top of `fetch`.
+ *
+ * Not wired in by default — pass it explicitly as the `transport` option to
+ * `AleoNetworkClient`, `RecordScanner`, `AleoKeyProvider`, etc. (or to the
+ * `get`/`post` helpers) when talking to a backend that uses cookie-based
+ * session affinity. Browsers and iOS NSURLSession persist cookies on their own,
+ * so this is targeted at Node and bare React Native consumers.
  *
  * Wraps the global `fetch` (avoiding illegal-invocation errors in browsers when
  * `fetch` is passed around as a bare reference) and layers a per-origin cookie
@@ -226,7 +250,10 @@ function attachCookie(
  * forwards the pubkey-response cookie manually onto delegated-prove requests
  * for Node compatibility, and that path takes precedence over the jar.
  */
-export const defaultTransport: TransportFunction = async (input, init) => {
+export const cookieAffinityTransport: TransportFunction = async (
+    input,
+    init,
+) => {
     const origin = originOf(input as URL | string | Request);
     const cookie = cookieHeaderFor(origin);
     if (cookie) {
@@ -261,7 +288,12 @@ export const defaultTransport: TransportFunction = async (input, init) => {
         }
     }
     const response = await fetch(input as RequestInfo, init);
-    storeSetCookies(origin, readSetCookies(response));
+    // A response's `Set-Cookie` belongs to the final response URL's origin,
+    // which can differ from the request input's when fetch follows redirects
+    // (cross-origin or http→https). Prefer `response.url`; fall back to the
+    // request origin for minimal mocked responses that don't expose a `url`.
+    const responseOrigin = responseOriginOf(response) ?? origin;
+    storeSetCookies(responseOrigin, readSetCookies(response));
     return response;
 };
 

--- a/sdk/src/utils/utils.ts
+++ b/sdk/src/utils/utils.ts
@@ -149,7 +149,12 @@ function readSetCookies(response: unknown): string[] {
     } catch {
         return [];
     }
-    return raw ? [raw] : [];
+    if (!raw) return [];
+    // Some older runtimes comma-join multiple Set-Cookie headers into a
+    // single string. Split only when the comma is followed by a likely
+    // new cookie name (`alpha[\w-]*=`), which excludes commas inside
+    // `Expires=Wed, 21 Oct 2015 …` date attributes.
+    return raw.split(/, (?=[A-Za-z][\w-]*=)/);
 }
 
 function storeSetCookies(origin: string | null, cookies: string[]) {

--- a/sdk/src/utils/utils.ts
+++ b/sdk/src/utils/utils.ts
@@ -217,7 +217,14 @@ export const defaultTransport: TransportFunction = async (input, init) => {
     const origin = originOf(input as URL | string | Request);
     const cookie = cookieHeaderFor(origin);
     if (cookie) {
-        if (isRequestLike(input)) {
+        // Per the Fetch spec, an explicit `init.headers` REPLACES the
+        // Request input's headers when fetch builds the actual request.
+        // So if init.headers is provided, that's the only place worth
+        // attaching the cookie — attaching to input.headers would be
+        // silently discarded.
+        if (init?.headers !== undefined && init.headers !== null) {
+            init.headers = attachCookie(init.headers, cookie);
+        } else if (isRequestLike(input)) {
             try {
                 if (!input.headers.has("cookie"))
                     input.headers.set("cookie", cookie);
@@ -226,7 +233,7 @@ export const defaultTransport: TransportFunction = async (input, init) => {
                 // rather than failing the request.
             }
         } else if (init) {
-            init.headers = attachCookie(init.headers, cookie);
+            init.headers = attachCookie(undefined, cookie);
         } else {
             init = { headers: attachCookie(undefined, cookie) };
         }

--- a/sdk/tests/cookie-jar.test.ts
+++ b/sdk/tests/cookie-jar.test.ts
@@ -214,7 +214,7 @@ describe("defaultTransport cookie jar", () => {
         );
     });
 
-    it("attaches the jar cookie when the input is a Request object", async () => {
+    it("attaches the jar cookie when the input is a Request object (via init.headers, not by mutating the Request)", async () => {
         const origin = "https://request-input.example.test";
         // Seed the jar.
         fetchStub.onCall(0).resolves(makeResponse("route=upstream-3"));
@@ -226,16 +226,17 @@ describe("defaultTransport cookie jar", () => {
         const req = new Request(`${origin}/next`);
         await defaultTransport(req);
 
-        // After the call, the Request's headers should carry the cookie.
-        // (Some runtimes treat Request headers as guarded; the transport
-        // catches that and skips silently — we only assert here when the
-        // header was settable.)
-        const forwarded = fetchStub.secondCall.args[0] as Request;
-        expect(forwarded).to.be.instanceof(Request);
-        const cookieOnReq = forwarded.headers.get("cookie");
-        if (cookieOnReq !== null) {
-            expect(cookieOnReq).to.equal("route=upstream-3");
-        }
+        // The cookie must reach fetch on init.headers (Fetch spec:
+        // init.headers replaces Request.headers). The original Request
+        // object must NOT have been mutated.
+        expect(req.headers.get("cookie")).to.equal(
+            null,
+            "caller's Request object must not be mutated",
+        );
+        const cookieOnInit = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookieOnInit).to.equal("route=upstream-3");
     });
 
     it("preserves a caller Cookie passed via a Headers instance", async () => {
@@ -328,6 +329,76 @@ describe("defaultTransport cookie jar", () => {
             fetchStub.secondCall.args[1] as RequestInit | undefined,
         );
         expect(cookie).to.equal("route=upstream-42");
+    });
+
+    it("does not mutate a caller-supplied Headers instance, and does not leak cookies across origins when reused", async () => {
+        const originA = "https://reuse-leak-a.example.test";
+        const originB = "https://reuse-leak-b.example.test";
+
+        // Seed each origin with its own routing cookie.
+        fetchStub.onCall(0).resolves(makeResponse("route=upstream-A"));
+        fetchStub.onCall(1).resolves(makeResponse("route=upstream-B"));
+        // Inspection targets — the two subsequent calls share the same
+        // Headers/init object across origins.
+        fetchStub.onCall(2).resolves(makeResponse());
+        fetchStub.onCall(3).resolves(makeResponse());
+
+        await defaultTransport(`${originA}/seed`);
+        await defaultTransport(`${originB}/seed`);
+
+        const sharedHeaders = new Headers({ "X-Trace-Id": "trace-1" });
+        const sharedInit: RequestInit = { headers: sharedHeaders };
+
+        await defaultTransport(`${originA}/req-A`, sharedInit);
+
+        // After the A call, the caller's shared Headers must NOT carry
+        // a Cookie, and the init object must still hold the original
+        // sharedHeaders reference (no replacement of the field on the
+        // caller's object).
+        expect(sharedHeaders.get("cookie")).to.equal(
+            null,
+            "caller's Headers must not be mutated",
+        );
+        expect(sharedInit.headers).to.equal(
+            sharedHeaders,
+            "caller's init.headers reference must not be replaced",
+        );
+
+        await defaultTransport(`${originB}/req-B`, sharedInit);
+
+        // Caller's Headers still untouched after the B call.
+        expect(sharedHeaders.get("cookie")).to.equal(null);
+        // And — critically — request B must carry origin B's cookie,
+        // not origin A's leftover from the first call.
+        const cookieOnB = getCookieHeader(
+            fetchStub.lastCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookieOnB).to.equal(
+            "route=upstream-B",
+            "origin B must NOT inherit origin A's cookie via shared init",
+        );
+    });
+
+    it("does not add new properties to a caller-supplied init object", async () => {
+        const origin = "https://no-init-key-pollution.example.test";
+        fetchStub.onCall(0).resolves(makeResponse("route=upstream-z"));
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/seed`);
+
+        // Caller passes init without a headers field.
+        const callerInit: RequestInit = { method: "GET" };
+        const originalKeys = Object.keys(callerInit).sort();
+
+        await defaultTransport(`${origin}/next`, callerInit);
+
+        // Transport must not have mutated callerInit by adding a
+        // `headers` field (or anything else).
+        expect(Object.keys(callerInit).sort()).to.deep.equal(originalKeys);
+        expect("headers" in callerInit).to.equal(
+            false,
+            "caller's init must not gain a headers field",
+        );
     });
 
     it("does not split on commas inside Expires=... date attributes (fallback path)", async () => {

--- a/sdk/tests/cookie-jar.test.ts
+++ b/sdk/tests/cookie-jar.test.ts
@@ -1,0 +1,274 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import { defaultTransport } from "../src/utils/utils.js";
+
+/**
+ * Tests for the per-origin cookie jar inside `defaultTransport`.
+ *
+ * The transport captures `Set-Cookie` headers from responses and replays them
+ * as `Cookie` on later requests to the same origin, so SDK consumers running
+ * on Node or bare React Native can talk to backends that use cookie-based
+ * session affinity.
+ *
+ * The cookie jar is module-scoped, so each test below uses a fresh, unique
+ * origin to avoid pollution between tests.
+ *
+ * Imports `defaultTransport` directly from `src/utils/utils.js` so the test
+ * bundle doesn't pull in the WASM module — these are pure transport assertions.
+ */
+
+type FetchStub = sinon.SinonStub<
+    Parameters<typeof fetch>,
+    ReturnType<typeof fetch>
+>;
+
+function makeResponse(setCookie?: string): Response {
+    const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+    };
+    if (setCookie !== undefined) {
+        headers["set-cookie"] = setCookie;
+    }
+    return new Response("{}", { status: 200, headers });
+}
+
+function getCookieHeader(init: RequestInit | undefined): string | null {
+    if (!init || !init.headers) return null;
+    const headers = init.headers;
+    if (headers instanceof Headers) {
+        return headers.get("cookie");
+    }
+    if (Array.isArray(headers)) {
+        for (const pair of headers) {
+            if (
+                Array.isArray(pair) &&
+                typeof pair[0] === "string" &&
+                pair[0].toLowerCase() === "cookie"
+            ) {
+                return String(pair[1]);
+            }
+        }
+        return null;
+    }
+    if (typeof headers === "object") {
+        for (const [key, value] of Object.entries(headers)) {
+            if (key.toLowerCase() === "cookie") return String(value);
+        }
+    }
+    return null;
+}
+
+describe("defaultTransport cookie jar", () => {
+    let fetchStub: FetchStub;
+
+    beforeEach(() => {
+        // Stub the global fetch the transport delegates to.
+        fetchStub = sinon.stub(globalThis, "fetch") as FetchStub;
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it("captures the affinity Set-Cookie and attaches it on the next same-origin request", async () => {
+        const origin = "https://capture-attach.example.test";
+        // First call: server sends the Kong routing cookie.
+        // Second call: empty response so the assertion isolates the captured cookie.
+        fetchStub
+            .onFirstCall()
+            .resolves(makeResponse("route=upstream-7; Path=/; HttpOnly"));
+        fetchStub.onSecondCall().resolves(makeResponse());
+
+        // First request — no Cookie expected yet (jar is empty for this origin).
+        await defaultTransport(`${origin}/first`);
+        expect(
+            getCookieHeader(
+                fetchStub.firstCall.args[1] as RequestInit | undefined,
+            ),
+        ).to.equal(
+            null,
+            "first request must not have a Cookie header — jar is empty for this origin",
+        );
+
+        // Second request — jar should attach `route=upstream-7`.
+        await defaultTransport(`${origin}/second`);
+        const secondCookie = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(secondCookie).to.equal("route=upstream-7");
+    });
+
+    it("scopes cookies by origin — does not leak cookies from origin A to origin B", async () => {
+        const originA = "https://scope-a.example.test";
+        const originB = "https://scope-b.example.test";
+
+        // First call (origin A): set a cookie.
+        fetchStub.onCall(0).resolves(makeResponse("route=a"));
+        // Second call (origin B): the assertion target.
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${originA}/path`);
+        await defaultTransport(`${originB}/path`);
+
+        const cookieOnB = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookieOnB).to.equal(
+            null,
+            "origin B must NOT inherit origin A's cookie",
+        );
+    });
+
+    it("does not overwrite a caller-provided Cookie header", async () => {
+        const origin = "https://caller-wins.example.test";
+
+        // Seed the jar with a cookie at this origin.
+        fetchStub.onCall(0).resolves(makeResponse("route=fromserver"));
+        // Second call: caller passes their own Cookie header — should win.
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/seed`);
+        await defaultTransport(`${origin}/with-caller-cookie`, {
+            headers: { Cookie: "caller=wins" },
+        });
+
+        const cookie = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookie).to.equal("caller=wins");
+        expect(cookie).to.not.include("route=fromserver");
+    });
+
+    it("ignores response objects without a headers field (back-compat with minimal fetch mocks)", async () => {
+        const origin = "https://minimal-mock.example.test";
+        // Minimal response-like object — no `headers` field at all. This
+        // mirrors how the rest of the SDK tests stub fetch.
+        const minimal = {
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve("{}"),
+        };
+        fetchStub.onCall(0).resolves(minimal as unknown as Response);
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/first`);
+        await defaultTransport(`${origin}/second`);
+
+        // Nothing should have been captured from the headerless mock.
+        const cookie = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookie).to.equal(null);
+    });
+
+    it("uses getSetCookie() when the runtime exposes it (Node multi-Set-Cookie)", async () => {
+        const origin = "https://get-set-cookie.example.test";
+        const headers = {
+            // Simulates Node's Headers, which returns multiple Set-Cookie
+            // values via getSetCookie() while .get('set-cookie') collapses
+            // them into one ambiguous string.
+            getSetCookie: () => [
+                "route=upstream-9; Path=/",
+                "ignored-name=other; Path=/",
+            ],
+            get: (name: string) =>
+                name.toLowerCase() === "set-cookie"
+                    ? "route=upstream-9, ignored-name=other"
+                    : null,
+        };
+        fetchStub.onCall(0).resolves({
+            ok: true,
+            status: 200,
+            headers,
+            text: () => Promise.resolve("{}"),
+        } as unknown as Response);
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/first`);
+        await defaultTransport(`${origin}/second`);
+
+        const cookie = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        // Only the whitelisted `route` cookie is captured. The unrelated
+        // name is dropped even though getSetCookie() returned it.
+        expect(cookie).to.equal("route=upstream-9");
+    });
+
+    it("drops non-whitelisted cookies (no cross-client leakage of auth/session cookies)", async () => {
+        const origin = "https://whitelist.example.test";
+        fetchStub
+            .onCall(0)
+            .resolves(makeResponse("auth=secret-token; Path=/; HttpOnly"));
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/seed`);
+        await defaultTransport(`${origin}/check`);
+
+        const cookie = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookie).to.equal(
+            null,
+            "unrelated cookies must NOT enter the jar",
+        );
+    });
+
+    it("attaches the jar cookie when the input is a Request object", async () => {
+        const origin = "https://request-input.example.test";
+        // Seed the jar.
+        fetchStub.onCall(0).resolves(makeResponse("route=upstream-3"));
+        // Inspect what defaultTransport forwards to fetch.
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/seed`);
+
+        const req = new Request(`${origin}/next`);
+        await defaultTransport(req);
+
+        // After the call, the Request's headers should carry the cookie.
+        // (Some runtimes treat Request headers as guarded; the transport
+        // catches that and skips silently — we only assert here when the
+        // header was settable.)
+        const forwarded = fetchStub.secondCall.args[0] as Request;
+        expect(forwarded).to.be.instanceof(Request);
+        const cookieOnReq = forwarded.headers.get("cookie");
+        if (cookieOnReq !== null) {
+            expect(cookieOnReq).to.equal("route=upstream-3");
+        }
+    });
+
+    it("preserves a caller Cookie passed via a Headers instance", async () => {
+        const origin = "https://headers-instance.example.test";
+        fetchStub.onCall(0).resolves(makeResponse("route=fromserver"));
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/seed`);
+
+        const callerHeaders = new Headers({
+            Cookie: "caller=wins-via-headers",
+        });
+        await defaultTransport(`${origin}/next`, { headers: callerHeaders });
+
+        const cookie = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookie).to.equal("caller=wins-via-headers");
+    });
+
+    it("preserves a caller Cookie passed via tuple-array headers", async () => {
+        const origin = "https://tuple-array.example.test";
+        fetchStub.onCall(0).resolves(makeResponse("route=fromserver"));
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/seed`);
+        await defaultTransport(`${origin}/next`, {
+            headers: [["Cookie", "caller=wins-via-tuple"]],
+        });
+
+        const cookie = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookie).to.equal("caller=wins-via-tuple");
+    });
+});

--- a/sdk/tests/cookie-jar.test.ts
+++ b/sdk/tests/cookie-jar.test.ts
@@ -1,9 +1,9 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { defaultTransport } from "../src/utils/utils.js";
+import { cookieAffinityTransport } from "../src/utils/utils.js";
 
 /**
- * Tests for the per-origin cookie jar inside `defaultTransport`.
+ * Tests for the per-origin cookie jar inside `cookieAffinityTransport`.
  *
  * The transport captures `Set-Cookie` headers from responses and replays them
  * as `Cookie` on later requests to the same origin, so SDK consumers running
@@ -13,7 +13,7 @@ import { defaultTransport } from "../src/utils/utils.js";
  * The cookie jar is module-scoped, so each test below uses a fresh, unique
  * origin to avoid pollution between tests.
  *
- * Imports `defaultTransport` directly from `src/utils/utils.js` so the test
+ * Imports `cookieAffinityTransport` directly from `src/utils/utils.js` so the test
  * bundle doesn't pull in the WASM module — these are pure transport assertions.
  */
 
@@ -58,7 +58,7 @@ function getCookieHeader(init: RequestInit | undefined): string | null {
     return null;
 }
 
-describe("defaultTransport cookie jar", () => {
+describe("cookieAffinityTransport cookie jar", () => {
     let fetchStub: FetchStub;
 
     beforeEach(() => {
@@ -80,7 +80,7 @@ describe("defaultTransport cookie jar", () => {
         fetchStub.onSecondCall().resolves(makeResponse());
 
         // First request — no Cookie expected yet (jar is empty for this origin).
-        await defaultTransport(`${origin}/first`);
+        await cookieAffinityTransport(`${origin}/first`);
         expect(
             getCookieHeader(
                 fetchStub.firstCall.args[1] as RequestInit | undefined,
@@ -91,7 +91,7 @@ describe("defaultTransport cookie jar", () => {
         );
 
         // Second request — jar should attach `route=upstream-7`.
-        await defaultTransport(`${origin}/second`);
+        await cookieAffinityTransport(`${origin}/second`);
         const secondCookie = getCookieHeader(
             fetchStub.secondCall.args[1] as RequestInit | undefined,
         );
@@ -107,8 +107,8 @@ describe("defaultTransport cookie jar", () => {
         // Second call (origin B): the assertion target.
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${originA}/path`);
-        await defaultTransport(`${originB}/path`);
+        await cookieAffinityTransport(`${originA}/path`);
+        await cookieAffinityTransport(`${originB}/path`);
 
         const cookieOnB = getCookieHeader(
             fetchStub.secondCall.args[1] as RequestInit | undefined,
@@ -116,6 +116,55 @@ describe("defaultTransport cookie jar", () => {
         expect(cookieOnB).to.equal(
             null,
             "origin B must NOT inherit origin A's cookie",
+        );
+    });
+
+    it("scopes the cookie to the response origin (response.url), not the request input origin, after a cross-origin redirect", async () => {
+        const requestOrigin = "https://redirect-from.example.test";
+        const responseOrigin = "https://redirect-to.example.test";
+
+        // fetch follows a redirect: the request targets `requestOrigin` but
+        // the final response (carrying the Set-Cookie) is served from
+        // `responseOrigin`, surfaced via `response.url`.
+        const redirected = {
+            ok: true,
+            status: 200,
+            url: `${responseOrigin}/end`,
+            headers: {
+                get: (name: string) =>
+                    name.toLowerCase() === "set-cookie"
+                        ? "route=on-final-origin; Path=/; HttpOnly"
+                        : null,
+            },
+            text: () => Promise.resolve("{}"),
+        };
+        fetchStub.onCall(0).resolves(redirected as unknown as Response);
+        fetchStub.onCall(1).resolves(makeResponse());
+        fetchStub.onCall(2).resolves(makeResponse());
+
+        await cookieAffinityTransport(`${requestOrigin}/start`);
+
+        // A later request to the response origin must replay the cookie.
+        await cookieAffinityTransport(`${responseOrigin}/again`);
+        expect(
+            getCookieHeader(
+                fetchStub.secondCall.args[1] as RequestInit | undefined,
+            ),
+        ).to.equal(
+            "route=on-final-origin",
+            "cookie must be keyed under the response origin so it replays there",
+        );
+
+        // A later request to the original request input origin must NOT carry
+        // the cookie — it was never that origin's cookie.
+        await cookieAffinityTransport(`${requestOrigin}/again`);
+        expect(
+            getCookieHeader(
+                fetchStub.thirdCall.args[1] as RequestInit | undefined,
+            ),
+        ).to.equal(
+            null,
+            "cookie must be scoped to the response origin, not the request input origin",
         );
     });
 
@@ -127,8 +176,8 @@ describe("defaultTransport cookie jar", () => {
         // Second call: caller passes their own Cookie header — should win.
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/seed`);
-        await defaultTransport(`${origin}/with-caller-cookie`, {
+        await cookieAffinityTransport(`${origin}/seed`);
+        await cookieAffinityTransport(`${origin}/with-caller-cookie`, {
             headers: { Cookie: "caller=wins" },
         });
 
@@ -151,8 +200,8 @@ describe("defaultTransport cookie jar", () => {
         fetchStub.onCall(0).resolves(minimal as unknown as Response);
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/first`);
-        await defaultTransport(`${origin}/second`);
+        await cookieAffinityTransport(`${origin}/first`);
+        await cookieAffinityTransport(`${origin}/second`);
 
         // Nothing should have been captured from the headerless mock.
         const cookie = getCookieHeader(
@@ -184,8 +233,8 @@ describe("defaultTransport cookie jar", () => {
         } as unknown as Response);
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/first`);
-        await defaultTransport(`${origin}/second`);
+        await cookieAffinityTransport(`${origin}/first`);
+        await cookieAffinityTransport(`${origin}/second`);
 
         const cookie = getCookieHeader(
             fetchStub.secondCall.args[1] as RequestInit | undefined,
@@ -202,8 +251,8 @@ describe("defaultTransport cookie jar", () => {
             .resolves(makeResponse("auth=secret-token; Path=/; HttpOnly"));
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/seed`);
-        await defaultTransport(`${origin}/check`);
+        await cookieAffinityTransport(`${origin}/seed`);
+        await cookieAffinityTransport(`${origin}/check`);
 
         const cookie = getCookieHeader(
             fetchStub.secondCall.args[1] as RequestInit | undefined,
@@ -218,13 +267,13 @@ describe("defaultTransport cookie jar", () => {
         const origin = "https://request-input.example.test";
         // Seed the jar.
         fetchStub.onCall(0).resolves(makeResponse("route=upstream-3"));
-        // Inspect what defaultTransport forwards to fetch.
+        // Inspect what cookieAffinityTransport forwards to fetch.
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/seed`);
+        await cookieAffinityTransport(`${origin}/seed`);
 
         const req = new Request(`${origin}/next`);
-        await defaultTransport(req);
+        await cookieAffinityTransport(req);
 
         // The cookie must reach fetch on init.headers (Fetch spec:
         // init.headers replaces Request.headers). The original Request
@@ -244,12 +293,14 @@ describe("defaultTransport cookie jar", () => {
         fetchStub.onCall(0).resolves(makeResponse("route=fromserver"));
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/seed`);
+        await cookieAffinityTransport(`${origin}/seed`);
 
         const callerHeaders = new Headers({
             Cookie: "caller=wins-via-headers",
         });
-        await defaultTransport(`${origin}/next`, { headers: callerHeaders });
+        await cookieAffinityTransport(`${origin}/next`, {
+            headers: callerHeaders,
+        });
 
         const cookie = getCookieHeader(
             fetchStub.secondCall.args[1] as RequestInit | undefined,
@@ -262,8 +313,8 @@ describe("defaultTransport cookie jar", () => {
         fetchStub.onCall(0).resolves(makeResponse("route=fromserver"));
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/seed`);
-        await defaultTransport(`${origin}/next`, {
+        await cookieAffinityTransport(`${origin}/seed`);
+        await cookieAffinityTransport(`${origin}/next`, {
             headers: [["Cookie", "caller=wins-via-tuple"]],
         });
 
@@ -281,10 +332,10 @@ describe("defaultTransport cookie jar", () => {
         fetchStub.onCall(0).resolves(makeResponse("route=upstream-11"));
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/seed`);
+        await cookieAffinityTransport(`${origin}/seed`);
 
         const req = new Request(`${origin}/next`);
-        await defaultTransport(req, {
+        await cookieAffinityTransport(req, {
             headers: { "X-Trace-Id": "abc" },
         });
 
@@ -322,8 +373,8 @@ describe("defaultTransport cookie jar", () => {
         } as unknown as Response);
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/first`);
-        await defaultTransport(`${origin}/second`);
+        await cookieAffinityTransport(`${origin}/first`);
+        await cookieAffinityTransport(`${origin}/second`);
 
         const cookie = getCookieHeader(
             fetchStub.secondCall.args[1] as RequestInit | undefined,
@@ -343,13 +394,13 @@ describe("defaultTransport cookie jar", () => {
         fetchStub.onCall(2).resolves(makeResponse());
         fetchStub.onCall(3).resolves(makeResponse());
 
-        await defaultTransport(`${originA}/seed`);
-        await defaultTransport(`${originB}/seed`);
+        await cookieAffinityTransport(`${originA}/seed`);
+        await cookieAffinityTransport(`${originB}/seed`);
 
         const sharedHeaders = new Headers({ "X-Trace-Id": "trace-1" });
         const sharedInit: RequestInit = { headers: sharedHeaders };
 
-        await defaultTransport(`${originA}/req-A`, sharedInit);
+        await cookieAffinityTransport(`${originA}/req-A`, sharedInit);
 
         // After the A call, the caller's shared Headers must NOT carry
         // a Cookie, and the init object must still hold the original
@@ -364,7 +415,7 @@ describe("defaultTransport cookie jar", () => {
             "caller's init.headers reference must not be replaced",
         );
 
-        await defaultTransport(`${originB}/req-B`, sharedInit);
+        await cookieAffinityTransport(`${originB}/req-B`, sharedInit);
 
         // Caller's Headers still untouched after the B call.
         expect(sharedHeaders.get("cookie")).to.equal(null);
@@ -384,13 +435,13 @@ describe("defaultTransport cookie jar", () => {
         fetchStub.onCall(0).resolves(makeResponse("route=upstream-z"));
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/seed`);
+        await cookieAffinityTransport(`${origin}/seed`);
 
         // Caller passes init without a headers field.
         const callerInit: RequestInit = { method: "GET" };
         const originalKeys = Object.keys(callerInit).sort();
 
-        await defaultTransport(`${origin}/next`, callerInit);
+        await cookieAffinityTransport(`${origin}/next`, callerInit);
 
         // Transport must not have mutated callerInit by adding a
         // `headers` field (or anything else).
@@ -420,8 +471,8 @@ describe("defaultTransport cookie jar", () => {
         } as unknown as Response);
         fetchStub.onCall(1).resolves(makeResponse());
 
-        await defaultTransport(`${origin}/first`);
-        await defaultTransport(`${origin}/second`);
+        await cookieAffinityTransport(`${origin}/first`);
+        await cookieAffinityTransport(`${origin}/second`);
 
         const cookie = getCookieHeader(
             fetchStub.secondCall.args[1] as RequestInit | undefined,

--- a/sdk/tests/cookie-jar.test.ts
+++ b/sdk/tests/cookie-jar.test.ts
@@ -271,4 +271,90 @@ describe("defaultTransport cookie jar", () => {
         );
         expect(cookie).to.equal("caller=wins-via-tuple");
     });
+
+    it("attaches the cookie to init.headers (not input.headers) when both a Request and init.headers are provided", async () => {
+        // Fetch spec: init.headers fully overrides Request.headers when
+        // both are present. If we attach to input.headers here, fetch
+        // silently discards our cookie.
+        const origin = "https://request-plus-init-headers.example.test";
+        fetchStub.onCall(0).resolves(makeResponse("route=upstream-11"));
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/seed`);
+
+        const req = new Request(`${origin}/next`);
+        await defaultTransport(req, {
+            headers: { "X-Trace-Id": "abc" },
+        });
+
+        // Both `args[0]` (the Request) and `args[1]` (the init) are
+        // forwarded — fetch will use init.headers, so that's where the
+        // jar cookie must end up.
+        const initOnCall = fetchStub.secondCall.args[1] as
+            | RequestInit
+            | undefined;
+        expect(getCookieHeader(initOnCall)).to.equal(
+            "route=upstream-11",
+            "init.headers wins per fetch spec; cookie must be attached there",
+        );
+    });
+
+    it("parses multiple cookies from a comma-joined Set-Cookie fallback string", async () => {
+        // Older runtimes that don't implement getSetCookie() comma-join
+        // multiple Set-Cookie headers into a single string via
+        // headers.get('set-cookie'). With the whitelisted cookie not in
+        // the first position, the naive split(';')[0] approach would
+        // drop `route` entirely.
+        const origin = "https://comma-joined.example.test";
+        const headers = {
+            // No getSetCookie() — forces the fallback path.
+            get: (name: string) =>
+                name.toLowerCase() === "set-cookie"
+                    ? "first=val1; Path=/, route=upstream-42; Path=/; HttpOnly"
+                    : null,
+        };
+        fetchStub.onCall(0).resolves({
+            ok: true,
+            status: 200,
+            headers,
+            text: () => Promise.resolve("{}"),
+        } as unknown as Response);
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/first`);
+        await defaultTransport(`${origin}/second`);
+
+        const cookie = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookie).to.equal("route=upstream-42");
+    });
+
+    it("does not split on commas inside Expires=... date attributes (fallback path)", async () => {
+        const origin = "https://date-comma.example.test";
+        const headers = {
+            // Expires has a comma inside its date format. A naive split
+            // on `, ` would slice through it. Our split-on-comma-before-
+            // -cookie-name regex must skip it.
+            get: (name: string) =>
+                name.toLowerCase() === "set-cookie"
+                    ? "route=upstream-99; Expires=Wed, 21 Oct 2099 07:28:00 GMT; Path=/"
+                    : null,
+        };
+        fetchStub.onCall(0).resolves({
+            ok: true,
+            status: 200,
+            headers,
+            text: () => Promise.resolve("{}"),
+        } as unknown as Response);
+        fetchStub.onCall(1).resolves(makeResponse());
+
+        await defaultTransport(`${origin}/first`);
+        await defaultTransport(`${origin}/second`);
+
+        const cookie = getCookieHeader(
+            fetchStub.secondCall.args[1] as RequestInit | undefined,
+        );
+        expect(cookie).to.equal("route=upstream-99");
+    });
 });


### PR DESCRIPTION
Linear: [PRO-541](https://linear.app/provable/issue/PRO-541/sdk-provablehqsdk-per-origin-cookie-jar-for-session-affinity-gateways)

## Motivation

Some Aleo backends sit behind a gateway (Kong in our case) that uses cookie-based session affinity: the server sets a `Set-Cookie: route=<UUID>` on the first response and expects it back on subsequent requests so per-session state (ephemeral pubkeys, JWT registrations) stays on the same upstream instance. Browsers and iOS NSURLSession persist cookies automatically; Node `fetch` and bare React Native do not — without a jar, those runtimes land on a random upstream per request, which has produced intermittent 400/401 failures on the delegated-proving and record-scanner paths.

This adds a small per-origin cookie jar to `defaultTransport`. Since all SDK HTTP traffic flows through `TransportFunction`, the fix covers `AleoNetworkClient` and `RecordScanner` automatically. Browser remains a no-op (`Cookie` is a forbidden request header).

## Design

- **Whitelisted cookie names only.** Only `route` is captured. Unrelated auth/session/CSRF cookies on the same origin are ignored, so other SDK clients in the same process can't inherit caller state. The whitelist is a `const ReadonlySet` at the top of the module — easy to extend if other affinity cookie names appear.
- **Module-scoped jar, per-origin keyed.** `Map<origin, Map<cookieName, value>>`. Shared across all `defaultTransport` callers in the same process — appropriate for routing cookies, and the whitelist contains the blast radius.
- **Defensive response reading.** Prefers `getSetCookie()` when the runtime exposes it (Node 22+ — handles multiple `Set-Cookie` headers correctly). Falls back to `get('set-cookie')` and splits the comma-joined string on `, ` followed by a cookie-name pattern, so multiple cookies are captured even on older runtimes; the regex deliberately skips the comma inside `Expires=Wed, 21 Oct 2015 …` date attributes. No-ops if the response has no `headers` field (existing SDK tests stub fetch with minimal response-like objects).
- **Runtime-global guards.** `Headers` and `Request` constructor checks use `typeof X !== 'undefined'`, and the Request-headers manipulation is wrapped in a try/catch so guarded-header runtimes don't fail the request.
- **`init.headers` priority (Fetch spec).** When the caller passes both a `Request` input and `init.headers`, `init.headers` REPLACES the Request's headers in the actual fetch — so the cookie must be attached there, not on the Request, or fetch would silently discard it. The transport checks `init.headers` first and falls back to merging into the Request's headers only when no init override is present.
- **Caller's Cookie wins.** `attachCookie` never overwrites an existing `Cookie` header passed by the caller in any of the three `HeadersInit` shapes (`Headers` instance, tuple array, plain object). The manual pubkey-cookie forwarding in `network-client.ts` continues to take precedence on the DPS path.
- **No mutation of caller state.** The transport never mutates the caller's `init`, `Headers` instance, or `Request` input. It shallow-clones `init` (`{ ...init, headers: … }`), clones any `Headers` via `new Headers(headersInit)` before `.set()`, and for Request input it copies the Request's existing headers into a fresh `Headers` and passes them via `init.headers`. This avoids a cross-origin leak where a caller reusing the same `Headers`/`init` would otherwise see origin A's routing cookie persist into the object and block origin B's correct cookie.

## Changes

| File | Net |
|---|---|
| `sdk/src/utils/utils.ts` | +238/-15 |
| `sdk/tests/cookie-jar.test.ts` | +431 (new) |

## Test plan

- [x] `cd sdk && rm -rf tmp && yarn exec rollup -c rollup.test.js && yarn exec mocha tmp/testnet/tests/cookie-jar.test.js --timeout 60000` — 14/14 passing:
  - captures the affinity Set-Cookie and attaches it on the next same-origin request
  - scopes cookies by origin (origin A does not leak to origin B)
  - does not overwrite a caller-provided Cookie header
  - ignores response objects without a `headers` field (back-compat with existing minimal fetch mocks)
  - uses `getSetCookie()` when the runtime exposes it (Node multi-Set-Cookie)
  - drops non-whitelisted cookies (no cross-client leakage of auth/session)
  - attaches jar cookie when the input is a `Request` object (via `init.headers`, not by mutating the Request)
  - preserves caller `Cookie` passed via a `Headers` instance
  - preserves caller `Cookie` passed via tuple-array headers
  - attaches the cookie to `init.headers` (not `input.headers`) when both a Request and `init.headers` are provided
  - parses multiple cookies from a comma-joined Set-Cookie fallback string
  - does not split on commas inside `Expires=…` date attributes (fallback path)
  - does not mutate a caller-supplied Headers instance, and does not leak cookies across origins when reused
  - does not add new properties to a caller-supplied init object
- [x] `yarn exec prettier --check sdk/src/utils/utils.ts sdk/tests/cookie-jar.test.ts` — clean
- [x] Broader `yarn test:sdk` — verified no new regressions beyond pre-existing failures (URL parsing in `new RecordScanner`, WASM `passStringToWasm0`) which reproduce on `mainnet` without this change

## Review history

| Round | Finding | Addressed in |
|---|---|---|
| Initial review | broader tests fail on `response.headers.get` over minimal mocks; prettier; runtime-global checks; cookie jar shared across clients; multi-`Set-Cookie` handling | `a4a0d23` |
| Cursor (medium) | `init.headers` overrides `Request.headers` per Fetch spec — cookie on `input.headers` would be discarded | `84aa1a1` |
| Cursor (low) | comma-joined `Set-Cookie` fallback only parses first cookie | `67fdb91` |
| Cursor (medium) | mutating caller's `init` / `Headers` / `Request` causes stale cross-origin cookies via shared-state reuse | `a2009dc` |

## Notes for reviewers

- This is a Node/RN-targeted fix; the browser code path is effectively a no-op.
- Downstream consumer (shield-mobile) currently carries this via `patches/@provablehq+sdk+0.10.2.patch`. Once this lands and is published, that patch file can be deleted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared HTTP plumbing and cookie handling for proving/record-scanner paths; behavior is opt-in and whitelisted, but incorrect jar logic could still mis-route affinity-sensitive requests.
> 
> **Overview**
> Adds an **opt-in** `cookieAffinityTransport` that keeps a per-origin jar for Kong-style **`route`** affinity cookies on Node/React Native, where `fetch` does not persist cookies. Responses’ `Set-Cookie` values are stored (whitelist-only), replayed on later same-origin requests, and keyed by **`response.url`** after redirects. **`defaultTransport` is unchanged**; consumers pass `cookieAffinityTransport` via the existing `transport` option on network clients and related helpers.
> 
> The transport follows Fetch header rules (`init.headers` overrides `Request`), never overwrites caller `Cookie` headers, and avoids mutating caller `init`/`Headers`/`Request`. **`cookieAffinityTransport`** is re-exported from `browser.ts` and `utils/index.ts`. A dedicated **`cookie-jar.test.ts`** suite covers origin scoping, redirects, `getSetCookie()`, comma-joined fallbacks, and no-mutation guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1905b05f9e0b5f72a64ad9ee360b4d2e67046057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->