### PR TITLE
Gate headers on custom transport

### DIFF
--- a/sdk/src/network-client.ts
+++ b/sdk/src/network-client.ts
@@ -69,6 +69,12 @@ interface DelegatedProvingParams {
   dpsPrivacy?: boolean;
 }
 
+const HEADERS = new Set([
+    "x-aleo-sdk-version",
+    "x-aleo-environment",
+    "x-aleo-method",
+]);
+
 /**
  * Client library that encapsulates REST calls to publicly exposed endpoints of Aleo nodes. The methods provided in this
  * allow users to query public information from the Aleo blockchain and submit transactions to the network.
@@ -259,6 +265,23 @@ class AleoNetworkClient {
         delete this.headers[headerName];
     }
 
+    private userHeaders(): { [key: string]: string } {
+        const result: { [key: string]: string } = {};
+        for (const [key, value] of Object.entries(this.headers)) {
+            if (!HEADERS.has(key.toLowerCase())) {
+                result[key] = value;
+            }
+        }
+        return result;
+    }
+
+    private method(method: string): { [key: string]: string } {
+        if (this.hasCustomTransport) {
+            return this.userHeaders();
+        }
+        return { ...this.headers, "X-ALEO-METHOD": method };
+    }
+
     /**
      * Fetches data from the Aleo network and returns it as a JSON object.
      *
@@ -286,10 +309,9 @@ class AleoNetworkClient {
             const ctx = {...this.ctx};
             return await retryWithBackoff(async () => {
                 const response = await get(this.host + url, {
-                    headers: {
-                        ...this.headers,
-                        ...ctx,
-                    },
+                    headers: this.hasCustomTransport
+                        ? this.userHeaders()
+                        : { ...this.headers, ...ctx },
                 }, this.transport);
                 return await response.text();
             });
@@ -1717,7 +1739,7 @@ class AleoNetworkClient {
             const response = await retryWithBackoff(() =>
                 this._sendPost(`${this.host}/${endpoint}`, {
                     body: transactionString,
-                    headers: Object.assign({}, {...this.headers, "X-ALEO-METHOD" : "submitTransaction"}, {
+                    headers: Object.assign({}, this.method("submitTransaction"), {
                         "Content-Type": "application/json",
                     }),
                 }),
@@ -1749,7 +1771,7 @@ class AleoNetworkClient {
             const response = await retryWithBackoff(() =>
                 post(this.host + "/solution/broadcast", {
                     body: solution,
-                    headers: Object.assign({}, {...this.headers, "X-ALEO-METHOD": "submitSolution"}, {
+                    headers: Object.assign({}, this.method("submitSolution"), {
                         "Content-Type": "application/json",
                     }),
                 }, this.transport),
@@ -1785,7 +1807,8 @@ class AleoNetworkClient {
             `${this.baseUrl}/jwts/${consumerId}`,
             {
                 headers: {
-                    'X-Provable-API-Key': apiKey
+                    ...this.method("refreshJwt"),
+                    'X-Provable-API-Key': apiKey,
                 }
             },
             this.transport,
@@ -1890,8 +1913,7 @@ class AleoNetworkClient {
 
         // Create the necessary headers to hit the provable api.
         const headers: Record<string, string> = {
-            ...this.headers,
-            "X-ALEO-METHOD": "submitProvingRequest",
+            ...this.method("submitProvingRequest"),
             "Content-Type": "application/json",
         };
         if (jwtData?.jwt) {
@@ -2032,10 +2054,7 @@ class AleoNetworkClient {
                     const res = await this.transport(
                         `${this.host}/transaction/confirmed/${transactionId}`,
                         {
-                            headers: {
-                                ...this.headers,
-                                "X-ALEO-METHOD" : "waitForTransactionConfirmation",
-                            },
+                            headers: this.method("waitForTransactionConfirmation"),
                         },
                     );
                     if (!res.ok) {

--- a/sdk/tests/transport.test.ts
+++ b/sdk/tests/transport.test.ts
@@ -67,6 +67,50 @@ describe("Configurable Transport", () => {
             expect(callOptions.headers["X-Custom"]).to.equal("test-value");
         });
 
+        it("suppresses SDK identifying headers when a custom transport is used", async () => {
+            const transport = createMockTransport('"ok"');
+            const client = new AleoNetworkClient("https://example.com", { transport });
+
+            await client.fetchRaw("/test");
+
+            const callOptions = transport.firstCall.args[1];
+            // With a custom transport and no user-supplied headers, none of our SDK
+            // headers (version/environment + method tag) should be attached.
+            const headers = callOptions.headers ?? {};
+            expect(headers["X-Aleo-SDK-Version"]).to.be.undefined;
+            expect(headers["X-Aleo-environment"]).to.be.undefined;
+            expect(headers["X-ALEO-METHOD"]).to.be.undefined;
+        });
+
+        it("forwards headers set via setHeader even with a custom transport", async () => {
+            const transport = createMockTransport('"ok"');
+            const client = new AleoNetworkClient("https://example.com", { transport });
+
+            // Header added after construction (no options.headers supplied).
+            client.setHeader("X-Custom", "later-value");
+            await client.fetchRaw("/test");
+
+            const callOptions = transport.firstCall.args[1];
+            expect(callOptions.headers["X-Custom"]).to.equal("later-value");
+            // The caller's header flows through, but our SDK defaults must not leak.
+            expect(callOptions.headers["X-Aleo-SDK-Version"]).to.be.undefined;
+            expect(callOptions.headers["X-Aleo-environment"]).to.be.undefined;
+        });
+
+        it("attaches SDK identifying headers when using the default transport", async () => {
+            const transport = createMockTransport('"ok"');
+            // Default transport, but route the underlying request through our stub
+            // so we can inspect the headers the SDK attaches.
+            const client = new AleoNetworkClient("https://example.com");
+            client.transport = transport;
+
+            await client.getLatestHeight();
+
+            const callOptions = transport.firstCall.args[1];
+            expect(callOptions.headers["X-Aleo-SDK-Version"]).to.be.a("string");
+            expect(callOptions.headers["X-ALEO-METHOD"]).to.equal("getLatestHeight");
+        });
+
         it("retry logic works with custom transport", async () => {
             let attemptCount = 0;
             const transport: sinon.SinonStub = sinon.stub().callsFake(async () => {

--- a/wasm/src/utilities/rest.rs
+++ b/wasm/src/utilities/rest.rs
@@ -88,6 +88,8 @@ pub async fn get_program_from_network(base_url: &str, program_id: &str) -> Resul
     get(&format!("{base_url}/{}/program/{}", get_network(), program_id)).await
 }
 
+const SDK_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (wasm)");
+
 /// Make a GET request to the service.
 pub async fn get<T>(url: &str) -> Result<T>
 where
@@ -95,7 +97,7 @@ where
 {
     let client = reqwest::Client::new();
     for i in 0..DEFAULT_RETRIES {
-        let request = client.get(url).send().await;
+        let request = client.get(url).header("X-Aleo-SDK-Version", SDK_VERSION).send().await;
         match request {
             Ok(res) => {
                 let status = res.status();


### PR DESCRIPTION
## Summary

Ensure headers aren't passed when a custom transport option is specified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom-transport integrations lose automatic SDK/method headers (intentional), which could affect proxies or logging that depended on them; default clients and auth headers like `X-Provable-API-Key` are unaffected.
> 
> **Overview**
> When `AleoNetworkClient` is constructed with a **custom `transport`**, outbound requests no longer include SDK-identifying headers (`X-Aleo-SDK-Version`, `X-Aleo-environment`, `X-ALEO-METHOD`). Caller headers from `options.headers` or `setHeader()` still pass through.
> 
> Header assembly is centralized via `userHeaders()` / `method()`, used by GET (`fetchRaw`), POSTs (broadcast, proving, JWT refresh), and transaction polling. **Default transport behavior is unchanged**—those headers and per-call method tags are still sent.
> 
> WASM REST GETs now add **`X-Aleo-SDK-Version`** (crate version + `(wasm)`). New transport tests cover suppression vs default transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fcef0dc0d484671d4754886643db68e5bd5990f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->