### PR TITLE
[Feature] Add serializeProvingRequest and encryptSerializedProvingRequest

### DIFF
--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -319,7 +319,15 @@ export {
     KeyVerifier as FunctionKeyVerifier,
 } from "./keys/verifier/interface.js";
 
-export { encryptAuthorization, encryptProvingRequest, encryptViewKey, encryptRegistrationRequest, zeroizeBytes } from "./security.js";
+export {
+    encryptAuthorization,
+    encryptProvingRequest,
+    encryptSerializedProvingRequest,
+    encryptViewKey,
+    encryptRegistrationRequest,
+    serializeProvingRequest,
+    zeroizeBytes,
+} from "./security.js";
 
 export {
     // Converters

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -27,6 +27,46 @@ export function encryptProvingRequest(publicKey: string, provingRequest: Proving
 }
 
 /**
+ * Serialize a ProvingRequest for later encryption with
+ * `encryptSerializedProvingRequest`.
+ *
+ * Useful when the request may have to be encrypted more than once: the
+ * delegated proving service's one-time keys are single-use, so a client that
+ * needs to resend a request (e.g. after the service rejected a spent or
+ * unknown `key_id`) can keep the serialized form and re-encrypt it for a
+ * fresh key instead of rebuilding and re-signing the request.
+ *
+ * @param {ProvingRequest} provingRequest the ProvingRequest to serialize.
+ *
+ * @returns {string} the serialized ProvingRequest in RFC 4648 standard Base64.
+ */
+export function serializeProvingRequest(provingRequest: ProvingRequest): string {
+    return base64.encode(provingRequest.toBytesLe());
+}
+
+/**
+ * Encrypt an already-serialized ProvingRequest (as produced by
+ * `serializeProvingRequest`) with a cryptobox X25519 public key
+ * (libsodium-compatible wire format).
+ *
+ * Produces exactly the same ciphertext format as `encryptProvingRequest` —
+ * `encryptSerializedProvingRequest(pk, serializeProvingRequest(req))` and
+ * `encryptProvingRequest(pk, req)` are interchangeable from the proving
+ * service's point of view.
+ *
+ * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
+ * @param {string} serializedProvingRequest the serialized ProvingRequest in RFC 4648 standard Base64.
+ *
+ * @returns {string} the encrypted ProvingRequest in RFC 4648 standard Base64.
+ */
+export function encryptSerializedProvingRequest(
+    publicKey: string,
+    serializedProvingRequest: string,
+): string {
+    return encryptMessage(publicKey, base64.decode(serializedProvingRequest));
+}
+
+/**
  * Encrypt a view key with a cryptobox X25519 public key (libsodium-compatible wire format).
  *
  * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -36,12 +36,19 @@ export function encryptProvingRequest(publicKey: string, provingRequest: Proving
  * unknown `key_id`) can keep the serialized form and re-encrypt it for a
  * fresh key instead of rebuilding and re-signing the request.
  *
+ * The returned buffer contains the plaintext request (including the signed
+ * authorization and its inputs) and is owned by the caller: keep it only as
+ * long as a resend may still be needed, then overwrite it with
+ * `zeroizeBytes(serialized)`. Zeroization in JavaScript is best-effort (see
+ * `zeroizeBytes`), and transient copies made inside the wasm boundary by
+ * `toBytesLe` are outside its reach.
+ *
  * @param {ProvingRequest} provingRequest the ProvingRequest to serialize.
  *
- * @returns {string} the serialized ProvingRequest in RFC 4648 standard Base64.
+ * @returns {Uint8Array} the serialized ProvingRequest bytes.
  */
-export function serializeProvingRequest(provingRequest: ProvingRequest): string {
-    return base64.encode(provingRequest.toBytesLe());
+export function serializeProvingRequest(provingRequest: ProvingRequest): Uint8Array {
+    return provingRequest.toBytesLe();
 }
 
 /**
@@ -54,16 +61,21 @@ export function serializeProvingRequest(provingRequest: ProvingRequest): string 
  * `encryptProvingRequest(pk, req)` are interchangeable from the proving
  * service's point of view.
  *
+ * The input buffer is not mutated and deliberately not zeroized here: the
+ * caller keeps ownership so the same bytes can be re-encrypted for another
+ * one-time key (retry). Call `zeroizeBytes(serializedProvingRequest)` once
+ * no resend can be needed anymore.
+ *
  * @param {string} publicKey The cryptobox X25519 public key to encrypt with (encoded in RFC 4648 standard Base64).
- * @param {string} serializedProvingRequest the serialized ProvingRequest in RFC 4648 standard Base64.
+ * @param {Uint8Array} serializedProvingRequest the serialized ProvingRequest bytes.
  *
  * @returns {string} the encrypted ProvingRequest in RFC 4648 standard Base64.
  */
 export function encryptSerializedProvingRequest(
     publicKey: string,
-    serializedProvingRequest: string,
+    serializedProvingRequest: Uint8Array,
 ): string {
-    return encryptMessage(publicKey, base64.decode(serializedProvingRequest));
+    return encryptMessage(publicKey, serializedProvingRequest);
 }
 
 /**

--- a/sdk/src/security.ts
+++ b/sdk/src/security.ts
@@ -11,7 +11,14 @@ import { ViewKey, Authorization, ProvingRequest } from "./wasm.js";
  * @returns {string} the encrypted authorization in RFC 4648 standard Base64.
  */
 export function encryptAuthorization(publicKey: string, authorization: Authorization): string {
-    return encryptMessage(publicKey, authorization.toBytesLe());
+    // Zeroize the intermediate plaintext bytes regardless of success or
+    // failure — same pattern as encryptRegistrationRequest.
+    const bytes = authorization.toBytesLe();
+    try {
+        return encryptMessage(publicKey, bytes);
+    } finally {
+        zeroizeBytes(bytes);
+    }
 }
 
 /**
@@ -23,7 +30,14 @@ export function encryptAuthorization(publicKey: string, authorization: Authoriza
  * @returns {string} the encrypted ProvingRequest in RFC 4648 standard Base64.
  */
 export function encryptProvingRequest(publicKey: string, provingRequest: ProvingRequest): string {
-    return encryptMessage(publicKey, provingRequest.toBytesLe());
+    // Zeroize the intermediate plaintext bytes regardless of success or
+    // failure — same pattern as encryptRegistrationRequest.
+    const bytes = provingRequest.toBytesLe();
+    try {
+        return encryptMessage(publicKey, bytes);
+    } finally {
+        zeroizeBytes(bytes);
+    }
 }
 
 /**
@@ -87,7 +101,14 @@ export function encryptSerializedProvingRequest(
  * @returns {string} the encrypted view key in RFC 4648 standard Base64.
  */
 export function encryptViewKey(publicKey: string, viewKey: ViewKey): string {
-    return encryptMessage(publicKey, viewKey.toBytesLe());
+    // Zeroize the intermediate plaintext bytes regardless of success or
+    // failure — same pattern as encryptRegistrationRequest.
+    const bytes = viewKey.toBytesLe();
+    try {
+        return encryptMessage(publicKey, bytes);
+    } finally {
+        zeroizeBytes(bytes);
+    }
 }
 
 /**

--- a/sdk/tests/security.test.ts
+++ b/sdk/tests/security.test.ts
@@ -11,8 +11,29 @@ import {
     serializeProvingRequest,
     zeroizeBytes,
     Authorization,
+    ExecutionRequest,
     ProvingRequest,
 } from "../src/node.js";
+
+// Construct a Request-variant ProvingRequest without any network access —
+// same pattern as the routing tests in network-client.test.ts.
+function buildProvingRequest(): ProvingRequest {
+    const privateKey = new Account().privateKey();
+    const inputs = ["aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px", "100u64"];
+    const inputTypes = ["address.public", "u64.public"];
+    const executionRequest = ExecutionRequest.sign(
+        privateKey,
+        "credits.aleo",
+        "transfer_public",
+        inputs,
+        inputTypes,
+        undefined,
+        undefined,
+        true,
+        false,
+    );
+    return ProvingRequest.fromRequest(executionRequest, undefined, false);
+}
 
 describe("security", () => {
     before(async () => {
@@ -109,42 +130,92 @@ describe("security", () => {
             expect(raw.length).to.equal(32 + 16 + viewKeyBytes.length);
         });
 
-        it("encryptSerializedProvingRequest round-trips through sodium.crypto_box_seal_open", () => {
+        it("serializeProvingRequest returns the request's exact toBytesLe bytes", () => {
+            const provingRequest = buildProvingRequest();
+
+            const serialized = serializeProvingRequest(provingRequest);
+
+            expect(serialized).to.be.an.instanceOf(Uint8Array);
+            expect(serialized).to.deep.equal(provingRequest.toBytesLe());
+            // Wire-valid: the bytes deserialize back into a Request-variant.
+            expect(ProvingRequest.fromBytesLeRequest(serialized).kind()).to.equal("request");
+        });
+
+        it("encryptSerializedProvingRequest round-trips and leaves the input buffer untouched", () => {
             const keyPair = sodium.crypto_box_keypair();
             const pub = sodium.to_base64(keyPair.publicKey, sodium.base64_variants.ORIGINAL);
-            // Arbitrary request bytes — the function is agnostic to the payload.
-            const requestBytes = new Account().viewKey().toBytesLe();
+            const serialized = serializeProvingRequest(buildProvingRequest());
+            const reference = serialized.slice();
 
-            const ciphertext = encryptSerializedProvingRequest(pub, base64.encode(requestBytes));
+            const ciphertext = encryptSerializedProvingRequest(pub, serialized);
+
+            // Input ownership stays with the caller: not mutated, reusable for a retry.
+            expect(serialized).to.deep.equal(reference);
 
             const plaintextBytes = sodium.crypto_box_seal_open(
                 sodium.from_base64(ciphertext, sodium.base64_variants.ORIGINAL),
                 keyPair.publicKey,
                 keyPair.privateKey,
             );
-            expect(plaintextBytes).to.deep.equal(requestBytes);
+            expect(plaintextBytes).to.deep.equal(reference);
         });
 
-        it("the serialized path is byte-compatible with the typed encrypt* wrappers", () => {
+        it("is interchangeable with encryptProvingRequest for the same request", () => {
             const keyPair = sodium.crypto_box_keypair();
             const pub = sodium.to_base64(keyPair.publicKey, sodium.base64_variants.ORIGINAL);
-            const viewKey = new Account().viewKey();
-            const expected = viewKey.toBytesLe();
+            const provingRequest = buildProvingRequest();
+            const serialized = serializeProvingRequest(provingRequest);
 
-            // encryptViewKey(pk, vk) and encryptSerializedProvingRequest(pk,
-            // base64(vk.toBytesLe())) feed the same bytes into the same sealed
-            // box, so both ciphertexts must decrypt to identical plaintext.
-            const typed = encryptViewKey(pub, viewKey);
-            const serialized = encryptSerializedProvingRequest(pub, base64.encode(expected));
+            const typedCiphertext = encryptProvingRequest(pub, provingRequest);
+            const serializedCiphertext = encryptSerializedProvingRequest(pub, serialized);
 
-            for (const ciphertext of [typed, serialized]) {
-                const plaintextBytes = sodium.crypto_box_seal_open(
+            const open = (ciphertext: string) =>
+                sodium.crypto_box_seal_open(
                     sodium.from_base64(ciphertext, sodium.base64_variants.ORIGINAL),
                     keyPair.publicKey,
                     keyPair.privateKey,
                 );
-                expect(plaintextBytes).to.deep.equal(expected);
+            expect(open(typedCiphertext)).to.deep.equal(open(serializedCiphertext));
+            expect(open(serializedCiphertext)).to.deep.equal(serialized);
+        });
+
+        it("supports the retry pattern: re-encrypt for a fresh key, then zeroize", () => {
+            const firstKeyPair = sodium.crypto_box_keypair();
+            const secondKeyPair = sodium.crypto_box_keypair();
+            const serialized = serializeProvingRequest(buildProvingRequest());
+            const reference = serialized.slice();
+
+            let firstCiphertext: string;
+            let secondCiphertext: string;
+            try {
+                firstCiphertext = encryptSerializedProvingRequest(
+                    sodium.to_base64(firstKeyPair.publicKey, sodium.base64_variants.ORIGINAL),
+                    serialized,
+                );
+                // e.g. the proving service rejected the first one-time key —
+                // the SAME bytes are re-encrypted for a fresh key.
+                secondCiphertext = encryptSerializedProvingRequest(
+                    sodium.to_base64(secondKeyPair.publicKey, sodium.base64_variants.ORIGINAL),
+                    serialized,
+                );
+            } finally {
+                zeroizeBytes(serialized);
             }
+
+            expect(serialized).to.deep.equal(new Uint8Array(reference.length));
+
+            const firstPlaintext = sodium.crypto_box_seal_open(
+                sodium.from_base64(firstCiphertext, sodium.base64_variants.ORIGINAL),
+                firstKeyPair.publicKey,
+                firstKeyPair.privateKey,
+            );
+            const secondPlaintext = sodium.crypto_box_seal_open(
+                sodium.from_base64(secondCiphertext, sodium.base64_variants.ORIGINAL),
+                secondKeyPair.publicKey,
+                secondKeyPair.privateKey,
+            );
+            expect(firstPlaintext).to.deep.equal(reference);
+            expect(secondPlaintext).to.deep.equal(reference);
         });
 
         it("fuzz: 50 random messages all decrypt back to the original", () => {

--- a/sdk/tests/security.test.ts
+++ b/sdk/tests/security.test.ts
@@ -5,8 +5,10 @@ import {
     Account,
     encryptAuthorization,
     encryptProvingRequest,
+    encryptSerializedProvingRequest,
     encryptViewKey,
     encryptRegistrationRequest,
+    serializeProvingRequest,
     zeroizeBytes,
     Authorization,
     ProvingRequest,
@@ -37,8 +39,10 @@ describe("security", () => {
         it("all encrypt/zeroize exports exist as functions", () => {
             expect(encryptAuthorization).to.be.a("function");
             expect(encryptProvingRequest).to.be.a("function");
+            expect(encryptSerializedProvingRequest).to.be.a("function");
             expect(encryptViewKey).to.be.a("function");
             expect(encryptRegistrationRequest).to.be.a("function");
+            expect(serializeProvingRequest).to.be.a("function");
             expect(zeroizeBytes).to.be.a("function");
             // Guard against WASM types being tree-shaken away.
             expect(Authorization).to.exist;
@@ -103,6 +107,44 @@ describe("security", () => {
 
             // 32-byte ephemeral public key prefix + 16-byte Poly1305 tag + payload
             expect(raw.length).to.equal(32 + 16 + viewKeyBytes.length);
+        });
+
+        it("encryptSerializedProvingRequest round-trips through sodium.crypto_box_seal_open", () => {
+            const keyPair = sodium.crypto_box_keypair();
+            const pub = sodium.to_base64(keyPair.publicKey, sodium.base64_variants.ORIGINAL);
+            // Arbitrary request bytes — the function is agnostic to the payload.
+            const requestBytes = new Account().viewKey().toBytesLe();
+
+            const ciphertext = encryptSerializedProvingRequest(pub, base64.encode(requestBytes));
+
+            const plaintextBytes = sodium.crypto_box_seal_open(
+                sodium.from_base64(ciphertext, sodium.base64_variants.ORIGINAL),
+                keyPair.publicKey,
+                keyPair.privateKey,
+            );
+            expect(plaintextBytes).to.deep.equal(requestBytes);
+        });
+
+        it("the serialized path is byte-compatible with the typed encrypt* wrappers", () => {
+            const keyPair = sodium.crypto_box_keypair();
+            const pub = sodium.to_base64(keyPair.publicKey, sodium.base64_variants.ORIGINAL);
+            const viewKey = new Account().viewKey();
+            const expected = viewKey.toBytesLe();
+
+            // encryptViewKey(pk, vk) and encryptSerializedProvingRequest(pk,
+            // base64(vk.toBytesLe())) feed the same bytes into the same sealed
+            // box, so both ciphertexts must decrypt to identical plaintext.
+            const typed = encryptViewKey(pub, viewKey);
+            const serialized = encryptSerializedProvingRequest(pub, base64.encode(expected));
+
+            for (const ciphertext of [typed, serialized]) {
+                const plaintextBytes = sodium.crypto_box_seal_open(
+                    sodium.from_base64(ciphertext, sodium.base64_variants.ORIGINAL),
+                    keyPair.publicKey,
+                    keyPair.privateKey,
+                );
+                expect(plaintextBytes).to.deep.equal(expected);
+            }
         });
 
         it("fuzz: 50 random messages all decrypt back to the original", () => {


### PR DESCRIPTION
## Motivation

`security.ts` owns the client side of the encrypted-transport contract with the delegated proving service: four typed wrappers (`encryptAuthorization`, `encryptProvingRequest`, `encryptViewKey`, `encryptRegistrationRequest`) around the private `encryptMessage`, whose docstring pins the wire format down to the byte. What's missing is a way to encrypt a proving request **a second time** without holding the wasm object: the service's one-time keys are single-use and pod-local, so a client whose POST was rejected with `encrypted request failed` (spent/unknown `key_id`, e.g. lost routing affinity — the same issue `network-client.ts` works around with its manual set-cookie handling in the `/prove` flow) must fetch a fresh pubkey and encrypt again. Re-encrypting the SAME serialized request — instead of rebuilding and re-signing it — keeps transition ids identical, which makes such a retry idempotent at the network level: a duplicate broadcast is consensus-rejected.

shield-core implements exactly this retry (ProvableHQ/shield-core#233), and the wallet extension currently has to carry its own copy of "`toBytesLe` + `crypto_box_seal` + base64" to do the re-encrypt in its offscreen document (ProvableHQ/shield-extension#893). These two exports let consumers drop that duplication and keep the wire format defined in one place — here:

- `serializeProvingRequest(provingRequest): Uint8Array` — the request's `toBytesLe()` bytes. The buffer is caller-owned plaintext: keep it only while a resend may still be needed, then overwrite it with `zeroizeBytes`.
- `encryptSerializedProvingRequest(publicKey, serializedProvingRequest: Uint8Array): string` — same ciphertext format as `encryptProvingRequest`; the two are interchangeable from the proving service's point of view. Does not mutate and deliberately does not zeroize its input, so the same bytes can be re-encrypted for a retry.

The bytes-in/bytes-out shape follows this repo's own guidance ("prefer byte array representations of sensitive data over strings" — `zeroizeBytes` docs): a returned base64 string could never be cleared from memory.

Alongside (separate commit, easy to drop if unwanted): `encryptAuthorization`, `encryptProvingRequest` and `encryptViewKey` now zeroize their internally created `toBytesLe()` plaintext copy in a `finally` block, aligning them with the pattern `encryptRegistrationRequest` already established in this file.

Pure JS, no wasm involvement, no new dependencies.

## Test Plan

Extended `tests/security.test.ts` (mocha + libsodium cross-check, same idiom as the existing suite). New tests build a real Request-variant `ProvingRequest` without network access (same pattern as `network-client.test.ts`):

- `serializeProvingRequest` returns the request's exact `toBytesLe()` bytes, and the bytes deserialize back via `ProvingRequest.fromBytesLeRequest` (wire-valid),
- `encryptSerializedProvingRequest` round-trips through `sodium.crypto_box_seal_open` and leaves the input buffer untouched (compared against a copy),
- interchangeability: typed `encryptProvingRequest` and the serialized path decrypt to identical plaintext,
- the retry pattern end-to-end: encrypt for key A, re-encrypt the SAME buffer for key B, `zeroizeBytes` in `finally` — buffer is all zeros afterwards while both ciphertexts still decrypt correctly.

Ran `rollup -c rollup.test.js && mocha "tmp/**/security.test.js" --timeout 60000` — 24 passing (mainnet + testnet builds).

## Related PRs

- ProvableHQ/shield-core#233 — delegated-proving key-rejection retry (consumer of this API)
- ProvableHQ/shield-extension#893 — offscreen re-encrypt; will switch to these exports and drop its direct `@serenity-kit/noble-sodium` usage once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the security encryption helpers and handles signed proving-request plaintext, but behavior is additive and tightens zeroization on existing one-shot encrypt paths without altering the wire format.
> 
> **Overview**
> Adds **`serializeProvingRequest`** and **`encryptSerializedProvingRequest`** so clients can keep signed proving-request bytes and re-encrypt them for a new one-time delegated-proving key after a rejected or spent `key_id`, without rebuilding or re-signing (same ciphertext shape as **`encryptProvingRequest`**). The serialized path leaves the caller-owned buffer intact for retries; callers clear it with **`zeroizeBytes`** when done.
> 
> **`encryptAuthorization`**, **`encryptProvingRequest`**, and **`encryptViewKey`** now **`zeroizeBytes`** their internal **`toBytesLe()`** plaintext in a **`finally`** block, matching **`encryptRegistrationRequest`**. New exports are wired through **`browser.ts`**; **`security.test.ts`** covers serialization, interchangeability, and the re-encrypt-then-zeroize retry flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3dd43d3cfce14d99ff0138cfc306b78037c8a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->