### PR TITLE
[Fix] Merge static and provided program imports

### DIFF
--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -392,8 +392,77 @@ class ProgramManager {
     }
 
     /**
+     * Collect static imports declared by the entry program together with any
+     * caller-provided imports, then resolve missing transitive dependencies.
+     * Caller-provided program sources take precedence over network sources.
+     */
+    private async collectProgramImports(
+        program: string | Program,
+        imports: ProgramImports | undefined,
+        tolerateNetworkErrors: boolean,
+    ): Promise<Map<string, string>> {
+        const programSource = typeof program === "string" ? program : program.toString();
+        const providedImports = { ...(imports ?? {}) };
+        let resolvedImports: ProgramImports = { ...providedImports };
+
+        if (ProgramManager.getImportNames(programSource).length > 0) {
+            try {
+                const networkImports = await this.networkClient.getProgramImports(
+                    programSource,
+                    { ...resolvedImports },
+                );
+                resolvedImports = { ...networkImports, ...providedImports };
+            } catch (e) {
+                if (!tolerateNetworkErrors) throw e;
+                logger.warn(`Failed to resolve program imports from network: ${e}.`);
+            }
+        }
+
+        const collected = new Map<string, string>();
+        const collectQueue: [string, string][] = Object.entries(resolvedImports).map(
+            ([name, source]) => [name, typeof source === "string" ? source : source.toString()]
+        );
+
+        while (collectQueue.length > 0) {
+            const [name, source] = collectQueue.shift()!;
+            if (collected.has(name)) continue;
+            collected.set(name, source);
+
+            try {
+                const subImports = ProgramManager.getImportNames(source);
+                const unknownImports = subImports.filter(
+                    (id: string) => !collected.has(id) && !(id in resolvedImports),
+                );
+                if (unknownImports.length > 0) {
+                    const fetched = await Promise.all(
+                        unknownImports.map(async (id: string) => {
+                            try {
+                                const importedSource = await this.networkClient.getProgram(id);
+                                return [id, importedSource] as [string, string];
+                            } catch (e) {
+                                if (!tolerateNetworkErrors) throw e;
+                                return null;
+                            }
+                        }),
+                    );
+                    for (const entry of fetched) {
+                        if (entry && !collected.has(entry[0])) {
+                            collectQueue.push(entry);
+                        }
+                    }
+                }
+            } catch (e) {
+                if (!tolerateNetworkErrors) throw e;
+                logger.warn(`Failed to resolve transitive imports for ${name}: ${e}`);
+            }
+        }
+
+        return collected;
+    }
+
+    /**
      * Build a ProgramImportsBuilder from a program and its imports.
-     * Fetches imports from the network if not provided, resolves transitive
+     * Fetches missing imports from the network, resolves transitive
      * dependencies, and optionally pre-loads cached keys from the KeyStore.
      *
      * @param loadKeys When true (default), loads cached proving/verifying keys
@@ -415,17 +484,7 @@ class ProgramManager {
             return { builder, importEditions: new Map() };
         }
 
-        let resolvedImports: ProgramImports = {};
-        if (imports) {
-            resolvedImports = { ...imports };
-        }
-        if (importNames.length > 0 && !imports) {
-            try {
-                resolvedImports = await this.networkClient.getProgramImports(programSource);
-            } catch (e) {
-                logger.warn(`Failed to resolve program imports from network: ${e}.`);
-            }
-        }
+        const collected = await this.collectProgramImports(programSource, imports, true);
 
         // Build a map of which functions each import actually calls,
         // so we only load keys for functions in the call chain.
@@ -433,58 +492,7 @@ class ProgramManager {
             programObj.getCallGraph(entryFunction),
         );
 
-        // Phase 1: Collect all programs via BFS, discovering transitive imports.
-        // The initial getProgramImports call above already resolves the full
-        // transitive closure via recursive DFS.  The BFS loop here only needs
-        // to handle user-provided imports whose transitive deps may not yet be
-        // known.  For each unknown import we issue a single getProgram() call
-        // (not a full recursive getProgramImports) and fetch siblings in
-        // parallel to minimize round-trips.
-        const collected = new Map<string, string>();
-        const collectQueue: [string, string][] = Object.entries(resolvedImports).map(
-            ([name, src]) => [name, typeof src === "string" ? src : src.toString()]
-        );
-
-        while (collectQueue.length > 0) {
-            const [name, source] = collectQueue.shift()!;
-            if (collected.has(name)) continue;
-            collected.set(name, source);
-
-            // Discover transitive imports for collection (call-graph tracing
-            // happens in a separate pass after topological sorting).
-            try {
-                const subImports = ProgramManager.getImportNames(source);
-                if (subImports.length > 0) {
-                    // Fetch only unknown transitive imports — the source for
-                    // programs already in collected/resolvedImports is known, so
-                    // we skip them.  Fetches within a BFS level run in parallel.
-                    const unknownImports = subImports.filter(
-                        (id: string) => !collected.has(id) && !(id in resolvedImports),
-                    );
-                    if (unknownImports.length > 0) {
-                        const fetched = await Promise.all(
-                            unknownImports.map(async (id: string) => {
-                                try {
-                                    const src = await this.networkClient.getProgram(id);
-                                    return [id, src] as [string, string];
-                                } catch {
-                                    return null;
-                                }
-                            }),
-                        );
-                        for (const entry of fetched) {
-                            if (entry && !collected.has(entry[0])) {
-                                collectQueue.push(entry);
-                            }
-                        }
-                    }
-                }
-            } catch (e) {
-                logger.warn(`Failed to resolve transitive imports for ${name}: ${e}`);
-            }
-        }
-
-        // Phase 2: Add programs in topological order (leaves first).
+        // Add programs in topological order (leaves first).
         // A simple DFS post-order ensures dependencies are added before
         // dependents, regardless of the order collected entries arrived.
         const sorted: [string, string][] = [];
@@ -3700,7 +3708,9 @@ class ProgramManager {
             throw new Error("Authorization must be provided if estimating fee for Authorization.")
         }
         const programSource = program ? program.toString() : await this.networkClient.getProgram(programName, edition);
-        const programImports = imports ?? await this.networkClient.getProgramImports(programSource);
+        const programImports = Object.fromEntries(
+            await this.collectProgramImports(programSource, imports, false),
+        );
         return WasmProgramManager.estimateFeeForAuthorization(authorization, programSource, programImports, edition);
     }
 
@@ -3744,7 +3754,9 @@ class ProgramManager {
             throw new Error("Function name must be specified when estimating fee.");
         }
         const programSource = program ? program.toString() : await this.networkClient.getProgram(programName, edition);
-        const programImports = imports ? imports : await this.networkClient.getProgramImports(programSource);
+        const programImports = Object.fromEntries(
+            await this.collectProgramImports(programSource, imports, false),
+        );
         return WasmProgramManager.estimateExecutionFee(programSource, functionName, programImports, edition);
     }
 

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -193,6 +193,42 @@ describe("ProgramImportsBuilder", () => {
             expect(builder.contains("multiply_test.aleo")).to.equal(true);
         });
 
+        it("should merge entry imports with additional caller-provided imports", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const imports = { "sum_double_test.aleo": ADD_DOUBLE_PROGRAM };
+
+            const networkStub = sinon.stub(pm.networkClient, "getProgramImports").callsFake(
+                async (_program, seededImports = {}) => ({
+                    ...seededImports,
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                }),
+            );
+            sinon.stub(pm.networkClient, "getProgram")
+                .withArgs("sum_test.aleo")
+                .resolves(ADD_PROGRAM);
+            sinon.stub(pm.networkClient, "getProgramAmendmentCount").resolves({
+                program_id: "test.aleo",
+                edition: 1,
+                amendment_count: 0,
+            });
+
+            const { builder } = await (pm as any).buildProgramImports(
+                DOUBLE_PROGRAM,
+                imports,
+                false,
+                "double_it",
+            );
+
+            expect(networkStub.calledOnce).to.equal(true);
+            expect(networkStub.firstCall.args[1]).to.deep.equal(imports);
+            expect(Array.from(builder.programNames())).to.have.members([
+                "multiply_test.aleo",
+                "sum_double_test.aleo",
+                "sum_test.aleo",
+            ]);
+        });
+
         it("should not fail when network fetch errors", async () => {
             const keyProvider = createMockKeyProvider();
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
@@ -226,6 +262,47 @@ describe("ProgramImportsBuilder", () => {
             expect(builder.contains("double_test.aleo")).to.equal(true);
             expect(builder.contains("multiply_test.aleo")).to.equal(true);
             expect(Array.from(builder.programNames())).to.have.length(2);
+        });
+    });
+
+    describe("fee estimation import resolution", () => {
+        it("should merge entry imports with caller imports for both fee estimators", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const imports = { "sum_double_test.aleo": ADD_DOUBLE_PROGRAM };
+
+            sinon.stub(pm.networkClient, "getProgramImports").callsFake(
+                async (_program, seededImports = {}) => ({
+                    ...seededImports,
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                }),
+            );
+            sinon.stub(pm.networkClient, "getProgram")
+                .withArgs("sum_test.aleo")
+                .resolves(ADD_PROGRAM);
+            const executionFeeStub = sinon.stub(ProgramManagerBase, "estimateExecutionFee").returns(1n);
+            const authorizationFeeStub = sinon.stub(ProgramManagerBase, "estimateFeeForAuthorization").returns(1n);
+
+            await pm.estimateExecutionFee({
+                programName: "double_test.aleo",
+                functionName: "double_it",
+                program: DOUBLE_PROGRAM,
+                imports,
+            });
+            await pm.estimateFeeForAuthorization({
+                authorization: {} as any,
+                programName: "double_test.aleo",
+                program: DOUBLE_PROGRAM,
+                imports,
+            });
+
+            const expectedImports = {
+                "multiply_test.aleo": MULTIPLY_PROGRAM,
+                "sum_double_test.aleo": ADD_DOUBLE_PROGRAM,
+                "sum_test.aleo": ADD_PROGRAM,
+            };
+            expect(executionFeeStub.firstCall.args[2]).to.deep.equal(expectedImports);
+            expect(authorizationFeeStub.firstCall.args[2]).to.deep.equal(expectedImports);
         });
     });
 


### PR DESCRIPTION
## Motivation

ProgramManager currently skips resolving the entry program static import closure whenever callers provide an imports map. This breaks execution paths that need both statically declared imports and caller-provided dynamic-call targets, including the local-proving failure described in https://github.com/ProvableHQ/shield-extension/issues/873.

This PR centralizes import collection so that it:

- resolves the entry program static imports even when additional imports are provided
- discovers missing transitive dependencies
- preserves caller-provided sources as overrides
- applies the same behavior to ProgramImportsBuilder and both fee estimators

## Test Plan

- [x] yarn build:sdk
- [x] Mainnet program-imports suite: 81 passing
- [x] Testnet static-plus-provided import regressions: 2 passing
- [x] git diff --cached --check

## Related PRs

- https://github.com/ProvableHQ/shield-extension/pull/872
- https://github.com/ProvableHQ/shield-extension/issues/873

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution and fee-estimation import resolution; behavior changes when partial `imports` are supplied, though overrides and new tests reduce regression risk.
> 
> **Overview**
> Fixes import resolution when callers pass an `imports` map: **static `import` declarations on the entry program are no longer skipped**, so execution and fee paths get both network/static closure and extra caller targets (e.g. dynamic-call programs).
> 
> **`collectProgramImports`** is the new shared helper. It seeds `getProgramImports` with caller-provided sources, merges network results with overrides (`provided` wins), walks transitive deps via BFS/`getProgram`, and returns a `Map`. **`buildProgramImports`** delegates collection to it and keeps topological ordering, call-graph key scoping, and KeyStore loading unchanged.
> 
> **`estimateExecutionFee`** and **`estimateFeeForAuthorization`** now build imports through `collectProgramImports` (strict network errors) instead of using only the caller map or a bare `getProgramImports` call. Tests cover merged static + provided imports and fee estimator args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6378f8a960405a85acd360897159462b091a583f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->