### PR TITLE
[Chore] Update SDK to v0.11.3 and snarkvm dependency to v4.8.1

### DIFF
--- a/create-leo-app/package.json
+++ b/create-leo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-leo-app",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "type": "module",
   "license": "GPL-3.0",
   "collaborators": [

--- a/create-leo-app/template-build-and-execute-authorization-ts/package.json
+++ b/create-leo-app/template-build-and-execute-authorization-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2"
+    "@provablehq/sdk": "^0.11.3"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-devnode-js/package.json
+++ b/create-leo-app/template-devnode-js/package.json
@@ -7,6 +7,6 @@
     "dev": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2"
+    "@provablehq/sdk": "^0.11.3"
   }
 }

--- a/create-leo-app/template-extension/package.json
+++ b/create-leo-app/template-extension/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf static/js && rollup --config"
   },
   "devDependencies": {
-    "@provablehq/sdk": "^0.11.2",
+    "@provablehq/sdk": "^0.11.3",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@web/rollup-plugin-import-meta-assets": "^2.2.1",
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-nextjs-ts/package.json
+++ b/create-leo-app/template-nextjs-ts/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2",
+    "@provablehq/sdk": "^0.11.3",
     "next": "15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/create-leo-app/template-node-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-node-credits-aleo-functions-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.2"
+        "@provablehq/sdk": "^0.11.3"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
+++ b/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.2"
+        "@provablehq/sdk": "^0.11.3"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-dynamic-dispatch-ts/package.json
+++ b/create-leo-app/template-node-dynamic-dispatch-ts/package.json
@@ -15,7 +15,7 @@
         "test:all": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.2"
+        "@provablehq/sdk": "^0.11.3"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-loyalty-program-ts/package.json
+++ b/create-leo-app/template-node-loyalty-program-ts/package.json
@@ -15,7 +15,7 @@
         "start:caching": "npm run build && node dist/index.js key_caching"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.2",
+        "@provablehq/sdk": "^0.11.3",
         "dotenv": "^16.4.5"
     },
     "devDependencies": {

--- a/create-leo-app/template-node-ts/package.json
+++ b/create-leo-app/template-node-ts/package.json
@@ -10,7 +10,7 @@
     "test": "npm run build && node dist/index.js && node dist/dynamic-dispatch.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2"
+    "@provablehq/sdk": "^0.11.3"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-node/package.json
+++ b/create-leo-app/template-node/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2"
+    "@provablehq/sdk": "^0.11.3"
   }
 }

--- a/create-leo-app/template-offline-public-transaction-ts/package.json
+++ b/create-leo-app/template-offline-public-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node --trace-uncaught dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2"
+    "@provablehq/sdk": "^0.11.3"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-private-transaction-ts/package.json
+++ b/create-leo-app/template-private-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2"
+    "@provablehq/sdk": "^0.11.3"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-react-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-react-credits-aleo-functions-ts/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.2",
+        "@provablehq/sdk": "^0.11.3",
         "comlink": "^4.4.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-leo/package.json
+++ b/create-leo-app/template-react-leo/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2",
+    "@provablehq/sdk": "^0.11.3",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-loyalty-program-ts/package.json
+++ b/create-leo-app/template-react-loyalty-program-ts/package.json
@@ -13,7 +13,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2",
+    "@provablehq/sdk": "^0.11.3",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-managed-worker/package.json
+++ b/create-leo-app/template-react-managed-worker/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2",
+    "@provablehq/sdk": "^0.11.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/create-leo-app/template-react-ts/package.json
+++ b/create-leo-app/template-react-ts/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2",
+    "@provablehq/sdk": "^0.11.3",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-vanilla/package.json
+++ b/create-leo-app/template-vanilla/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@provablehq/sdk": "^0.11.2",
+        "@provablehq/sdk": "^0.11.3",
         "tslib": "^2.8.1",
         "vite": "^6.4.3"
     }

--- a/e2e/dynamic/package.json
+++ b/e2e/dynamic/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2"
+    "@provablehq/sdk": "^0.11.3"
   }
 }

--- a/e2e/mainnet/package.json
+++ b/e2e/mainnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2"
+    "@provablehq/sdk": "^0.11.3"
   }
 }

