### PR TITLE
[Chore] Bump @provablehq/sdk to ^0.11.0 in dynamic-dispatch template

### DIFF
--- a/create-leo-app/template-node-dynamic-dispatch-ts/package.json
+++ b/create-leo-app/template-node-dynamic-dispatch-ts/package.json
@@ -15,7 +15,7 @@
         "test:all": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.10.0"
+        "@provablehq/sdk": "^0.11.0"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2872,21 +2872,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@provablehq/sdk@npm:^0.10.0":
-  version: 0.10.5
-  resolution: "@provablehq/sdk@npm:0.10.5"
-  dependencies:
-    "@provablehq/wasm": "npm:^0.10.5"
-    "@scure/base": "npm:^2.0.0"
-    "@serenity-kit/noble-sodium": "npm:0.2.3"
-    comlink: "npm:^4.4.2"
-    core-js: "npm:^3.40.0"
-    mime: "npm:^4.0.6"
-    xmlhttprequest-ssl: "npm:^4.0.0"
-  checksum: 10c0/1b72f0650ba4e571616527bd47eaf2a886db8a12a2d87e8d656e5d5dcf58b10e60d0ab6c1efa1b5b03cf952f60b6483ed1a6b383a0478906eb63eea753181d77
-  languageName: node
-  linkType: hard
-
 "@provablehq/sdk@npm:^0.11.0, @provablehq/sdk@workspace:sdk":
   version: 0.0.0-use.local
   resolution: "@provablehq/sdk@workspace:sdk"
@@ -2925,13 +2910,6 @@ __metadata:
     xmlhttprequest-ssl: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
-
-"@provablehq/wasm@npm:^0.10.5":
-  version: 0.10.5
-  resolution: "@provablehq/wasm@npm:0.10.5"
-  checksum: 10c0/97e4c3e28a1cfcb76af9d35f6d48e44650cf43bc70e683011067515e65b707f16c53bdba476b24604b19f5f962819b6d128870c74e603d06ee86bcf53c58acaf
-  languageName: node
-  linkType: hard
 
 "@provablehq/wasm@npm:^0.11.0, @provablehq/wasm@workspace:wasm":
   version: 0.0.0-use.local
@@ -13715,7 +13693,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-dynamic-dispatch-ts@workspace:create-leo-app/template-node-dynamic-dispatch-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.10.0"
+    "@provablehq/sdk": "npm:^0.11.0"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"


### PR DESCRIPTION
## Motivation

`template-node-dynamic-dispatch-ts` is still pinned at `^0.10.0` while the other templates were moved to `^0.11.0` in #1327. With the local SDK at v0.11.0, that older pin keeps Yarn from linking the local `sdk/` workspace, so Yarn resolves against the published `@provablehq/sdk@0.10.5` tarball, whose runtime export doesn't yet include `setKeyStore` (added in #1262, not present in the 0.10.x publish).

That's what's been causing the `create-leo-app dynamic-dispatch (call.dynamic + deep chain)` CI job to fail with `TypeError: pm.setKeyStore is not a function` at `createProgramManager`.

Bumping the pin restores the workspace link. `yarn.lock` drops the two npm tarball entries (`@provablehq/sdk@npm:0.10.5`, `@provablehq/wasm@npm:0.10.5`) since the workspace now satisfies the range.

## Test Plan

Local:
- [x] `yarn install`: clean.
- [x] `cd create-leo-app/template-node-dynamic-dispatch-ts && yarn build`: template builds.
- [x] `setKeyStore` present in bundled `dist/index.js`.
- [x] `node dist/index.js` clears `createProgramManager` and proceeds into "Loading program" / "Creating authorization".

CI:
- [x] `create-leo-app dynamic-dispatch (call.dynamic + deep chain)` goes green.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and lockfile alignment only; no application logic changes.
> 
> **Overview**
> Aligns **`template-node-dynamic-dispatch-ts`** with the other create-leo-app templates by bumping **`@provablehq/sdk`** from **`^0.10.0`** to **`^0.11.0`**.
> 
> The lockfile no longer pulls published **`0.10.5`** tarballs for **`@provablehq/sdk`** / **`@provablehq/wasm`**; Yarn can satisfy the range from the monorepo **`sdk/`** workspace instead. That restores APIs such as **`setKeyStore`** that the dynamic-dispatch template expects, addressing the CI failure where **`pm.setKeyStore`** was undefined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d172f30b675577f404079fde7caa6533e573aeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->