### PR TITLE
[Feature] Add helper method for generating USDCx hook data

### DIFF
--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -102,6 +102,7 @@ import {
 } from "./record-provider.js";
 import { RecordScanner, RecordScannerJWTData, RecordScannerOptions } from "./record-scanner.js";
 import { SealanceMerkleTree } from "./integrations/sealance/merkle-tree.js";
+import { generateHookData } from "./integrations/circle/hook-data.js";
 
 // @TODO: This function is no longer needed, remove it.
 async function initializeWasm() {
@@ -223,6 +224,7 @@ export {
     FunctionObject,
     FunctionKeyPair,
     FunctionKeyProvider,
+    generateHookData,
     Header,
     isProvingResponse,
     isProveApiErrorBody,

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -120,3 +120,6 @@ export const RECORD_DOMAIN = "RecordScannerV0";
 export const ZERO_ADDRESS = "aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc";
 export const FIVE_MINUTES = 5 * 60 * 1000; // 5 minutes in milliseconds
 
+export const HOOK_DATA_RECIPIENT = "aleo1r5fwayr4vhaz2mgyuqg7qer3apunn2zefe7m9cle94rar0dwcgyq6hg9ze";
+export const SECRET_NONCE = "0scalar";
+

--- a/sdk/src/integrations/circle/hook-data.ts
+++ b/sdk/src/integrations/circle/hook-data.ts
@@ -1,7 +1,7 @@
 import { BHP256, Plaintext, Scalar } from "../../wasm.js";
 
 // This method generates the hook data for the Circle USDCx shielded mint flow.  
-function generateHookData(recipientAddress: String, secretNonce: String): Uint8Array {
+function generateHookData(recipientAddress: string, secretNonce: string): Uint8Array {
   // Leo's BHP256::commit_to_field uses the typed plaintext bits, not raw address bits.
   const recipientBits = Plaintext.fromString(recipientAddress).toBitsLe();
   const secret = Scalar.fromString(secretNonce);

--- a/sdk/src/integrations/circle/hook-data.ts
+++ b/sdk/src/integrations/circle/hook-data.ts
@@ -1,0 +1,17 @@
+import { BHP256, Plaintext, Scalar } from "../../wasm.js";
+
+// This method generates the hook data for the Circle USDCx shielded mint flow.  
+function generateHookData(recipientAddress: String, secretNonce: String): Uint8Array {
+  // Leo's BHP256::commit_to_field uses the typed plaintext bits, not raw address bits.
+  const recipientBits = Plaintext.fromString(recipientAddress).toBitsLe();
+  const secret = Scalar.fromString(secretNonce);
+  const committedField = new BHP256().commit(recipientBits, secret);
+  const committedBytes = committedField.toBytesLe();
+
+  const hookData = new Uint8Array(65);
+  hookData[0] = 2;
+  hookData.set(committedBytes, 1);
+  return hookData;
+}
+
+export { generateHookData };

--- a/sdk/tests/circle-usdcx.test.ts
+++ b/sdk/tests/circle-usdcx.test.ts
@@ -1,4 +1,4 @@
-import { generateHookData } from "../src/integrations/circle/hook-data.ts";
+import { generateHookData } from "../src/integrations/circle/hook-data.js";
 import {SECRET_NONCE, HOOK_DATA_RECIPIENT } from "../src/constants.js";
 import { expect } from "chai";
 

--- a/sdk/tests/circle-usdcx.test.ts
+++ b/sdk/tests/circle-usdcx.test.ts
@@ -1,0 +1,12 @@
+import { generateHookData } from "../src/integrations/circle/hook-data.ts";
+import {SECRET_NONCE, HOOK_DATA_RECIPIENT } from "../src/constants.js";
+import { expect } from "chai";
+
+describe("hook-data encoding", () => {
+  it("should generate a correct 32 byte encoding and format into 65 byte hook data array", () => {
+    // Create hook data for the recipient address and secret nonce
+    const hookData = generateHookData(HOOK_DATA_RECIPIENT, SECRET_NONCE);
+    expect(hookData.length).to.equal(65);
+    expect(hookData[0]).to.equal(2); // Check the first byte is 2
+  });
+});


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR closes [issue](https://github.com/ProvableHQ/sdk/issues/1338).  The new helper method returns a 65 byte hook data array that sets the correct flag byte (2u32) along with correctly computing a 32 byte encoding.

Wallets and users will need to compute the encoding twice -- once when submitting the hook data array to the Ethereum contract and once again when minting funds on Aleo:  https://testnet.explorer.provable.com/program/shielded_usdcx_wrapper.aleo

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

A dedicated test was added to the test directory:   `circle-usdcx.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK utility and test-only constants with no changes to auth, networking, or existing transfer flows.
> 
> **Overview**
> Adds **`generateHookData`** for the Circle USDCx shielded mint flow: it BHP256-commits a recipient address (via typed `Plaintext` bits) and a secret nonce scalar, then returns a **65-byte** `Uint8Array` with flag byte **`2`** and the 32-byte commitment in the remainder.
> 
> The helper is exported from the browser SDK bundle, and **`HOOK_DATA_RECIPIENT`** / **`SECRET_NONCE`** constants support tests. **`circle-usdcx.test.ts`** asserts length 65 and the leading flag byte.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba7e0cd1626274a618957a21e018949ceae6f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->