--- a/e2e/nodenext/package.json
+++ b/e2e/nodenext/package.json
@@ -2,7 +2,7 @@
     "name": "nodenext",
     "type": "module",
     "dependencies": {
-        "@provablehq/sdk": "^0.11.2",
+        "@provablehq/sdk": "^0.11.3",
         "typescript": "^5.7.3"
     },
     "scripts": {

--- a/e2e/testnet/package.json
+++ b/e2e/testnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.2"
+    "@provablehq/sdk": "^0.11.3"
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/sdk",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Provable Team"
@@ -91,7 +91,7 @@
   },
   "homepage": "https://github.com/ProvableHQ/sdk#readme",
   "dependencies": {
-    "@provablehq/wasm": "^0.11.2",
+    "@provablehq/wasm": "^0.11.3",
     "@scure/base": "^2.0.0",
     "@serenity-kit/noble-sodium": "0.2.3",
     "comlink": "^4.4.2",

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -3796,7 +3796,7 @@ class ProgramManager {
      * import { AleoKeyProvider, getOrInitConsensusVersionTestHeights, ProgramManager, NetworkRecordProvider } from "@provablehq/sdk/mainnet.js";
      * 
      * // Initialize the development consensus heights in order to work with devnode.
-     * getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14");
+     * getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
      *
      * // Create a new NetworkClient and RecordProvider.
      * const recordProvider = new NetworkRecordProvider(account, networkClient);
@@ -3963,7 +3963,7 @@ class ProgramManager {
      * import { ProgramManager, NetworkRecordProvider, getOrInitConsensusVersionTestHeights } from "@provablehq/sdk/mainnet.js";
      * 
      * // Initialize the development consensus heights in order to work with a local devnode.
-     * getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14");
+     * getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
      *
      * // Create a new NetworkClient, and RecordProvider
      * const recordProvider = new NetworkRecordProvider(account, networkClient);

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -627,7 +627,7 @@ describe('WASM Objects', () => {
         });
     });
     describe('Set development consensus version heights', () => {
-        it.only('Consensus version heights can be set externally', async () => {
+        it('Consensus version heights can be set externally', async () => {
             if (process.env["RUN_SKIPPED"]) {
                 const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
                 console.log(heights);

--- a/sdk/tests/wasm.test.ts
+++ b/sdk/tests/wasm.test.ts
@@ -627,11 +627,11 @@ describe('WASM Objects', () => {
         });
     });
     describe('Set development consensus version heights', () => {
-        it('Consensus version heights can be set externally', async () => {
+        it.only('Consensus version heights can be set externally', async () => {
             if (process.env["RUN_SKIPPED"]) {
-                const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14");
+                const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
                 console.log(heights);
-                expect(heights).to.deep.equal([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14]);
+                expect(heights).to.deep.equal([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]);
             }
         });
     });

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "12aca1021aef2c476bad30d2f681e891b2be4f07dbc230a96df09cb693bfb3cb"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2599,8 +2599,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb463ee0dbf27520e3b885239da9539d1817bef54414e166abecf53e89bd9182"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2627,8 +2626,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb79631afb088804f48b2b5c553d80003d2d29d164ebdd72b4ae2805167dd294"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2642,8 +2640,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ec5f1223fb704743fb493b810ff7827f97b14ba6522b2a30863c7ed9b8c419"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2653,8 +2650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbbdf99a4b98096477aa642e87f3c032de69dd312120c71557bd3715f7a6ca7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2664,8 +2660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d84b57411579eddf10b9c844874188fa6a1ef461dd195e1004fc0b8b80b8851"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2675,8 +2670,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81d401f337875ebfd9a33551b4ac81e2c79d70309b37e661551df4e756c8ab"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2696,14 +2690,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9e7e5832d167a90d02f2a3dbb329a35ac434d828dfa5a303201ee98f20458"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f3d2413bc19683240cfb561417b90fd45dd7104c82318dae5aa6f4789e49bf"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2714,8 +2706,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336325d1cb446c27a0e519c46671efb4d0afeae5509de142b5225741ad34f6f9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2729,8 +2720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51eb87b289e03b4fa2d6d1d2ae1a731e2471c19916690bd3881e838e5c5f2a0c"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2745,8 +2735,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67f19e8cc472228e6d502c194ee0d40ac8e55f6d6796c4a9de19867f8790310"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2759,8 +2748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62da3b39df237d0bc23db92a77356ae9d78e3030254a777132f7ffa1e361cfaa"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2769,8 +2757,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d791b3f4c37906ebe8dc22f4e9b0596e7d3498619f8654da631cc1494f9ad5dc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2780,8 +2767,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac8d680858600c493c592cac496fb0f6ae3542845d79cdf71059dbe4189f8b3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2793,8 +2779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3ca8f3eae95acb4484f3e1b23dab4a979e10db8fc1dadd8f156413ce8303fa"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2806,8 +2791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875d94a9ebdb15b18f0141a6fd1abfc08d7c4268d08b2729d9343dd7e53557c1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2818,8 +2802,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e2f1ffdf6cc1bedb1d0e97388096e17a9376ff387f787172caaa1a163642d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2831,8 +2814,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0471631ca8ca82c66a21a41dc83691ac949423564eeb67eb0b84a29e9d6b3983"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2845,8 +2827,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752db19fec19734761c805077da1e80e3ef5e68fac0ab94ebbf2c67559780fce"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2857,8 +2838,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeeab6a2a88ecff12d1f146bd652ad4445dcd2fa4f429235e50a7b634fa08927"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2874,8 +2854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bd7a8bb5498077596820b1659296d09bb47165d14512d8e6a77bb37c2e7d4c"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std",
  "parking_lot",
@@ -2888,8 +2867,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9820c26fc45b4ecc4428363d865679a06bbaf20f16d243989558dc4f3a6b6a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2909,8 +2887,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a68a723c76f588353bfc6c32d23784a93afbdde70232eece87721e3b9667718"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2928,8 +2905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e08eea78d9bd65da1b6500a03c5eb46fca629598449f2e5f8ddf7f6c5b497d9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2950,8 +2926,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c1d0cc78b332ab23e3caecd78384cba7739588fc347d59e1bc4b8f6781c938"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2966,8 +2941,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e784ce5f6ae527e47daa30257bfbc03a6faa07a58b56980d50096bdb17cdf4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2978,8 +2952,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37774ccb2e135e81210a00b2ac7a7e831bee8dc77f705b4dd1400784fffb1cb"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2987,8 +2960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fdb611ced23d55453a6607aa1f5742c21791e320c53173f9b6c89cc99915fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2998,8 +2970,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adab0b7f3d8e906be46d4a4a705401d179d75b6c7c507a54e1ac21794d58d7f6"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3010,8 +2981,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce77a6d7ad511e10cbf15e413278f7c55cc98cd9f8cc97bf9a2a97949a356e8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3022,8 +2992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26872058a807c86fc29be004db89d06061063bf0669cede9598153948a46db18"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3034,8 +3003,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e98c7497bb3861a1610a6987edf5b3e79b76c249209252baeb1767a8e238e51"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3046,8 +3014,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb85f50dc014ca37d78e91187e3ed6f2c5f36c505656841647c8a7d16d3951e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "rand 0.10.1",
  "rustc_version",
@@ -3060,8 +3027,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a60e65f8e1c8be65456815cb016cf9c153f272948ebce50f01c5c7b9832eb5c"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3078,8 +3044,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca088fc9fbab4f64484f016c7b8f43ac7864e38962776ba5fe87e340b8a9d1d0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -3091,8 +3056,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab7feccfa232a8125d5d08523f1097c2ff9f940df1b5dd680db33e22051b282"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3116,8 +3080,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b4eb3a3f68f644f3a97badd97231a6142be4c544a827d33527de8bdf0a63b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3129,8 +3092,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2820939e81acdb3a1e956c02a1519a697c04c42500369e13334175c1be5a474c"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3143,8 +3105,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc1aa3d423f36e151fded47358648b3e9f5bdef8f14b649867b2970a8b478f0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3156,8 +3117,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c221e93a87d8d95d04a7ae80cbc002f6f234de6b0aeb2e4cc671472c4ed86a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3167,8 +3127,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909c86ab8ffb66d68e65008a2bc7587f804f90c880e546959e012768f2f52c8a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3183,8 +3142,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90735fbb67ea6a28835fa4aca7fbd23f8082254001a26458fd54bd8e25a280ec"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3193,8 +3151,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9930f2b8f6d7af1c4df5ca9e1fc58a1245614d602a23dcacdba2f49c196dce"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3214,8 +3171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39769888aa99f476ba96f58f130baec1adf8cc2cb403e582f6b750d9fe7b4618"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3237,8 +3193,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fab416cca1cc120da5e23da9f96c33e63a66291d5b57900edff4e066eb37860"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3255,8 +3210,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af053ce8e70479bf733f1060d8583f5508fe395afe1776494428dd8bd3d6b198"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3281,8 +3235,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce50be3cbc636838eda13c6312fe1c957b3d09a61fe8d1636f2ce227be756e60"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3307,8 +3260,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef3f5387331260f4af6c6ce339814516e5783f6c78ec83cceb5a922688e25c7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3322,6 +3274,7 @@ dependencies = [
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
+ "snarkvm-ledger-authority",
  "snarkvm-ledger-block",
  "snarkvm-ledger-committee",
  "snarkvm-ledger-narwhal-data",
@@ -3342,8 +3295,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f292aa7ab9d8db2a092256cf79ee704445b82a0bfdc008ddce2fde78bf5f56"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -3355,8 +3307,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e9a83a46498378477aaee8e7a07a5ddd2cd5a7c05bf9b2a1497cda317ac3dc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3382,8 +3333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22fa0ec46f528d531af6ab72005a51acff64d7c9a9732384f11c59c65f64f50"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -3404,8 +3354,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef07277ee50c309a3e74d49d869ffc5e4e358a00b57738760cdb2a8e2ab77ebe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3418,8 +3367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4d04f7357366dcbbae21249334ed2ad5ffefc09bd00f0d418f4bba34fba86c"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3442,8 +3390,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50ca261adb518781bf4cfb9d6b69c385d00fca93bf5b5e6838c93598206bd8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -3453,8 +3400,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-wasm"
 version = "4.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca37740071a92654a9edd06f0820fed4ee9404d397bcb75d0a8b038b175762f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b7f0859592c75dd251430377240c7697a37ab899#b7f0859592c75dd251430377240c7697a37ab899"
 dependencies = [
  "getrandom 0.4.2",
  "snarkvm-console",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-wasm"
-version = "0.11.2"
+version = "0.11.3"
 authors = [ "The Provable Team" ]
 description = "WebAssembly based toolkit for developing zero-knowledge applications with Aleo"
 homepage = "https://provable.com"
@@ -22,14 +22,17 @@ crate-type = [ "cdylib", "rlib" ]
 doctest = false
 
 [dependencies.snarkvm-algorithms]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 
 [dependencies.snarkvm-circuit-network]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 features = ["wasm"]
 
 [dependencies.snarkvm-console]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 default-features = false
 features = [
     "account",
@@ -42,31 +45,38 @@ features = [
 ]
 
 [dependencies.snarkvm-ledger-block]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 features = ["wasm"]
 
 [dependencies.snarkvm-ledger-query]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-ledger-store]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 
 [dependencies.snarkvm-parameters]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer-program]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 features = ["wasm"]
 
 [dependencies.snarkvm-synthesizer]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 features = ["async", "wasm"]
 
 [dependencies.snarkvm-wasm]
-version = "4.7.3"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "b7f0859592c75dd251430377240c7697a37ab899"
 features = ["fields", "utilities"]
 
 [dependencies.anyhow]

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/wasm",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [

--- a/wasm/src/utilities/mod.rs
+++ b/wasm/src/utilities/mod.rs
@@ -46,7 +46,7 @@ pub mod test;
 /// import { getOrInitConsensusVersionTestHeights } from '@provablehq/sdk';
 ///
 /// Set the consensus version heights.
-/// getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14");
+/// getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
 #[wasm_bindgen::prelude::wasm_bindgen(js_name = getOrInitConsensusVersionTestHeights)]
 pub fn get_or_init_consensus_version_heights(heights: Option<String>) -> js_sys::Array {
     // Call the underlying Rust function that returns [(ConsensusVersion, u32); N]

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
         "@codemirror/language": "^6.10.8",
         "@codemirror/legacy-modes": "^6.4.2",
         "@codemirror/stream-parser": "^0.19.9",
-        "@provablehq/sdk": "^0.11.2",
+        "@provablehq/sdk": "^0.11.3",
         "@uiw/codemirror-theme-noctis-lilac": "^4.23.7",
         "@uiw/codemirror-theme-okaidia": "^4.23.7",
         "@uiw/react-codemirror": "^4.23.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,12 +3002,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@provablehq/sdk@npm:^0.11.2, @provablehq/sdk@workspace:sdk":
+"@provablehq/sdk@npm:^0.11.3, @provablehq/sdk@workspace:sdk":
   version: 0.0.0-use.local
   resolution: "@provablehq/sdk@workspace:sdk"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.18.2"
-    "@provablehq/wasm": "npm:^0.11.2"
+    "@provablehq/wasm": "npm:^0.11.3"
     "@rollup/plugin-replace": "npm:^6.0.2"
     "@scure/base": "npm:^2.0.0"
     "@serenity-kit/noble-sodium": "npm:0.2.3"
@@ -3041,7 +3041,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@provablehq/wasm@npm:^0.11.2, @provablehq/wasm@workspace:wasm":
+"@provablehq/wasm@npm:^0.11.3, @provablehq/wasm@workspace:wasm":
   version: 0.0.0-use.local
   resolution: "@provablehq/wasm@workspace:wasm"
   dependencies:
@@ -4760,7 +4760,7 @@ __metadata:
     "@babel/core": "npm:^7.29.6"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4793,7 +4793,7 @@ __metadata:
     "@babel/core": "npm:^7.29.6"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4825,7 +4825,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -4859,7 +4859,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aleo-starter@workspace:create-leo-app/template-vanilla"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     tslib: "npm:^2.8.1"
     vite: "npm:^6.4.3"
   languageName: unknown
@@ -4877,7 +4877,7 @@ __metadata:
     "@codemirror/language": "npm:^6.10.8"
     "@codemirror/legacy-modes": "npm:^6.4.2"
     "@codemirror/stream-parser": "npm:^0.19.9"
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@uiw/codemirror-theme-noctis-lilac": "npm:^4.23.7"
@@ -6704,7 +6704,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "devnode-starter@workspace:create-leo-app/template-devnode-js"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
   languageName: unknown
   linkType: soft
 
@@ -6882,7 +6882,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-dynamic@workspace:e2e/dynamic"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
   languageName: unknown
   linkType: soft
 
@@ -6890,7 +6890,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-mainnet@workspace:e2e/mainnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
   languageName: unknown
   linkType: soft
 
@@ -6898,7 +6898,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-testnet@workspace:e2e/testnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
   languageName: unknown
   linkType: soft
 
@@ -7639,7 +7639,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "extension-starter@workspace:create-leo-app/template-extension"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     "@rollup/plugin-node-resolve": "npm:^16.0.0"
     "@web/rollup-plugin-import-meta-assets": "npm:^2.2.1"
     rimraf: "npm:^6.0.1"
@@ -10306,7 +10306,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-build-and-execute-authorization-ts-starter@workspace:create-leo-app/template-build-and-execute-authorization-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10377,7 +10377,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-offline-transaction-example@workspace:create-leo-app/template-offline-public-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10396,7 +10396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-starter@workspace:create-leo-app/template-node"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
   languageName: unknown
   linkType: soft
 
@@ -10404,7 +10404,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-starter@workspace:create-leo-app/template-node-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10416,7 +10416,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-transfer-private-starter@workspace:create-leo-app/template-private-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10428,7 +10428,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nodenext@workspace:e2e/nodenext"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
@@ -13792,7 +13792,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-nextjs@workspace:create-leo-app/template-nextjs-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
@@ -13808,7 +13808,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-credits-aleo-functions-ts@workspace:create-leo-app/template-node-credits-aleo-functions-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13820,7 +13820,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-dynamic-dispatch-proving-ts@workspace:create-leo-app/template-node-dynamic-dispatch-proving-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13832,7 +13832,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-dynamic-dispatch-ts@workspace:create-leo-app/template-node-dynamic-dispatch-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13844,7 +13844,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-loyalty-program-ts@workspace:create-leo-app/template-node-loyalty-program-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     dotenv: "npm:^16.4.5"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
@@ -13861,7 +13861,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -13899,7 +13899,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.11.2"
+    "@provablehq/sdk": "npm:^0.11.3"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Pinning snarkVM to a git rev and extending consensus version test heights can change proving, execution, and devnode behavior across the whole stack.
> 
> **Overview**
> Releases **v0.11.3** for `create-leo-app`, `@provablehq/sdk`, and `@provablehq/wasm`, and aligns every template, e2e package, `website`, and `yarn.lock` on `@provablehq/sdk` / `@provablehq/wasm` **^0.11.3**.
> 
> The WASM crate no longer pulls **snarkVM** from crates.io; all `snarkvm-*` dependencies in `wasm/Cargo.toml` are pinned to a fixed **git revision** on `ProvableHQ/snarkVM`, with `Cargo.lock` updated accordingly (including a new `snarkvm-ledger-authority` edge on `snarkvm-synthesizer`).
> 
> Devnode / test consensus setup now documents and asserts **two extra** `getOrInitConsensusVersionTestHeights` entries (`15` and `16`) in `program-manager` JSDoc, `wasm` bindings docs, and `sdk/tests/wasm.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cffae8ac2c7e7133afe14fecc29c3d1138057ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->