### PR TITLE
[Release] Bump SDK version to v0.11.4

### DIFF
--- a/create-leo-app/package.json
+++ b/create-leo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-leo-app",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "type": "module",
   "license": "GPL-3.0",
   "collaborators": [

--- a/create-leo-app/template-build-and-execute-authorization-ts/package.json
+++ b/create-leo-app/template-build-and-execute-authorization-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3"
+    "@provablehq/sdk": "^0.11.4"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-devnode-js/index.js
+++ b/create-leo-app/template-devnode-js/index.js
@@ -32,7 +32,7 @@ constructor:
 async function main() {
     // Initialize multi-threading to allow WASM execution.
     await initThreadPool();
-    const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13");
+    const heights = getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
     console.log(`Set development consensus heights to ${heights}`);
 
     const privateKey = "APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH";

--- a/create-leo-app/template-devnode-js/package.json
+++ b/create-leo-app/template-devnode-js/package.json
@@ -7,6 +7,6 @@
     "dev": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3"
+    "@provablehq/sdk": "^0.11.4"
   }
 }

--- a/create-leo-app/template-extension/package.json
+++ b/create-leo-app/template-extension/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf static/js && rollup --config"
   },
   "devDependencies": {
-    "@provablehq/sdk": "^0.11.3",
+    "@provablehq/sdk": "^0.11.4",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@web/rollup-plugin-import-meta-assets": "^2.2.1",
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-nextjs-ts/package.json
+++ b/create-leo-app/template-nextjs-ts/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3",
+    "@provablehq/sdk": "^0.11.4",
     "next": "15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/create-leo-app/template-node-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-node-credits-aleo-functions-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.3"
+        "@provablehq/sdk": "^0.11.4"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
+++ b/create-leo-app/template-node-dynamic-dispatch-proving-ts/package.json
@@ -8,7 +8,7 @@
         "start": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.3"
+        "@provablehq/sdk": "^0.11.4"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-dynamic-dispatch-ts/package.json
+++ b/create-leo-app/template-node-dynamic-dispatch-ts/package.json
@@ -15,7 +15,7 @@
         "test:all": "npm run build && node dist/index.js"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.3"
+        "@provablehq/sdk": "^0.11.4"
     },
     "devDependencies": {
         "rimraf": "^6.0.1",

--- a/create-leo-app/template-node-loyalty-program-ts/package.json
+++ b/create-leo-app/template-node-loyalty-program-ts/package.json
@@ -15,7 +15,7 @@
         "start:caching": "npm run build && node dist/index.js key_caching"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.3",
+        "@provablehq/sdk": "^0.11.4",
         "dotenv": "^16.4.5"
     },
     "devDependencies": {

--- a/create-leo-app/template-node-ts/package.json
+++ b/create-leo-app/template-node-ts/package.json
@@ -10,7 +10,7 @@
     "test": "npm run build && node dist/index.js && node dist/dynamic-dispatch.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3"
+    "@provablehq/sdk": "^0.11.4"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-node/package.json
+++ b/create-leo-app/template-node/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3"
+    "@provablehq/sdk": "^0.11.4"
   }
 }

--- a/create-leo-app/template-offline-public-transaction-ts/package.json
+++ b/create-leo-app/template-offline-public-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "dev": "npm run build && node --trace-uncaught dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3"
+    "@provablehq/sdk": "^0.11.4"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-private-transaction-ts/package.json
+++ b/create-leo-app/template-private-transaction-ts/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node dist/index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3"
+    "@provablehq/sdk": "^0.11.4"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/create-leo-app/template-react-credits-aleo-functions-ts/package.json
+++ b/create-leo-app/template-react-credits-aleo-functions-ts/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@provablehq/sdk": "^0.11.3",
+        "@provablehq/sdk": "^0.11.4",
         "comlink": "^4.4.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-leo/package.json
+++ b/create-leo-app/template-react-leo/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3",
+    "@provablehq/sdk": "^0.11.4",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-loyalty-program-ts/package.json
+++ b/create-leo-app/template-react-loyalty-program-ts/package.json
@@ -13,7 +13,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3",
+    "@provablehq/sdk": "^0.11.4",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-react-managed-worker/package.json
+++ b/create-leo-app/template-react-managed-worker/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3",
+    "@provablehq/sdk": "^0.11.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/create-leo-app/template-react-ts/package.json
+++ b/create-leo-app/template-react-ts/package.json
@@ -12,7 +12,7 @@
     "install-leo": "./install.sh"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3",
+    "@provablehq/sdk": "^0.11.4",
     "comlink": "^4.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/create-leo-app/template-vanilla/package.json
+++ b/create-leo-app/template-vanilla/package.json
@@ -9,7 +9,7 @@
         "preview": "vite preview"
     },
     "devDependencies": {
-        "@provablehq/sdk": "^0.11.3",
+        "@provablehq/sdk": "^0.11.4",
         "tslib": "^2.8.1",
         "vite": "^6.4.3"
     }

--- a/docs/api_reference/sdk-src_network-client.md
+++ b/docs/api_reference/sdk-src_network-client.md
@@ -19,6 +19,8 @@ const localNetworkClient = new AleoNetworkClient("http://0.0.0.0:3030", undefine
 
 // Connection to a public beacon node
 const account = Account.fromCiphertext(process.env.ciphertext, process.env.password);
+const apiKey = process.env.apiKey;
+const consumerId = process.env.consumerId;
 const publicNetworkClient = new AleoNetworkClient("https://api.provable.com/v2", undefined, account);
 ```
 
@@ -32,7 +34,7 @@ Set an account to use in networkClient calls
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | *Set an account to use for record scanning functions.*
+__account__ | `Account` | *Set an account to use for record scanning functions.*
 
 #### Examples
 
@@ -80,6 +82,54 @@ const networkClient = new AleoNetworkClient("http://0.0.0.0:3030", undefined);
 
 // Set the host to a public node.
 networkClient.setHost("https://api.provable.com/v2");
+```
+
+---
+
+### `setProverUri(proverUri)`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Set a new uri for a remote prover.
+
+Parameters | Type | Description
+--- | --- | ---
+__proverUri__ | `string` | *The uri of the remote prover.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a networkClient that connects to the provable explorer api.
+const networkClient = new AleoNetworkClient("https://api.provable.com/v2", undefined);
+
+// Set the prover uri.
+networkClient.setProverUri("https://prover.provable.prove");
+```
+
+---
+
+### `setRecordScannerUri(recordScannerUri)`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Set a new uri for a remote record scanner.
+
+Parameters | Type | Description
+--- | --- | ---
+__recordScannerUri__ | `string` | *The uri of the remote record scanner.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a networkClient that connects to the provable explorer api.
+const networkClient = new AleoNetworkClient("https://api.provable.com/v2", undefined);
+
+// Set the record scanner uri.
+networkClient.setRecordScannerUri("https://scanner.provable.scan");
 ```
 
 ---
@@ -496,6 +546,19 @@ const latestHeight = networkClient.getLatestHeight();
 
 ---
 
+### `getStatePaths(commitments) ► Promise.<Array.<string>>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns state paths for the given record commitments.
+
+Parameters | Type | Description
+--- | --- | ---
+__commitments__ | `Array.<string>` | *Array of commitment field strings.*
+__*return*__ | `Promise.<Array.<string>>` | *Array of state path strings corresponding to the commitments.*
+
+---
+
 ### `getLatestBlockHash() ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -577,6 +640,27 @@ const networkClient = new AleoNetworkClient("https://api.provable.com/v2", undef
 
 const programVersion = networkClient.getLatestProgramEdition("hello_hello.aleo");
 assert.equal(programVersion, 1);
+```
+
+---
+
+### `getProgramAmendmentCount(programId) ► Object`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the current edition and amendment count for a program.
+
+Parameters | Type | Description
+--- | --- | ---
+__programId__ | `string` | *The program ID (e.g. &quot;hello_hello.aleo&quot;)*
+__*return*__ | `Object` | **
+
+#### Examples
+
+```javascript
+const networkClient = new AleoNetworkClient("https://api.provable.com/v2");
+const info = await networkClient.getProgramAmendmentCount("hello_hello.aleo");
+console.log(info.edition, info.amendment_count);
 ```
 
 ---
@@ -1054,16 +1138,37 @@ __*return*__ | `Promise.<JwtData>` | *The JWT token and expiration time*
 
 ---
 
+### `handleProvingResponse()`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Parses a /prove/authorization or /prove/request response. Returns a result object (never throws for 200/400/500/503).
+
+---
+
 ### `submitProvingRequest(options) ► Promise.<ProvingResponse>`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Submit a &#x60;ProvingRequest&#x60; to a remote proving service for delegated proving. If the broadcast flag of the &#x60;ProvingRequest&#x60; is set to &#x60;true&#x60; the remote service will attempt to broadcast the result &#x60;Transaction&#x60; on behalf of the requestor.
+Submit a &#x60;ProvingRequest&#x60; to a remote proving service for delegated proving. If the broadcast flag of the &#x60;ProvingRequest&#x60; is set to &#x60;true&#x60; the remote service will attempt to broadcast the result &#x60;Transaction&#x60; on behalf of the requestor. Throws on HTTP 400, 500, 503 (and retries on 500/503). Callers should [submitProvingRequestSafe](submitProvingRequestSafe) to handle proving request failures without throwing.
 
 Parameters | Type | Description
 --- | --- | ---
 __options__ | `DelegatedProvingParams` | *The optional parameters required to submit a proving request.*
 __*return*__ | `Promise.<ProvingResponse>` | *The ProvingResponse containing the transaction result and the result of the broadcast if the &#x60;broadcast&#x60; flag was set to &#x60;true&#x60;.*
+
+---
+
+### `submitProvingRequestSafe(options) ► Promise.<ProvingResult>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Submit a proving request and return a result object instead of throwing. This method is usable when callers want to handle HTTP status (400, 500, 503) yourself. Retries on 500/503 and returns on 200 or 400.
+
+Parameters | Type | Description
+--- | --- | ---
+__options__ | `DelegatedProvingParams` | *The optional parameters required to submit a proving request.*
+__*return*__ | `Promise.<ProvingResult>` | *&#x60;{ ok: true, data }&#x60; on success (200), or &#x60;{ ok: false, status, error }&#x60; on 400/500/503. Check &#x60;result.ok&#x60; and then either &#x60;result.data&#x60; or &#x60;result.status&#x60; / &#x60;result.error.message&#x60;.*
 
 ---
 
@@ -1112,7 +1217,7 @@ Set an account to use in networkClient calls
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | *Set an account to use for record scanning functions.*
+__account__ | `Account` | *Set an account to use for record scanning functions.*
 
 #### Examples
 
@@ -1134,7 +1239,7 @@ Return the Aleo account used in the networkClient
 
 Parameters | Type | Description
 --- | --- | ---
-__*return*__ | [Account](sdk-src_account.md) | **
+__*return*__ | `Account` | **
 
 #### Examples
 
@@ -1164,6 +1269,54 @@ const networkClient = new AleoNetworkClient("http://0.0.0.0:3030", undefined);
 
 // Set the host to a public node.
 networkClient.setHost("https://api.provable.com/v2");
+```
+
+---
+
+### `setProverUri(proverUri)`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Set a new uri for a remote prover.
+
+Parameters | Type | Description
+--- | --- | ---
+__proverUri__ | `string` | *The uri of the remote prover.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a networkClient that connects to the provable explorer api.
+const networkClient = new AleoNetworkClient("https://api.provable.com/v2", undefined);
+
+// Set the prover uri.
+networkClient.setProverUri("https://prover.provable.prove");
+```
+
+---
+
+### `setRecordScannerUri(recordScannerUri)`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Set a new uri for a remote record scanner.
+
+Parameters | Type | Description
+--- | --- | ---
+__recordScannerUri__ | `string` | *The uri of the remote record scanner.*
+
+#### Examples
+
+```javascript
+import { AleoNetworkClient } from "@provablehq/sdk/mainnet.js";
+
+// Create a networkClient that connects to the provable explorer api.
+const networkClient = new AleoNetworkClient("https://api.provable.com/v2", undefined);
+
+// Set the record scanner uri.
+networkClient.setRecordScannerUri("https://scanner.provable.scan");
 ```
 
 ---
@@ -1582,6 +1735,19 @@ const latestHeight = networkClient.getLatestHeight();
 
 ---
 
+### `getStatePaths(commitments) ► Promise.<Array.<string>>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns state paths for the given record commitments.
+
+Parameters | Type | Description
+--- | --- | ---
+__commitments__ | `Array.<string>` | *Array of commitment field strings.*
+__*return*__ | `Promise.<Array.<string>>` | *Array of state path strings corresponding to the commitments.*
+
+---
+
 ### `getLatestBlockHash() ► Promise.<string>`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -1663,6 +1829,27 @@ const networkClient = new AleoNetworkClient("https://api.provable.com/v2", undef
 
 const programVersion = networkClient.getLatestProgramEdition("hello_hello.aleo");
 assert.equal(programVersion, 1);
+```
+
+---
+
+### `getProgramAmendmentCount(programId) ► Object`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the current edition and amendment count for a program.
+
+Parameters | Type | Description
+--- | --- | ---
+__programId__ | `string` | *The program ID (e.g. &quot;hello_hello.aleo&quot;)*
+__*return*__ | `Object` | **
+
+#### Examples
+
+```javascript
+const networkClient = new AleoNetworkClient("https://api.provable.com/v2");
+const info = await networkClient.getProgramAmendmentCount("hello_hello.aleo");
+console.log(info.edition, info.amendment_count);
 ```
 
 ---
@@ -2130,12 +2317,25 @@ __*return*__ | `Promise.<string>` | *The solution id of the submitted solution o
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Submit a &#x60;ProvingRequest&#x60; to a remote proving service for delegated proving. If the broadcast flag of the &#x60;ProvingRequest&#x60; is set to &#x60;true&#x60; the remote service will attempt to broadcast the result &#x60;Transaction&#x60; on behalf of the requestor.
+Submit a &#x60;ProvingRequest&#x60; to a remote proving service for delegated proving. If the broadcast flag of the &#x60;ProvingRequest&#x60; is set to &#x60;true&#x60; the remote service will attempt to broadcast the result &#x60;Transaction&#x60; on behalf of the requestor. Throws on HTTP 400, 500, 503 (and retries on 500/503). Callers should [submitProvingRequestSafe](submitProvingRequestSafe) to handle proving request failures without throwing.
 
 Parameters | Type | Description
 --- | --- | ---
 __options__ | `DelegatedProvingParams` | *The optional parameters required to submit a proving request.*
 __*return*__ | `Promise.<ProvingResponse>` | *The ProvingResponse containing the transaction result and the result of the broadcast if the &#x60;broadcast&#x60; flag was set to &#x60;true&#x60;.*
+
+---
+
+### `submitProvingRequestSafe(options) ► Promise.<ProvingResult>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Submit a proving request and return a result object instead of throwing. This method is usable when callers want to handle HTTP status (400, 500, 503) yourself. Retries on 500/503 and returns on 200 or 400.
+
+Parameters | Type | Description
+--- | --- | ---
+__options__ | `DelegatedProvingParams` | *The optional parameters required to submit a proving request.*
+__*return*__ | `Promise.<ProvingResult>` | *&#x60;{ ok: true, data }&#x60; on success (200), or &#x60;{ ok: false, status, error }&#x60; on 400/500/503. Check &#x60;result.ok&#x60; and then either &#x60;result.data&#x60; or &#x60;result.status&#x60; / &#x60;result.error.message&#x60;.*
 
 ---
 
@@ -2215,5 +2415,18 @@ Parameters | Type | Description
 __apiKey__ | `string` | *The API key for authentication.*
 __consumerId__ | `string` | *The consumer ID associated with the API key.*
 __*return*__ | `Promise.<JwtData>` | *The JWT token and expiration time*
+
+---
+
+### `handleProvingResponse(response) ► Promise.<ProvingResult>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Parses a /prove/authorization or /prove/request response. Returns a result object (never throws for 200/400/500/503).
+
+Parameters | Type | Description
+--- | --- | ---
+__response__ | `Response` | **
+__*return*__ | `Promise.<ProvingResult>` | **
 
 ---

--- a/docs/api_reference/sdk-src_program-manager.md
+++ b/docs/api_reference/sdk-src_program-manager.md
@@ -6,6 +6,123 @@
 
 [Source file](../../sdk/src/program-manager.ts)
 
+## Functions
+
+### `inputsToFields(inputs) ► Array.<string>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Convert an array of Aleo type strings to field element strings.
+
+Inputs that are already field elements (e.g. &quot;1field&quot;) are passed through directly.
+Other Aleo values (e.g. &quot;1u32&quot;, records, futures, dynamic records) are parsed via
+Value and converted to their field representation.
+
+Parameters | Type | Description
+--- | --- | ---
+__inputs__ | `Array.<string>` | *Array of Aleo value strings*
+__*return*__ | `Array.<string>` | *Array of field element strings*
+
+---
+
+### `verifyProof(options) ► boolean`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Verify an Aleo zkSnark proof against a verifying key and public inputs.
+
+This verifies a proof produced by an Aleo program that may not be deployed on chain.
+It directly invokes the Varuna proof verification from snarkVM.
+
+**Note:** The proof must have been generated with the Fiat-Shamir domain separator
+&quot;snark_verify&quot;. Proofs generated via snarkVM with a different function name will fail
+verification even if the circuit and inputs are correct.
+
+Inputs can be raw field element strings (e.g. &quot;1field&quot;) or Aleo type strings
+(e.g. &quot;1u32&quot;, &quot;true&quot;, &quot;{ x: 1u8, y: 2u8 }&quot;). Non-field inputs are automatically
+converted to their field representation via Value.toFields().
+
+Parameters | Type | Description
+--- | --- | ---
+__options__ | `VerificationOptions` | *The verification parameters*
+__*return*__ | `boolean` | *True if the proof is valid, false otherwise*
+
+#### Examples
+
+```javascript
+import { verifyProof } from "@provablehq/sdk/mainnet.js";
+
+// Using raw field elements:
+const isValid = verifyProof({
+    verifyingKey: "verifier1...",
+    inputs: ["1field", "2field"],
+    proof: "proof1...",
+});
+
+// Using Aleo types (automatically converted to fields):
+const isValid2 = verifyProof({
+    verifyingKey: "verifier1...",
+    inputs: ["1u32", "2u32"],
+    proof: "proof1...",
+});
+```
+
+---
+
+### `verifyBatchProof(options) ► boolean`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Verify a batch Aleo zkSnark proof against multiple verifying keys and their corresponding public inputs.
+
+Each verifying key is paired with one or more sets of public inputs (instances).
+Inputs can be raw field element strings or Aleo type strings — non-field inputs
+are automatically converted to their field representation.
+
+**Note:** The proof must have been generated with the Fiat-Shamir domain separator
+&quot;snark_verify_batch&quot;. Proofs generated with a different function name will fail
+verification even if the circuits and inputs are correct.
+
+Parameters | Type | Description
+--- | --- | ---
+__options__ | `BatchVerificationOptions` | *The batch verification parameters*
+__*return*__ | `boolean` | *True if the batch proof is valid, false otherwise*
+
+#### Examples
+
+```javascript
+import { verifyBatchProof } from "@provablehq/sdk/mainnet.js";
+
+const isValid = verifyBatchProof({
+    verifyingKeys: ["verifier1...", "verifier2..."],
+    inputs: [[["1field", "2field"]], [["3field"]]],
+    proof: "proof1...",
+});
+```
+
+---
+
+### `programChecksum(program) ► Uint8Array`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Get the checksum of an Aleo program.
+
+Parameters | Type | Description
+--- | --- | ---
+__program__ | `string` | *Program string or Program object*
+__*return*__ | `Uint8Array` | *The keccak256 checksum of the program as a 32-byte Uint8Array*
+
+#### Examples
+
+```javascript
+import { programChecksum } from "@provablehq/sdk/mainnet.js";
+
+const checksum = programChecksum("program foo.aleo; ...");
+```
+
+---
+
 # Class `ProgramManager`
 
 The ProgramManager class is used to execute and deploy programs on the Aleo network and create value transfers.
@@ -27,6 +144,28 @@ __recordProvider__ | `RecordProvider` | *A record provider that implements {@lin
 
 ## Methods
 
+### `ensureInclusionKeys()`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Pre-load the inclusion prover for offline execution. Required when the
+user provides an explicit OfflineQuery (truly offline — can&#x27;t fetch lazily).
+For CallbackQuery, snarkVM handles inclusion key loading on demand.
+
+---
+
+### `buildCallbackQuery()`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Create a CallbackQuery that delegates all state fetching to the
+transport-aware network client. WASM calls back into these functions
+during trace.prepare_async() instead of making its own reqwest calls.
+
+This handles ALL programs including those with DynamicRecord inputs.
+
+---
+
 ### `checkFee()`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -43,7 +182,7 @@ Set the account to use for transaction submission to the Aleo network
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | *Account to use for transaction submission*
+__account__ | `Account` | *Account to use for transaction submission*
 
 ---
 
@@ -80,6 +219,113 @@ Set the record provider that provides records for transactions
 Parameters | Type | Description
 --- | --- | ---
 __recordProvider__ | `RecordProvider` | **
+
+---
+
+### `setKeyStore(keyStore)`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Set the key store for automatic key caching across executions.
+
+Parameters | Type | Description
+--- | --- | ---
+__keyStore__ | `KeyStore` | **
+
+---
+
+### `collectProgramImports()`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Collect static imports declared by the entry program together with any
+caller-provided imports, then resolve missing transitive dependencies.
+Caller-provided program sources take precedence over network sources.
+
+---
+
+### `buildProgramImports(loadKeys)`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Build a ProgramImportsBuilder from a program and its imports.
+Fetches missing imports from the network, resolves transitive
+dependencies, and optionally pre-loads cached keys from the KeyStore.
+
+Parameters | Type | Description
+--- | --- | ---
+__loadKeys__ | `undefined` | *When true (default), loads cached proving/verifying keys
+  from the KeyStore into the builder. Set to false for authorization and
+  proving request paths where keys are not synthesized.*
+
+---
+
+### `getImportNames()`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Extract &#x60;import program_name.aleo;&#x60; names from program source via regex.
+Avoids a WASM round-trip compared to Program.fromString + getImports.
+
+---
+
+### `callGraphToMap()`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Convert the JS object returned by Program.getCallGraph() into a
+Map&lt;string, Set&lt;string&gt;&gt; for use in buildProgramImports.
+
+---
+
+### `resolveKeyStore()`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Resolve the active KeyStore, preferring the directly-set _keyStore
+over the KeyProvider&#x27;s keyStore().
+
+---
+
+### `resolveEditionAndAmendment()`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Resolve the edition and amendment count for a program from the network.
+Returns &#x60;{ edition, amendment }&#x60; or falls back to &#x60;{ edition: 1, amendment: 0 }&#x60;.
+
+---
+
+### `loadKeysFromStore()`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Load cached proving/verifying keys from the KeyStore into a ProgramImportsBuilder.
+Only loads keys for the specified functions — returns immediately if
+functionNames is empty or undefined.
+Resolves edition and amendment from the network for accurate key locator
+construction when not explicitly provided.
+
+---
+
+### `persistExtractedKeys()`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Persist newly synthesized keys from the returned ProgramImportsBuilder
+into the KeyStore. Only writes keys that are not already in the store,
+avoiding unnecessary writes of large proving keys.
+Fetches each program&#x27;s current edition and amendment count from the network
+for accurate key locator construction.
+
+---
+
+### `resolveTopLevelKeys()`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Resolve top-level function keys, checking the KeyStore first and
+falling back to the KeyProvider.
 
 ---
 
@@ -503,7 +749,7 @@ const authorization = await programManager.buildAuthorizationUnchecked({
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Builds a &#x60;ProvingRequest&#x60; for submission to a prover for execution.
+Builds a &#x60;ProvingRequest&#x60; for submission to a prover for execution. If building a proving request with an ExecutionRequest, a private key must be explicitly provided.
 
 Parameters | Type | Description
 --- | --- | ---
@@ -623,6 +869,30 @@ setTimeout(async () => {
  assert(transaction.id() === tx_id);
 }, 10000);
 ```
+
+---
+
+### `prepareInputs(programSource, functionName, inputs) ► Array.<string>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Prepares user-provided inputs for a function call by auto-converting bare
+string identifiers to field elements where the function signature expects
+a &#x60;field&#x60; type. This lets callers of dynamic-dispatch programs pass
+human-readable strings (e.g. &#x60;&quot;my_program&quot;&#x60;) instead of requiring
+&#x60;stringToField(&quot;my_program&quot;).toString()&#x60;.
+
+Inputs that already look like a numeric field literal (matching
+&#x60;/^\d+field$/&#x60; after trimming whitespace) are left untouched. Non-field
+inputs are returned as-is. If introspection fails for any reason the
+original inputs are returned unchanged.
+
+Parameters | Type | Description
+--- | --- | ---
+__programSource__ | `string` | *The program source code or Program object*
+__functionName__ | `string` | *The function to inspect*
+__inputs__ | `Array.<string>` | *The raw user-provided inputs*
+__*return*__ | `Array.<string>` | *The (possibly converted) inputs*
 
 ---
 
@@ -1556,7 +1826,7 @@ __*return*__ | `Promise.<Transaction>` | *- A promise that resolves to the trans
 import { AleoKeyProvider, getOrInitConsensusVersionTestHeights, ProgramManager, NetworkRecordProvider } from "@provablehq/sdk/mainnet.js";
 
 // Initialize the development consensus heights in order to work with devnode.
-getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
+getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
 
 // Create a new NetworkClient and RecordProvider.
 const recordProvider = new NetworkRecordProvider(account, networkClient);
@@ -1606,7 +1876,7 @@ __*return*__ | `string` | *The transaction id of the deployed program or a failu
 import { ProgramManager, NetworkRecordProvider, getOrInitConsensusVersionTestHeights } from "@provablehq/sdk/mainnet.js";
 
 // Initialize the development consensus heights in order to work with a local devnode.
-getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
+getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
 
 // Create a new NetworkClient, and RecordProvider
 const recordProvider = new NetworkRecordProvider(account, networkClient);
@@ -1697,7 +1967,7 @@ Set the account to use for transaction submission to the Aleo network
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | *Account to use for transaction submission*
+__account__ | `Account` | *Account to use for transaction submission*
 
 ---
 
@@ -1734,6 +2004,18 @@ Set the record provider that provides records for transactions
 Parameters | Type | Description
 --- | --- | ---
 __recordProvider__ | `RecordProvider` | **
+
+---
+
+### `setKeyStore(keyStore)`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Set the key store for automatic key caching across executions.
+
+Parameters | Type | Description
+--- | --- | ---
+__keyStore__ | `KeyStore` | **
 
 ---
 
@@ -2158,7 +2440,7 @@ const authorization = await programManager.buildAuthorizationUnchecked({
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Builds a &#x60;ProvingRequest&#x60; for submission to a prover for execution.
+Builds a &#x60;ProvingRequest&#x60; for submission to a prover for execution. If building a proving request with an ExecutionRequest, a private key must be explicitly provided.
 
 Parameters | Type | Description
 --- | --- | ---
@@ -2278,6 +2560,30 @@ setTimeout(async () => {
  assert(transaction.id() === tx_id);
 }, 10000);
 ```
+
+---
+
+### `prepareInputs(programSource, functionName, inputs) ► Array.<string>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Prepares user-provided inputs for a function call by auto-converting bare
+string identifiers to field elements where the function signature expects
+a &#x60;field&#x60; type. This lets callers of dynamic-dispatch programs pass
+human-readable strings (e.g. &#x60;&quot;my_program&quot;&#x60;) instead of requiring
+&#x60;stringToField(&quot;my_program&quot;).toString()&#x60;.
+
+Inputs that already look like a numeric field literal (matching
+&#x60;/^\d+field$/&#x60; after trimming whitespace) are left untouched. Non-field
+inputs are returned as-is. If introspection fails for any reason the
+original inputs are returned unchanged.
+
+Parameters | Type | Description
+--- | --- | ---
+__programSource__ | `string` | *The program source code or Program object*
+__functionName__ | `string` | *The function to inspect*
+__inputs__ | `Array.<string>` | *The raw user-provided inputs*
+__*return*__ | `Array.<string>` | *The (possibly converted) inputs*
 
 ---
 
@@ -3213,7 +3519,7 @@ __*return*__ | `Promise.<Transaction>` | *- A promise that resolves to the trans
 import { AleoKeyProvider, getOrInitConsensusVersionTestHeights, ProgramManager, NetworkRecordProvider } from "@provablehq/sdk/mainnet.js";
 
 // Initialize the development consensus heights in order to work with devnode.
-getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
+getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
 
 // Create a new NetworkClient and RecordProvider.
 const recordProvider = new NetworkRecordProvider(account, networkClient);
@@ -3263,7 +3569,7 @@ __*return*__ | `string` | *The transaction id of the deployed program or a failu
 import { ProgramManager, NetworkRecordProvider, getOrInitConsensusVersionTestHeights } from "@provablehq/sdk/mainnet.js";
 
 // Initialize the development consensus heights in order to work with a local devnode.
-getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12");
+getOrInitConsensusVersionTestHeights("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
 
 // Create a new NetworkClient, and RecordProvider
 const recordProvider = new NetworkRecordProvider(account, networkClient);
@@ -3330,5 +3636,183 @@ setTimeout(async () => {
  assert(transaction.id() === tx.id());
 }, 20000);
 ```
+
+---
+
+### `ensureInclusionKeys(isOffline) ► Promise.<void>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Pre-load the inclusion prover for offline execution. Required when the
+user provides an explicit OfflineQuery (truly offline — can&#x27;t fetch lazily).
+For CallbackQuery, snarkVM handles inclusion key loading on demand.
+
+Parameters | Type | Description
+--- | --- | ---
+__isOffline__ | `boolean` | **
+__*return*__ | `Promise.<void>` | **
+
+---
+
+### `buildCallbackQuery() ► CallbackQuery`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Create a CallbackQuery that delegates all state fetching to the
+transport-aware network client. WASM calls back into these functions
+during trace.prepare_async() instead of making its own reqwest calls.
+
+This handles ALL programs including those with DynamicRecord inputs.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [CallbackQuery](sdk-src_wasm.md) | **
+
+---
+
+### `collectProgramImports(program, imports, tolerateNetworkErrors) ► Promise.<Map.<string, string>>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Collect static imports declared by the entry program together with any
+caller-provided imports, then resolve missing transitive dependencies.
+Caller-provided program sources take precedence over network sources.
+
+Parameters | Type | Description
+--- | --- | ---
+__program__ | `string` | **
+__imports__ | [ProgramImports](sdk-src_wasm.md) | **
+__tolerateNetworkErrors__ | `boolean` | **
+__*return*__ | `Promise.<Map.<string, string>>` | **
+
+---
+
+### `buildProgramImports(loadKeys) ► Promise.<object>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Build a ProgramImportsBuilder from a program and its imports.
+Fetches missing imports from the network, resolves transitive
+dependencies, and optionally pre-loads cached keys from the KeyStore.
+
+Parameters | Type | Description
+--- | --- | ---
+__loadKeys__ | `undefined` | *When true (default), loads cached proving/verifying keys
+  from the KeyStore into the builder. Set to false for authorization and
+  proving request paths where keys are not synthesized.*
+__*return*__ | `Promise.<object>` | **
+
+---
+
+### `getImportNames(programSource) ► Array`
+
+![modifier: private](images/badges/modifier-private.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Extract &#x60;import program_name.aleo;&#x60; names from program source via regex.
+Avoids a WASM round-trip compared to Program.fromString + getImports.
+
+Parameters | Type | Description
+--- | --- | ---
+__programSource__ | `string` | **
+__*return*__ | `Array` | **
+
+---
+
+### `callGraphToMap(callGraph) ► Map.<string, Set.<string>>`
+
+![modifier: private](images/badges/modifier-private.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Convert the JS object returned by Program.getCallGraph() into a
+Map&lt;string, Set&lt;string&gt;&gt; for use in buildProgramImports.
+
+Parameters | Type | Description
+--- | --- | ---
+__callGraph__ | `Record.<string, Array>` | **
+__*return*__ | `Map.<string, Set.<string>>` | **
+
+---
+
+### `resolveKeyStore() ► Promise.<(KeyStore|undefined)>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Resolve the active KeyStore, preferring the directly-set _keyStore
+over the KeyProvider&#x27;s keyStore().
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Promise.<(KeyStore\|undefined)>` | **
+
+---
+
+### `resolveEditionAndAmendment(programName, fallbackEdition) ► Promise.<object>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Resolve the edition and amendment count for a program from the network.
+Returns &#x60;{ edition, amendment }&#x60; or falls back to &#x60;{ edition: 1, amendment: 0 }&#x60;.
+
+Parameters | Type | Description
+--- | --- | ---
+__programName__ | `string` | **
+__fallbackEdition__ | `number` | **
+__*return*__ | `Promise.<object>` | **
+
+---
+
+### `loadKeysFromStore(builder, programName, functionNames, edition, amendment) ► Promise.<void>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Load cached proving/verifying keys from the KeyStore into a ProgramImportsBuilder.
+Only loads keys for the specified functions — returns immediately if
+functionNames is empty or undefined.
+Resolves edition and amendment from the network for accurate key locator
+construction when not explicitly provided.
+
+Parameters | Type | Description
+--- | --- | ---
+__builder__ | `ProgramImportsBuilder` | **
+__programName__ | `string` | **
+__functionNames__ | `Array` | **
+__edition__ | `number` | **
+__amendment__ | `number` | **
+__*return*__ | `Promise.<void>` | **
+
+---
+
+### `persistExtractedKeys(builder, importEditions) ► Promise.<void>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Persist newly synthesized keys from the returned ProgramImportsBuilder
+into the KeyStore. Only writes keys that are not already in the store,
+avoiding unnecessary writes of large proving keys.
+Fetches each program&#x27;s current edition and amendment count from the network
+for accurate key locator construction.
+
+Parameters | Type | Description
+--- | --- | ---
+__builder__ | `ProgramImportsBuilder` | **
+__importEditions__ | `Map.<string, object>` | **
+__*return*__ | `Promise.<void>` | **
+
+---
+
+### `resolveTopLevelKeys(programName, functionName, keySearchParams, edition, amendment) ► Promise.<(FunctionKeyPair|undefined)>`
+
+![modifier: private](images/badges/modifier-private.svg)
+
+Resolve top-level function keys, checking the KeyStore first and
+falling back to the KeyProvider.
+
+Parameters | Type | Description
+--- | --- | ---
+__programName__ | `string` | **
+__functionName__ | `string` | **
+__keySearchParams__ | `KeySearchParams` | **
+__edition__ | `number` | **
+__amendment__ | `number` | **
+__*return*__ | `Promise.<(FunctionKeyPair\|undefined)>` | **
 
 ---

--- a/docs/api_reference/sdk-src_record-provider.md
+++ b/docs/api_reference/sdk-src_record-provider.md
@@ -21,7 +21,7 @@ Set the account used to search for records
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | *The account used to use for searching for records.*
+__account__ | `Account` | *The account used to use for searching for records.*
 
 ---
 
@@ -119,7 +119,7 @@ Set the account used to search for records
 
 Parameters | Type | Description
 --- | --- | ---
-__account__ | [Account](sdk-src_account.md) | *The account used to use for searching for records.*
+__account__ | `Account` | *The account used to use for searching for records.*
 
 ---
 

--- a/docs/api_reference/sdk-src_wasm.md
+++ b/docs/api_reference/sdk-src_wasm.md
@@ -54,11 +54,12 @@ __*return*__ | [Plaintext](sdk-src_wasm.md) | *The address object.*
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
 
-Create an aleo address object from a string representation of an address
+Create an aleo address object from a string representation of an address.
+The input is automatically lowercased before parsing.
 
 Parameters | Type | Description
 --- | --- | ---
-__address__ | `string` | *String representation of an addressm*
+__address__ | `string` | *String representation of an address*
 __*return*__ | [Address](sdk-src_wasm.md) | *Address*
 
 ---
@@ -75,6 +76,30 @@ __*return*__ | `Uint8Array` | **
 
 ---
 
+### `toI8Lossy() ► I8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to an I8 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I8` | **
+
+---
+
+### `toU8Lossy() ► U8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to a U8 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U8` | **
+
+---
+
 ### `fromBitsLe(bits) ► Address`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
@@ -88,6 +113,42 @@ __*return*__ | [Address](sdk-src_wasm.md) | *The address object.*
 
 ---
 
+### `toI16Lossy() ► I16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to an I16 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I16` | **
+
+---
+
+### `toI32Lossy() ► I32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to an I32 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I32` | **
+
+---
+
+### `toI64Lossy() ► I64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to an I64 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I64` | **
+
+---
+
 ### `toPlaintext() ► Plaintext`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -97,6 +158,54 @@ Get the plaintext representation of the address.
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | [Plaintext](sdk-src_wasm.md) | **
+
+---
+
+### `toString() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get a string representation of an Aleo address object
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | *String representation of the address*
+
+---
+
+### `toU16Lossy() ► U16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to a U16 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U16` | **
+
+---
+
+### `toU32Lossy() ► U32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to a U32 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U32` | **
+
+---
+
+### `toU64Lossy() ► U64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to a U64 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U64` | **
 
 ---
 
@@ -126,6 +235,30 @@ __*return*__ | [Address](sdk-src_wasm.md) | *Address corresponding to the view k
 
 ---
 
+### `toI128Lossy() ► I128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to an I128 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I128` | **
+
+---
+
+### `toU128Lossy() ► U128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to a U128 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U128` | **
+
+---
+
 ### `fromProgramId(program_id) ► Address`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
@@ -136,6 +269,18 @@ Parameters | Type | Description
 --- | --- | ---
 __program_id__ | `string` | *The program ID string.*
 __*return*__ | [Address](sdk-src_wasm.md) | *The address corresponding to the program ID.*
+
+---
+
+### `toScalarLossy() ► Scalar`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to a Scalar with lossy truncation (via x-coordinate).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Scalar](sdk-src_wasm.md) | **
 
 ---
 
@@ -165,6 +310,18 @@ __*return*__ | [Address](sdk-src_wasm.md) | *Address corresponding to the privat
 
 ---
 
+### `toBooleanLossy() ► Boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to a Boolean with lossy truncation (LSB of x-coordinate).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Boolean](sdk-src_wasm.md) | **
+
+---
+
 ### `verify(Byte) ► boolean`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -175,6 +332,33 @@ Parameters | Type | Description
 --- | --- | ---
 __Byte__ | `Uint8Array` | *array representing a message signed by the address*
 __*return*__ | `boolean` | *Boolean representing whether or not the signature is valid*
+
+---
+
+### `isValid(address) ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Check if the input is a valid Aleo address.
+String addresses are automatically lowercased before validation.
+
+Parameters | Type | Description
+--- | --- | ---
+__address__ | `string` | *Either a string representation of an address
+       or a Uint8Array of bytes in little-endian format.*
+__*return*__ | `boolean` | *True if the input is a valid address, false otherwise.*
+
+---
+
+### `toField() ► Field`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the address to a Field element (x-coordinate of the underlying group point).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Field](sdk-src_wasm.md) | **
 
 ---
 
@@ -437,6 +621,18 @@ __value__ | `boolean` | **
 
 ## Methods
 
+### `toAddress() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to an Address (strict, via Group). Returns an error if conversion fails.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | **
+
+---
+
 ### `toBitsLe() ► Array.<any>`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -509,6 +705,31 @@ Parameters | Type | Description
 --- | --- | ---
 __bytes__ | `Uint8Array` | **
 __*return*__ | [Boolean](sdk-src_wasm.md) | **
+
+---
+
+### `toGroupLossy() ► Group`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to a Group element (lossy, via Field with Elligator-2 fallback).
+This conversion never fails.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
+### `toAddressLossy() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to an Address (lossy, via Group with Elligator-2 fallback).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | **
 
 ---
 
@@ -601,6 +822,30 @@ __*return*__ | [Boolean](sdk-src_wasm.md) | **
 
 ---
 
+### `toI8() ► I8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to an I8 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I8` | **
+
+---
+
+### `toU8() ► U8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to a U8 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U8` | **
+
+---
+
 ### `equals(other) ► boolean`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -626,6 +871,139 @@ __*return*__ | [Boolean](sdk-src_wasm.md) | **
 
 ---
 
+### `toI16() ► I16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to an I16 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I16` | **
+
+---
+
+### `toI32() ► I32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to an I32 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I32` | **
+
+---
+
+### `toI64() ► I64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to an I64 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I64` | **
+
+---
+
+### `toU16() ► U16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to a U16 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U16` | **
+
+---
+
+### `toU32() ► U32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to a U32 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U32` | **
+
+---
+
+### `toU64() ► U64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to a U64 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U64` | **
+
+---
+
+### `toI128() ► I128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to an I128 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I128` | **
+
+---
+
+### `toU128() ► U128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to a U128 (false&#x3D;0, true&#x3D;1).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U128` | **
+
+---
+
+### `toField() ► Field`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to a Field element (false&#x3D;0, true&#x3D;1). Lossless.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Field](sdk-src_wasm.md) | **
+
+---
+
+### `toGroup() ► Group`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to a Group element (strict, via Field x-coordinate recovery).
+Returns an error if the resulting field is not a valid x-coordinate.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
+### `toScalar() ► Scalar`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the boolean to a Scalar element (false&#x3D;0, true&#x3D;1). Lossless.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Scalar](sdk-src_wasm.md) | **
+
+---
+
 ### `toString() ► string`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -635,6 +1013,29 @@ Returns the string representation of the boolean element.
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `string` | **
+
+---
+
+# Class `CallbackQuery`
+
+A query implementation that delegates state fetching to JS callback functions.
+
+Instead of making direct HTTP calls via reqwest, each QueryTrait method
+calls a JS function that returns a Promise. The JS side handles the actual
+network request through the configured transport.
+
+## Constructors
+
+
+### `CallbackQuery(get_state_root, get_state_paths, get_block_height)`
+
+Create a new CallbackQuery with JS callback functions.
+
+Parameters | Type | Description
+--- | --- | ---
+__get_state_root__ | `function` | *A function that returns Promise&lt;string&gt; (the state root)*
+__get_state_paths__ | `function` | *A function that takes string[] (commitments) and returns Promise&lt;string[]&gt; (state paths)*
+__get_block_height__ | `function` | *A function that returns Promise&lt;number&gt; (the block height)*
 
 ---
 
@@ -816,6 +1217,163 @@ Serialize a Ciphertext into a js string.
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `string` | *The serialized Ciphertext.*
+
+---
+
+# Class `DynamicRecord`
+
+A fixed-size representation of an Aleo record. Like static records, a dynamic record
+contains an owner, nonce, and a version, but instead of storing the full data it only
+stores the Merkle root of the data, ensuring all dynamic records have a constant size.
+
+## Methods
+
+### `toBitsLe() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the dynamic record as a little-endian bit array (JS Array of booleans).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
+### `fromRecord(record) ► DynamicRecord`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Creates a DynamicRecord from a RecordPlaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__record__ | [RecordPlaintext](sdk-src_wasm.md) | **
+__*return*__ | [DynamicRecord](sdk-src_wasm.md) | **
+
+---
+
+### `fromString(s) ► DynamicRecord`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Creates a DynamicRecord from its string representation.
+
+Parameters | Type | Description
+--- | --- | ---
+__s__ | `string` | **
+__*return*__ | [DynamicRecord](sdk-src_wasm.md) | **
+
+---
+
+### `toBytesLe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Serializes the dynamic record to a little-endian byte array (Uint8Array).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | **
+
+---
+
+### `fromBytesLe(bytes) ► DynamicRecord`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Deserializes a DynamicRecord from a little-endian byte array (Uint8Array).
+
+Parameters | Type | Description
+--- | --- | ---
+__bytes__ | `Uint8Array` | **
+__*return*__ | [DynamicRecord](sdk-src_wasm.md) | **
+
+---
+
+### `root() ► Field`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the Merkle root of the record data as a Field.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Field](sdk-src_wasm.md) | **
+
+---
+
+### `nonce() ► Group`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the nonce of the record as a Group.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
+### `owner() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the owner address of the dynamic record.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | **
+
+---
+
+### `isHiding() ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns &#x60;true&#x60; if the dynamic record is a hiding variant (version !&#x3D; 0).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `boolean` | **
+
+---
+
+### `toFields() ► Array.<any>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the dynamic record as an array of field elements.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<any>` | **
+
+---
+
+### `toRecord(owner_is_private) ► RecordPlaintext`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Converts this DynamicRecord back to a RecordPlaintext.
+&#x60;owner_is_private&#x60; controls whether the owner field uses private or public visibility.
+
+Parameters | Type | Description
+--- | --- | ---
+__owner_is_private__ | `boolean` | **
+__*return*__ | [RecordPlaintext](sdk-src_wasm.md) | **
+
+---
+
+### `toString() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the string representation of the dynamic record.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | **
 
 ---
 
@@ -1108,6 +1666,19 @@ Field element.
 
 ## Methods
 
+### `toAddress() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field element to an Address (strict, via Group x-coordinate recovery).
+Returns an error if the field is not a valid x-coordinate on the curve.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | **
+
+---
+
 ### `toBitsLe() ► Array.<any>`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -1117,6 +1688,19 @@ Get the left endian boolean array representation of the field element.
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `Array.<any>` | **
+
+---
+
+### `toBoolean() ► Boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field element to a Boolean (strict).
+Returns an error if the field is not zero or one.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Boolean](sdk-src_wasm.md) | **
 
 ---
 
@@ -1145,6 +1729,30 @@ __*return*__ | `Uint8Array` | **
 
 ---
 
+### `toI8Lossy() ► I8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to an I8 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I8` | **
+
+---
+
+### `toU8Lossy() ► U8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to a U8 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U8` | **
+
+---
+
 ### `fromBitsLe(bits) ► Field`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
@@ -1155,6 +1763,42 @@ Parameters | Type | Description
 --- | --- | ---
 __bits__ | `Array.<any>` | **
 __*return*__ | [Field](sdk-src_wasm.md) | **
+
+---
+
+### `toI16Lossy() ► I16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to an I16 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I16` | **
+
+---
+
+### `toI32Lossy() ► I32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to an I32 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I32` | **
+
+---
+
+### `toI64Lossy() ► I64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to an I64 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I64` | **
 
 ---
 
@@ -1170,6 +1814,42 @@ __*return*__ | [Plaintext](sdk-src_wasm.md) | **
 
 ---
 
+### `toU16Lossy() ► U16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to a U16 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U16` | **
+
+---
+
+### `toU32Lossy() ► U32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to a U32 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U32` | **
+
+---
+
+### `toU64Lossy() ► U64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to a U64 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U64` | **
+
+---
+
 ### `fromBytesLe(bytes) ► Field`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
@@ -1180,6 +1860,82 @@ Parameters | Type | Description
 --- | --- | ---
 __bytes__ | `Uint8Array` | **
 __*return*__ | [Field](sdk-src_wasm.md) | **
+
+---
+
+### `toI128Lossy() ► I128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to an I128 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I128` | **
+
+---
+
+### `toU128Lossy() ► U128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field to a U128 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U128` | **
+
+---
+
+### `toGroupLossy() ► Group`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field element to a Group element with lossy conversion.
+
+Uses the snarkVM cast_lossy path: tries x-coordinate recovery first,
+falls back to the generator for field &#x3D;&#x3D; 1, and applies Elligator-2
+otherwise. This conversion never fails.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
+### `toScalarLossy() ► Scalar`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field element to a Scalar with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Scalar](sdk-src_wasm.md) | **
+
+---
+
+### `toAddressLossy() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field element to an Address with lossy conversion (via Group, Elligator-2 fallback).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | **
+
+---
+
+### `toBooleanLossy() ► Boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field element to a Boolean with lossy truncation (extracts least-significant bit).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Boolean](sdk-src_wasm.md) | **
 
 ---
 
@@ -1346,6 +2102,21 @@ __*return*__ | [Field](sdk-src_wasm.md) | **
 
 ---
 
+### `toGroup() ► Group`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the field element to a Group element (strict).
+
+Attempts to recover the group element from the field as an x-coordinate.
+Returns an error if the field is not a valid x-coordinate on the curve.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
 ### `toString() ► string`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -1363,6 +2134,31 @@ __*return*__ | `string` | **
 Elliptic curve element.
 
 ## Methods
+
+### `fromField(field) ► Group`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Generate the group element from the x coordinate of the group.
+
+Parameters | Type | Description
+--- | --- | ---
+__field__ | [Field](sdk-src_wasm.md) | **
+__*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
+### `toAddress() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group element to an Address (lossless — Address wraps Group).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | **
+
+---
 
 ### `toBitsLe() ► Array.<any>`
 
@@ -1401,6 +2197,30 @@ __*return*__ | `Uint8Array` | **
 
 ---
 
+### `toI8Lossy() ► I8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to an I8 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I8` | **
+
+---
+
+### `toU8Lossy() ► U8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to a U8 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U8` | **
+
+---
+
 ### `fromBitsLe(bits) ► Group`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
@@ -1414,6 +2234,42 @@ __*return*__ | [Group](sdk-src_wasm.md) | **
 
 ---
 
+### `toI16Lossy() ► I16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to an I16 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I16` | **
+
+---
+
+### `toI32Lossy() ► I32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to an I32 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I32` | **
+
+---
+
+### `toI64Lossy() ► I64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to an I64 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I64` | **
+
+---
+
 ### `toPlaintext() ► Plaintext`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -1423,6 +2279,42 @@ Create a plaintext element from a group element.
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | [Plaintext](sdk-src_wasm.md) | **
+
+---
+
+### `toU16Lossy() ► U16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to a U16 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U16` | **
+
+---
+
+### `toU32Lossy() ► U32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to a U32 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U32` | **
+
+---
+
+### `toU64Lossy() ► U64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to a U64 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U64` | **
 
 ---
 
@@ -1439,6 +2331,30 @@ __*return*__ | [Group](sdk-src_wasm.md) | **
 
 ---
 
+### `toI128Lossy() ► I128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to an I128 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I128` | **
+
+---
+
+### `toU128Lossy() ► U128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group to a U128 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U128` | **
+
+---
+
 ### `scalarMultiply(scalar) ► Group`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -1452,6 +2368,18 @@ __*return*__ | [Group](sdk-src_wasm.md) | **
 
 ---
 
+### `toScalarLossy() ► Scalar`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group element to a Scalar with lossy truncation (via x-coordinate).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Scalar](sdk-src_wasm.md) | **
+
+---
+
 ### `toXCoordinate() ► Field`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -1461,6 +2389,31 @@ Get the x-coordinate of the group element.
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | [Field](sdk-src_wasm.md) | **
+
+---
+
+### `toBooleanLossy() ► Boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group element to a Boolean with lossy truncation (LSB of x-coordinate).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Boolean](sdk-src_wasm.md) | **
+
+---
+
+### `fromFieldString(field) ► Group`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Generate the group element from a string representation of the x coordinate of the group.
+
+Parameters | Type | Description
+--- | --- | ---
+__field__ | `string` | **
+__*return*__ | [Group](sdk-src_wasm.md) | **
 
 ---
 
@@ -1561,6 +2514,19 @@ Parameters | Type | Description
 --- | --- | ---
 __other__ | [Group](sdk-src_wasm.md) | **
 __*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
+### `toField() ► Field`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the group element to a Field (returns x-coordinate).
+This is an alias for &#x60;toXCoordinate()&#x60;.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Field](sdk-src_wasm.md) | **
 
 ---
 
@@ -2028,6 +2994,18 @@ __*return*__ | [PrivateKey](sdk-src_wasm.md) | **
 
 ---
 
+### `toBytesLe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the byte representation of a private key
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | *Byte representation of a private key*
+
+---
+
 ### `to_view_key() ► ViewKey`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -2037,6 +3015,32 @@ Get the view key corresponding to the private key
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `ViewKey` | **
+
+---
+
+### `toString() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get a string representation of the private key. This function should be used very carefully
+as it exposes the private key plaintext
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | *String representation of a private key*
+
+---
+
+### `fromBytesLe(bytes) ► PrivateKey`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Get a private key from a byte representation
+
+Parameters | Type | Description
+--- | --- | ---
+__bytes__ | `Uint8Array` | *Byte representation of a private key*
+__*return*__ | [PrivateKey](sdk-src_wasm.md) | *Private key*
 
 ---
 
@@ -2233,6 +3237,18 @@ console.log(imports === expected_imports); // Output should be "true"
 
 ---
 
+### `toChecksum() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the checksum of the program.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | *The checksum of the program as a 32-byte Uint8Array*
+
+---
+
 ### `getMappings() ► Array`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -2304,6 +3320,47 @@ const credits_program = aleo_wasm.Program.getCreditsProgram();
 const credits_functions = credits_program.getFunctions();
 console.log(credits_functions === expected_functions); // Output should be "true"
 ```
+
+---
+
+### `nameToField() ► Field`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the program&#x27;s name (without the &#x60;.aleo&#x60; suffix) encoded as a field element.
+
+This is the same value as casting the program name identifier to a field on-chain
+(e.g. &#x60;my_program.aleo&#x60; -&gt; &#x60;Identifier(&quot;my_program&quot;) as field&#x60;), which is used as
+the program id in dynamic dispatch calls such as &#x60;IARC20@(token_id)&#x60;.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Field](sdk-src_wasm.md) | *The program name as a field element*
+
+#### Examples
+
+```javascript
+const program = aleo_wasm.Program.getCreditsProgram();
+const field = program.nameToField(); // Field encoding of "credits"
+```
+
+---
+
+### `getCallGraph(entry_function) ► object`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get the external call graph reachable from a specific entry function.
+
+Starting from &#x60;entry_function&#x60;, traces all reachable functions and closures
+within this program (via local calls) and collects external calls
+(&#x60;call program.aleo/function&#x60;). Returns a JS object mapping program names
+to arrays of called function names.
+
+Parameters | Type | Description
+--- | --- | ---
+__entry_function__ | `string` | *The name of the entry function to trace from*
+__*return*__ | `object` | *An object like &#x60;{ &quot;program.aleo&quot;: [&quot;fn1&quot;, &quot;fn2&quot;] }&#x60;*
 
 ---
 
@@ -2486,6 +3543,47 @@ __*return*__ | [Address](sdk-src_wasm.md) | *The address of the program*
 
 ---
 
+### `isArc20() ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Determine if the program implements the ARC-20 fungible token interface (IARC20).
+
+This checks that the program defines a &#x60;Token&#x60; record with an &#x60;amount: u128&#x60; entry
+(additional entries are permitted, per the interface&#x27;s open record definition) and
+that every function and view function required by ARC-20 is present with the exact
+input and output signature defined by the standard.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `boolean` | *True if the program implements the ARC-20 token interface*
+
+---
+
+### `isArc22() ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Determine if the program implements the ARC-22 compliant token interface (IARC22).
+
+This checks that the program defines &#x60;Token&#x60; and &#x60;ComplianceRecord&#x60; records with the
+entries required by the standard (additional entries are permitted, per the
+interface&#x27;s open record definitions), and that every function and view function
+required by ARC-22 is present with the exact input and output signature defined by
+the standard. The &#x60;MerkleProof&#x60; struct used by the private transfer functions may be
+declared locally (in which case its shape must match the standard exactly) or
+imported from another program such as a freeze list registry.
+
+Note: this checks the token interface (IARC22) only. The freeze list registry
+interface (IARC22Freezelist) is typically implemented by a separate program and is
+not required for a token program to be considered ARC-22 compliant.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `boolean` | *True if the program implements the ARC-22 token interface*
+
+---
+
 ### `isEqual(other) ► boolean`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -2508,6 +3606,355 @@ Get a string representation of the program
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `string` | *String containing the program source code*
+
+---
+
+# Class `ProgramImports`
+
+Backed by &#x60;Rc&lt;RefCell&lt;&gt;&gt;&#x60; for interior mutability — cloning produces a cheap
+reference-counted copy that shares the same underlying data. This allows
+execution functions to clone the builder internally while the caller&#x27;s
+original reference automatically sees any mutations (e.g. synthesized keys).
+
+## Constructors
+
+
+### `ProgramImports()`
+
+Create a new empty ProgramImports builder.
+
+Initializes an internal snarkVM Process. This is the same cost as a
+single execution call, but is paid once and reused across all operations.
+
+---
+
+## Methods
+
+### `addProgram(name, source, edition) ► void`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Add a program&#x27;s source code to the imports.
+
+The source is parsed, validated, and added to the internal Process.
+Static imports of the program are resolved depth-first from programs
+already present in this builder.
+
+Parameters | Type | Description
+--- | --- | ---
+__name__ | `string` | *The program name (e.g., &quot;my_program.aleo&quot;).*
+__source__ | `string` | *The program source code.*
+__edition__ | `number` | *The program edition (defaults to 1).*
+__*return*__ | `void` | **
+
+---
+
+### `fromObject(object) ► ProgramImports`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Create a ProgramImports from a plain JavaScript object.
+
+Accepts three formats:
+&#x60;&#x60;&#x60;js
+// 1. Plain string — source code only.
+{ &quot;my_program.aleo&quot;: &quot;program source...&quot; }
+
+// 2. Structured — program source with optional edition.
+{ &quot;my_program.aleo&quot;: { program: &quot;program source...&quot; } }
+
+// 3. Structured with keys — program source plus proving/verifying keys per function.
+{
+  &quot;my_program.aleo&quot;: {
+    program: &quot;program source...&quot;,
+    keys: {
+      &quot;my_function&quot;: {
+        provingKey: Uint8Array,
+        verifyingKey: Uint8Array
+      }
+    }
+  }
+}
+&#x60;&#x60;&#x60;
+
+Programs created via this method default to edition 1.
+
+Parameters | Type | Description
+--- | --- | ---
+__object__ | `Object` | *A plain JavaScript object mapping program names to source code
+  and optional keys.*
+__*return*__ | [ProgramImports](sdk-src_wasm.md) | **
+
+---
+
+### `getProgram(name) ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Return the source code of a program by name, without serializing keys.
+
+Parameters | Type | Description
+--- | --- | ---
+__name__ | `string` | *The program name (e.g., &quot;my_program.aleo&quot;).*
+__*return*__ | `string` | **
+
+---
+
+### `programNames() ► Array.<string>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Return the names of all programs in this builder as a JS &#x60;Array&lt;string&gt;&#x60;.
+
+This is a lightweight alternative to &#x60;toObject()&#x60; when you only need to
+enumerate program names without serializing keys.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array.<string>` | **
+
+---
+
+### `addProvingKey(program_name, identifier, key) ► void`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Add a proving key for a function or record within an imported program.
+
+The key is transferred directly from the WASM &#x60;ProvingKey&#x60; type with no
+serialization overhead.
+
+Parameters | Type | Description
+--- | --- | ---
+__program_name__ | `string` | *The program name (e.g., &quot;my_program.aleo&quot;).*
+__identifier__ | `string` | *The function name or record name the key belongs to.*
+__key__ | [ProvingKey](sdk-src_wasm.md) | *The proving key.*
+__*return*__ | `void` | **
+
+---
+
+### `getProvingKey(program_name, identifier) ► ProvingKey`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get a proving key for a specific program and identifier (function or record name).
+Returns a clone of the key from the internal Process. Non-destructive — the key
+remains available for future calls.
+
+Parameters | Type | Description
+--- | --- | ---
+__program_name__ | `string` | *The program name (e.g., &quot;my_program.aleo&quot;).*
+__identifier__ | `string` | *The function or record name.*
+__*return*__ | [ProvingKey](sdk-src_wasm.md) | **
+
+---
+
+### `addVerifyingKey(program_name, identifier, key) ► void`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Add a verifying key for a function or record within an imported program.
+
+The key is transferred directly from the WASM &#x60;VerifyingKey&#x60; type with no
+serialization overhead.
+
+Parameters | Type | Description
+--- | --- | ---
+__program_name__ | `string` | *The program name (e.g., &quot;my_program.aleo&quot;).*
+__identifier__ | `string` | *The function name or record name the key belongs to.*
+__key__ | [VerifyingKey](sdk-src_wasm.md) | *The verifying key.*
+__*return*__ | `void` | **
+
+---
+
+### `getVerifyingKey(program_name, identifier) ► VerifyingKey`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get a verifying key for a specific program and identifier (function or record name).
+Returns a clone of the key from the internal Process. Non-destructive — the key
+remains available for future calls.
+
+Parameters | Type | Description
+--- | --- | ---
+__program_name__ | `string` | *The program name (e.g., &quot;my_program.aleo&quot;).*
+__identifier__ | `string` | *The function or record name.*
+__*return*__ | [VerifyingKey](sdk-src_wasm.md) | **
+
+---
+
+### `addProvingKeyBytes(program_name, identifier, bytes) ► void`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Add a proving key from its byte representation.
+
+Deserializes the bytes into a native proving key and stores it. The program
+must already have been added via &#x60;addProgram&#x60;.
+
+Parameters | Type | Description
+--- | --- | ---
+__program_name__ | `string` | *The program name (e.g., &quot;my_program.aleo&quot;).*
+__identifier__ | `string` | *The function name or record name the key belongs to.*
+__bytes__ | `Uint8Array` | *The proving key bytes.*
+__*return*__ | `void` | **
+
+---
+
+### `addVerifyingKeyBytes(program_name, identifier, bytes) ► void`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Add a verifying key from its byte representation.
+
+Deserializes the bytes into a native verifying key and stores it. The program
+must already have been added via &#x60;addProgram&#x60;.
+
+Parameters | Type | Description
+--- | --- | ---
+__program_name__ | `string` | *The program name (e.g., &quot;my_program.aleo&quot;).*
+__identifier__ | `string` | *The function name or record name the key belongs to.*
+__bytes__ | `Uint8Array` | *The verifying key bytes.*
+__*return*__ | `void` | **
+
+---
+
+### `functionKeysAvailable(program_name) ► Array.<string>`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Return the names of functions that have both a proving key and a verifying key
+stored for the given program.
+
+Parameters | Type | Description
+--- | --- | ---
+__program_name__ | `string` | *The program name (e.g., &quot;my_program.aleo&quot;).*
+__*return*__ | `Array.<string>` | **
+
+---
+
+### `clone() ► ProgramImports`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Create a cheap clone that shares the same underlying data.
+
+Useful for passing to WASM execution functions which consume ownership:
+the caller keeps the original, and both copies see any mutations
+(e.g. synthesized keys) through the shared interior state.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [ProgramImports](sdk-src_wasm.md) | **
+
+---
+
+### `contains(name) ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Check whether a specific program has been added.
+
+Parameters | Type | Description
+--- | --- | ---
+__name__ | `string` | *The program name.*
+__*return*__ | `boolean` | **
+
+---
+
+### `isEmpty() ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Check whether any programs have been added to this builder.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `boolean` | **
+
+---
+
+### `toObject() ► Object`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Convert this ProgramImports to a plain JavaScript object.
+
+Entries without keys use the simple &#x60;{ &quot;name.aleo&quot;: &quot;source&quot; }&#x60; format.
+Entries with keys use the structured format:
+&#x60;&#x60;&#x60;js
+{
+  &quot;name.aleo&quot;: {
+    program: &quot;program source...&quot;,
+    keys: {
+      &quot;function_name&quot;: {
+        provingKey: Uint8Array,
+        verifyingKey: Uint8Array
+      }
+    }
+  }
+}
+&#x60;&#x60;&#x60;
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Object` | **
+
+---
+
+# Class `Proof`
+
+SNARK proof for verification of program execution
+
+## Methods
+
+### `fromBytes(bytes) ► Proof`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Construct a new proof from a byte array
+
+Parameters | Type | Description
+--- | --- | ---
+__bytes__ | `Uint8Array` | *Byte array representation of a proof*
+__*return*__ | [Proof](sdk-src_wasm.md) | **
+
+---
+
+### `fromString(string) ► Proof`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Create a proof from string
+
+Parameters | Type | Description
+--- | --- | ---
+__string__ | `string` | *String representation of the proof*
+__*return*__ | [Proof](sdk-src_wasm.md) | **
+
+---
+
+### `toBytes() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Return the byte representation of a proof
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | *Byte array representation of a proof*
+
+---
+
+### `toString() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get a string representation of the proof
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | *String representation of the proof*
 
 ---
 
@@ -2880,17 +4327,46 @@ provingKey.isTransferPublicToPrivateProver() ? console.log("Key verified") : thr
 
 Represents a proving request to a prover.
 
+Carries one of two variants:
+- &#x60;Authorization&#x60; — a fully-constructed snarkVM &#x60;Authorization&#x60; (plus optional
+  fee authorization). Submitted to &#x60;/prove/authorization&#x60; (encrypted-only).
+- &#x60;Request&#x60; — a single signed snarkVM &#x60;Request&#x60; (plus optional fee &#x60;Request&#x60;)
+  that the prover authorizes server-side. Submitted to &#x60;/prove/request&#x60;
+  (encrypted-only).
+
+Use [ProvingRequest#kind](ProvingRequest#kind) when handling a &#x60;ProvingRequest&#x60; of unknown
+variant (e.g. after deserialization). Variant-specific accessors throw if
+called on the wrong variant.
+
 ## Methods
+
+### `feeRequest() ► ExecutionRequest`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the signed fee &#x60;ExecutionRequest&#x60; in the Request variant, or
+&#x60;undefined&#x60; when no fee request is set or this is an Authorization variant.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `ExecutionRequest` | **
+
+---
 
 ### `fromString(request) ► ProvingRequest`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
 
-Creates a ProvingRequest from a string representation.
+Creates a &#x60;ProvingRequest&#x60; from a JSON string representation.
+
+The variant is determined automatically by the JSON shape:
+&#x60;{ authorization, ... }&#x60; → Authorization variant; &#x60;{ request, ... }&#x60; →
+Request variant. Use [ProvingRequest#kind](ProvingRequest#kind) to inspect the
+resulting variant.
 
 Parameters | Type | Description
 --- | --- | ---
-__request__ | `Uint8Array` | *String representation of the ProvingRequest.*
+__request__ | `string` | *JSON string representation of the ProvingRequest.*
 __*return*__ | [ProvingRequest](sdk-src_wasm.md) | **
 
 ---
@@ -2899,7 +4375,10 @@ __*return*__ | [ProvingRequest](sdk-src_wasm.md) | **
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Creates a left-endian byte representation of the ProvingRequest.
+Creates a left-endian byte representation of the ProvingRequest,
+dispatching on the variant. The bytes are wire-compatible with the
+matching DPS route (&#x60;/prove[/encrypted]&#x60; for Authorization,
+&#x60;/prove/request&#x60; for Request).
 
 Parameters | Type | Description
 --- | --- | ---
@@ -2907,11 +4386,35 @@ __*return*__ | `Uint8Array` | **
 
 ---
 
+### `fromRequest(request, fee_request, broadcast) ► ProvingRequest`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Creates a new Request-variant &#x60;ProvingRequest&#x60; from a single signed
+&#x60;ExecutionRequest&#x60; and an optional signed fee &#x60;ExecutionRequest&#x60;.
+
+The Request variant is processed by the DPS at the &#x60;/prove/request&#x60;
+endpoint, which is encrypted-only. The server runs
+&#x60;Process::authorize_request&#x60; to turn each &#x60;Request&#x60; into an
+&#x60;Authorization&#x60; before proving.
+
+Only valid for single-public-request executions. Layered / nested
+calls are not supported by &#x60;/prove/request&#x60; at this time.
+
+Parameters | Type | Description
+--- | --- | ---
+__request__ | `ExecutionRequest` | *The signed request for the function.*
+__fee_request__ | `ExecutionRequest` | *Optional signed request for the fee function. When omitted, the prover generates and pays the fee.*
+__broadcast__ | `boolean` | *Flag that indicates whether the remote proving service should attempt to submit the transaction on the caller&#x27;s behalf.*
+__*return*__ | [ProvingRequest](sdk-src_wasm.md) | **
+
+---
+
 ### `authorization() ► Authorization`
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Get the Authorization of the main function in the ProvingRequest.
+Returns the Authorization of the main function in the ProvingRequest.
 
 Parameters | Type | Description
 --- | --- | ---
@@ -2923,11 +4426,13 @@ __*return*__ | [Authorization](sdk-src_wasm.md) | **
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
 
-Creates a ProvingRequest from a left-endian byte representation of the ProvingRequest.
+Reads bytes as an Authorization-variant &#x60;ProvingRequest&#x60;. For the
+Request variant, use [ProvingRequest.fromBytesLeRequest](ProvingRequest.fromBytesLeRequest)
+explicitly — byte layout carries no variant discriminator.
 
 Parameters | Type | Description
 --- | --- | ---
-__bytes__ | `Uint8Array` | *Left-endian bytes representing the proving request.*
+__bytes__ | `Uint8Array` | *Left-endian bytes representing an Authorization-variant proving request.*
 __*return*__ | [ProvingRequest](sdk-src_wasm.md) | **
 
 ---
@@ -2936,7 +4441,8 @@ __*return*__ | [ProvingRequest](sdk-src_wasm.md) | **
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Get the fee Authorization in the ProvingRequest.
+Returns the fee Authorization in the ProvingRequest, or &#x60;undefined&#x60;
+when no fee is set or this is a Request variant.
 
 Parameters | Type | Description
 --- | --- | ---
@@ -2944,11 +4450,27 @@ __*return*__ | [Authorization](sdk-src_wasm.md) | **
 
 ---
 
+### `fromBytesLeRequest(bytes) ► ProvingRequest`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Reads bytes as a Request-variant &#x60;ProvingRequest&#x60;. Byte layout is
+disjoint from the Authorization variant; callers must pick the right
+reader for the bytes they hold.
+
+Parameters | Type | Description
+--- | --- | ---
+__bytes__ | `Uint8Array` | *Left-endian bytes representing a Request-variant proving request.*
+__*return*__ | [ProvingRequest](sdk-src_wasm.md) | **
+
+---
+
 ### `new(authorization, fee_authorization, broadcast) ► ProvingRequest`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
 
-Creates a new ProvingRequest from a function Authorization and an optional fee Authorization.
+Creates a new Authorization-variant &#x60;ProvingRequest&#x60; from a function
+&#x60;Authorization&#x60; and an optional fee &#x60;Authorization&#x60;.
 
 Parameters | Type | Description
 --- | --- | ---
@@ -2956,6 +4478,20 @@ __authorization__ | [Authorization](sdk-src_wasm.md) | *An Authorization for a f
 __fee_authorization__ | [Authorization](sdk-src_wasm.md) | *The authorization for the &#x60;credits.aleo/fee_public&#x60; or &#x60;credits.aleo/fee_private&#x60; function that pays the fee for the execution of the main function.*
 __broadcast__ | `boolean` | *Flag that indicates whether the remote proving service should attempt to submit the transaction on the caller&#x27;s behalf.*
 __*return*__ | [ProvingRequest](sdk-src_wasm.md) | **
+
+---
+
+### `kind() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the variant of this &#x60;ProvingRequest&#x60;: &#x60;&quot;authorization&quot;&#x60; or
+&#x60;&quot;request&quot;&#x60;. Useful when handling a &#x60;ProvingRequest&#x60; whose variant
+was determined at deserialization time.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | **
 
 ---
 
@@ -2969,6 +4505,18 @@ Parameters | Type | Description
 --- | --- | ---
 __other__ | [ProvingRequest](sdk-src_wasm.md) | **
 __*return*__ | `boolean` | **
+
+---
+
+### `request() ► ExecutionRequest`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the signed &#x60;ExecutionRequest&#x60; carried by the Request variant.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `ExecutionRequest` | **
 
 ---
 
@@ -2988,11 +4536,50 @@ __*return*__ | `boolean` | **
 
 ![modifier: public](images/badges/modifier-public.svg)
 
-Creates a string representation of the ProvingRequest.
+Creates a JSON string representation of the ProvingRequest.
+The shape carries enough information to recover the variant via
+[ProvingRequest.fromString](ProvingRequest.fromString).
 
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `string` | **
+
+---
+
+# Class `QueryOption`
+
+A unified query type that wraps either an OfflineQuery (pre-fetched state)
+or a CallbackQuery (on-demand JS transport delegation).
+
+Construct from JavaScript using the static factory methods:
+- &#x60;QueryOption.offlineQuery(offlineQuery)&#x60; for pre-fetched state
+- &#x60;QueryOption.callbackQuery(callbackQuery)&#x60; for on-demand JS callbacks
+
+## Methods
+
+### `offlineQuery(query) ► QueryOption`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Create a QueryOption from an OfflineQuery.
+
+Parameters | Type | Description
+--- | --- | ---
+__query__ | [OfflineQuery](sdk-src_wasm.md) | **
+__*return*__ | [QueryOption](sdk-src_wasm.md) | **
+
+---
+
+### `callbackQuery(query) ► QueryOption`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Create a QueryOption from a CallbackQuery.
+
+Parameters | Type | Description
+--- | --- | ---
+__query__ | [CallbackQuery](sdk-src_wasm.md) | **
+__*return*__ | [QueryOption](sdk-src_wasm.md) | **
 
 ---
 
@@ -3382,6 +4969,21 @@ __*return*__ | [RecordPlaintext](sdk-src_wasm.md) | *A clone of the RecordPlaint
 
 ---
 
+### `gamma(program_id, record_name, private_key) ► Group`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Compute the record&#x27;s gamma value.
+
+Parameters | Type | Description
+--- | --- | ---
+__program_id__ | `string` | *The program id that produced the record.*
+__record_name__ | `string` | *The name of the record within the program.*
+__private_key__ | [PrivateKey](sdk-src_wasm.md) | *The private key that created the record.*
+__*return*__ | [Group](sdk-src_wasm.md) | *The computed value of gamma.*
+
+---
+
 ### `nonce() ► string`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -3436,6 +5038,19 @@ Scalar field element.
 
 ## Methods
 
+### `toAddress() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to an Address (strict, via Field x-coordinate recovery).
+Returns an error if the resulting field is not a valid x-coordinate on the curve.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | **
+
+---
+
 ### `toBitsLe() ► Array.<any>`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -3445,6 +5060,19 @@ Get the left endian boolean array representation of the scalar element.
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | `Array.<any>` | **
+
+---
+
+### `toBoolean() ► Boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to a Boolean (strict).
+Returns an error if the scalar is not zero or one.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Boolean](sdk-src_wasm.md) | **
 
 ---
 
@@ -3473,6 +5101,30 @@ __*return*__ | `Uint8Array` | **
 
 ---
 
+### `toI8Lossy() ► I8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to an I8 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I8` | **
+
+---
+
+### `toU8Lossy() ► U8`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to a U8 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U8` | **
+
+---
+
 ### `fromBitsLe(bits) ► Scalar`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
@@ -3483,6 +5135,42 @@ Parameters | Type | Description
 --- | --- | ---
 __bits__ | `Array.<any>` | **
 __*return*__ | [Scalar](sdk-src_wasm.md) | **
+
+---
+
+### `toI16Lossy() ► I16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to an I16 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I16` | **
+
+---
+
+### `toI32Lossy() ► I32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to an I32 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I32` | **
+
+---
+
+### `toI64Lossy() ► I64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to an I64 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I64` | **
 
 ---
 
@@ -3498,6 +5186,42 @@ __*return*__ | [Plaintext](sdk-src_wasm.md) | **
 
 ---
 
+### `toU16Lossy() ► U16`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to a U16 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U16` | **
+
+---
+
+### `toU32Lossy() ► U32`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to a U32 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U32` | **
+
+---
+
+### `toU64Lossy() ► U64`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to a U64 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U64` | **
+
+---
+
 ### `fromBytesLe(bytes) ► Scalar`
 
 ![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
@@ -3508,6 +5232,66 @@ Parameters | Type | Description
 --- | --- | ---
 __bytes__ | `Uint8Array` | **
 __*return*__ | [Scalar](sdk-src_wasm.md) | **
+
+---
+
+### `toI128Lossy() ► I128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to an I128 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `I128` | **
+
+---
+
+### `toU128Lossy() ► U128`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to a U128 with lossy truncation.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `U128` | **
+
+---
+
+### `toGroupLossy() ► Group`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to a Group element with lossy conversion (via Field, Elligator-2 fallback).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
+### `toAddressLossy() ► Address`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to an Address with lossy conversion (via Group, Elligator-2 fallback).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Address](sdk-src_wasm.md) | **
+
+---
+
+### `toBooleanLossy() ► Boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to a Boolean with lossy truncation (extracts least-significant bit).
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Boolean](sdk-src_wasm.md) | **
 
 ---
 
@@ -3673,6 +5457,19 @@ __*return*__ | [Field](sdk-src_wasm.md) | **
 
 ---
 
+### `toGroup() ► Group`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Cast the scalar to a Group element (strict, via Field x-coordinate recovery).
+Returns an error if the resulting field is not a valid x-coordinate on the curve.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Group](sdk-src_wasm.md) | **
+
+---
+
 ### `toString() ► string`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -3776,6 +5573,18 @@ Get the plaintext representation of the signature.
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | [Plaintext](sdk-src_wasm.md) | **
+
+---
+
+### `toString() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Get a string representation of a signature
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | *String representation of a signature*
 
 ---
 
@@ -4177,6 +5986,239 @@ __*return*__ | `string` | *String representation of the transaction*
 
 ---
 
+# Class `Value`
+
+Aleo Value type. Value is the fundamental type representing program function inputs and outputs
+in Aleo. It wraps three variants: Plaintext, Record, and Future.
+
+## Examples
+
+```javascript
+// Parse a plaintext value from a string.
+const value = Value.fromString("100u64");
+console.log(value.valueType()); // "plaintext"
+console.log(value.isPlaintext()); // true
+
+// Extract the inner Plaintext.
+const plaintext = value.toPlaintext();
+console.log(plaintext.toString()); // "100u64"
+```
+
+## Methods
+
+### `toBitsLe() ► Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the little-endian boolean array representation of the bits.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array` | *Boolean array of bits in little-endian order.*
+
+---
+
+### `valueType() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the type of the value variant as a string.
+
+Possible values: &quot;plaintext&quot;, &quot;record&quot;, &quot;future&quot;, &quot;dynamic_record&quot;, or &quot;dynamic_future&quot;.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | *The variant type name.*
+
+---
+
+### `fromString(value) ► Value`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Creates a Value from its string representation.
+
+Parameters | Type | Description
+--- | --- | ---
+__value__ | `string` | *The string representation of the value.*
+__*return*__ | [Value](sdk-src_wasm.md) | *The Value object.*
+
+---
+
+### `toBytesLe() ► Uint8Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the little-endian byte array representation of the value.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Uint8Array` | *The little-endian byte array.*
+
+---
+
+### `isPlaintext() ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns true if the value is a Plaintext variant.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `boolean` | **
+
+---
+
+### `toPlaintext() ► Plaintext`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Extracts the inner Plaintext from a Plaintext variant.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [Plaintext](sdk-src_wasm.md) | *The inner Plaintext value.*
+
+---
+
+### `fromBytesLe(bytes) ► Value`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Creates a Value from a little-endian byte array.
+
+Parameters | Type | Description
+--- | --- | ---
+__bytes__ | `Uint8Array` | *A little-endian byte array.*
+__*return*__ | [Value](sdk-src_wasm.md) | *The Value object.*
+
+---
+
+### `toFieldsRaw() ► Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the raw field array representation of the value.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array` | *Array of raw Field elements.*
+
+---
+
+### `fromPlaintext(plaintext) ► Value`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Creates a Value from a Plaintext object.
+
+Parameters | Type | Description
+--- | --- | ---
+__plaintext__ | [Plaintext](sdk-src_wasm.md) | *The Plaintext to wrap.*
+__*return*__ | [Value](sdk-src_wasm.md) | *A Value wrapping the Plaintext.*
+
+---
+
+### `toBitsRawBe() ► Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the raw big-endian boolean array representation of the bits.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array` | *Raw boolean array of bits in big-endian order.*
+
+---
+
+### `toBitsRawLe() ► Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the raw little-endian boolean array representation of the bits.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array` | *Raw boolean array of bits in little-endian order.*
+
+---
+
+### `toRecordPlaintext() ► RecordPlaintext`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Extracts the inner Record from a Record variant as a RecordPlaintext.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | [RecordPlaintext](sdk-src_wasm.md) | *The inner record.*
+
+---
+
+### `fromRecordPlaintext(record) ► Value`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Creates a Value from a RecordPlaintext object.
+
+Parameters | Type | Description
+--- | --- | ---
+__record__ | [RecordPlaintext](sdk-src_wasm.md) | *The RecordPlaintext to wrap.*
+__*return*__ | [Value](sdk-src_wasm.md) | *A Value wrapping the Record.*
+
+---
+
+### `isFuture() ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns true if the value is a Future variant.
+
+Note: There is no &#x60;toFuture()&#x60; method because the Future type does not have a WASM wrapper.
+Use &#x60;toString()&#x60; or &#x60;toBytesLe()&#x60; to serialize a Future value.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `boolean` | **
+
+---
+
+### `isRecord() ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns true if the value is a Record variant.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `boolean` | **
+
+---
+
+### `toFields() ► Array`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the field array representation of the value.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `Array` | *Array of Field elements.*
+
+---
+
+### `toString() ► string`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Returns the string representation of the value.
+
+Parameters | Type | Description
+--- | --- | ---
+__*return*__ | `string` | *The string representation of the value.*
+
+---
+
 # Class `VerifyingKey`
 
 Verifying key for a function within an Aleo program
@@ -4221,6 +6263,21 @@ __*return*__ | `number` | *The number of constraints*
 
 ---
 
+### `verifyBatch(verifying_keys, inputs, proof) ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg) ![modifier: static](images/badges/modifier-static.svg)
+
+Verify a batch SNARK proof against multiple verifying keys and their corresponding public inputs.
+
+Parameters | Type | Description
+--- | --- | ---
+__verifying_keys__ | `Array.<string>` | *Array of verifying key strings, one per circuit*
+__inputs__ | `Array.<Array.<Array.<string>>>` | *3D array of field element strings [circuit_idx][instance_idx][field_idx]*
+__proof__ | [Proof](sdk-src_wasm.md) | *The batch proof to verify*
+__*return*__ | `boolean` | *True if the batch proof is valid, false otherwise*
+
+---
+
 ### `copy() ► VerifyingKey`
 
 ![modifier: public](images/badges/modifier-public.svg)
@@ -4230,6 +6287,20 @@ Create a copy of the verifying key
 Parameters | Type | Description
 --- | --- | ---
 __*return*__ | [VerifyingKey](sdk-src_wasm.md) | *A copy of the verifying key*
+
+---
+
+### `verify(inputs, proof) ► boolean`
+
+![modifier: public](images/badges/modifier-public.svg)
+
+Verify a SNARK proof against this verifying key and public inputs.
+
+Parameters | Type | Description
+--- | --- | ---
+__inputs__ | `Array.<string>` | *Array of field element strings representing public inputs (e.g. [&quot;1field&quot;, &quot;2field&quot;])*
+__proof__ | [Proof](sdk-src_wasm.md) | *The proof to verify*
+__*return*__ | `boolean` | *True if the proof is valid, false otherwise*
 
 ---
 

--- a/docs/api_reference/toc.md
+++ b/docs/api_reference/toc.md
@@ -3,22 +3,8 @@
 ## Table of contents
 
 * ![category:other](https://img.shields.io/badge/category-other-blue.svg?style=flat-square)
-  * [src/account](sdk-src_account.md) - _Key Management class. Enables the creation of a new Aleo Account, importation of an existing account from
-an existing private key or seed, and message signing and verification functionality. An Aleo Account is generated
-from a randomly generated seed (number) from which an account private key, view key, and a public account address are
-derived. The private key lies at the root of an Aleo account. It is a highly sensitive secret and should be protected
-as it allows for creation of Aleo Program executions and arbitrary value transfers. The View Key allows for decryption
-of a user&#x27;s activity on the blockchain. The Address is the public address to which other users of Aleo can send Aleo
-credits and other records to. This class should only be used in environments where the safety of the underlying key
-material can be assured._
-  * [src/function-key-provider](sdk-src_function-key-provider.md) - _AleoKeyProvider class. Implements the KeyProvider interface. Enables the retrieval of Aleo program proving and
-verifying keys for the credits.aleo program over http from official Aleo sources and storing and retrieving function
-keys from a local memory cache._
   * [src/network-client](sdk-src_network-client.md) - _Client library that encapsulates REST calls to publicly exposed endpoints of Aleo nodes. The methods provided in this
 allow users to query public information from the Aleo blockchain and submit transactions to the network._
-  * [src/offline-key-provider](sdk-src_offline-key-provider.md) - _A key provider meant for building transactions offline on devices such as hardware wallets. This key provider is not
-able to contact the internet for key material and instead relies on the user to insert Aleo function proving &amp;
-verifying keys from local storage prior to usage._
   * [src/program-manager](sdk-src_program-manager.md) - _The ProgramManager class is used to execute and deploy programs on the Aleo network and create value transfers._
   * [src/record-provider](sdk-src_record-provider.md) - _BlockHeightSearch is a RecordSearchParams implementation that allows for searching for records within a given
 block height range._

--- a/e2e/dynamic/package.json
+++ b/e2e/dynamic/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3"
+    "@provablehq/sdk": "^0.11.4"
   }
 }

--- a/e2e/mainnet/package.json
+++ b/e2e/mainnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3"
+    "@provablehq/sdk": "^0.11.4"
   }
 }

--- a/e2e/nodenext/package.json
+++ b/e2e/nodenext/package.json
@@ -2,7 +2,7 @@
     "name": "nodenext",
     "type": "module",
     "dependencies": {
-        "@provablehq/sdk": "^0.11.3",
+        "@provablehq/sdk": "^0.11.4",
         "typescript": "^5.7.3"
     },
     "scripts": {

--- a/e2e/testnet/package.json
+++ b/e2e/testnet/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@provablehq/sdk": "^0.11.3"
+    "@provablehq/sdk": "^0.11.4"
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/sdk",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "A Software Development Kit (SDK) for Zero-Knowledge Transactions",
   "collaborators": [
     "The Provable Team"
@@ -91,7 +91,7 @@
   },
   "homepage": "https://github.com/ProvableHQ/sdk#readme",
   "dependencies": {
-    "@provablehq/wasm": "^0.11.3",
+    "@provablehq/wasm": "^0.11.4",
     "@scure/base": "^2.0.0",
     "@serenity-kit/noble-sodium": "0.2.3",
     "comlink": "^4.4.2",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "12aca1021aef2c476bad30d2f681e891b2be4f07dbc230a96df09cb693bfb3cb"
 
 [[package]]
 name = "aleo-wasm"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-wasm"
-version = "0.11.3"
+version = "0.11.4"
 authors = [ "The Provable Team" ]
 description = "WebAssembly based toolkit for developing zero-knowledge applications with Aleo"
 homepage = "https://provable.com"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provablehq/wasm",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "type": "module",
   "description": "SnarkVM WASM binaries with javascript bindings",
   "collaborators": [

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
         "@codemirror/language": "^6.10.8",
         "@codemirror/legacy-modes": "^6.4.2",
         "@codemirror/stream-parser": "^0.19.9",
-        "@provablehq/sdk": "^0.11.3",
+        "@provablehq/sdk": "^0.11.4",
         "@uiw/codemirror-theme-noctis-lilac": "^4.23.7",
         "@uiw/codemirror-theme-okaidia": "^4.23.7",
         "@uiw/react-codemirror": "^4.23.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,12 +3002,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@provablehq/sdk@npm:^0.11.3, @provablehq/sdk@workspace:sdk":
+"@provablehq/sdk@npm:^0.11.4, @provablehq/sdk@workspace:sdk":
   version: 0.0.0-use.local
   resolution: "@provablehq/sdk@workspace:sdk"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.18.2"
-    "@provablehq/wasm": "npm:^0.11.3"
+    "@provablehq/wasm": "npm:^0.11.4"
     "@rollup/plugin-replace": "npm:^6.0.2"
     "@scure/base": "npm:^2.0.0"
     "@serenity-kit/noble-sodium": "npm:0.2.3"
@@ -3041,7 +3041,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@provablehq/wasm@npm:^0.11.3, @provablehq/wasm@workspace:wasm":
+"@provablehq/wasm@npm:^0.11.4, @provablehq/wasm@workspace:wasm":
   version: 0.0.0-use.local
   resolution: "@provablehq/wasm@workspace:wasm"
   dependencies:
@@ -4760,7 +4760,7 @@ __metadata:
     "@babel/core": "npm:^7.29.6"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4793,7 +4793,7 @@ __metadata:
     "@babel/core": "npm:^7.29.6"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -4825,7 +4825,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -4859,7 +4859,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aleo-starter@workspace:create-leo-app/template-vanilla"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     tslib: "npm:^2.8.1"
     vite: "npm:^6.4.3"
   languageName: unknown
@@ -4877,7 +4877,7 @@ __metadata:
     "@codemirror/language": "npm:^6.10.8"
     "@codemirror/legacy-modes": "npm:^6.4.2"
     "@codemirror/stream-parser": "npm:^0.19.9"
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
     "@uiw/codemirror-theme-noctis-lilac": "npm:^4.23.7"
@@ -6704,7 +6704,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "devnode-starter@workspace:create-leo-app/template-devnode-js"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
   languageName: unknown
   linkType: soft
 
@@ -6882,7 +6882,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-dynamic@workspace:e2e/dynamic"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
   languageName: unknown
   linkType: soft
 
@@ -6890,7 +6890,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-mainnet@workspace:e2e/mainnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
   languageName: unknown
   linkType: soft
 
@@ -6898,7 +6898,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-testnet@workspace:e2e/testnet"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
   languageName: unknown
   linkType: soft
 
@@ -7639,7 +7639,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "extension-starter@workspace:create-leo-app/template-extension"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     "@rollup/plugin-node-resolve": "npm:^16.0.0"
     "@web/rollup-plugin-import-meta-assets": "npm:^2.2.1"
     rimraf: "npm:^6.0.1"
@@ -10306,7 +10306,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-build-and-execute-authorization-ts-starter@workspace:create-leo-app/template-build-and-execute-authorization-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10377,7 +10377,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-offline-transaction-example@workspace:create-leo-app/template-offline-public-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10396,7 +10396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-starter@workspace:create-leo-app/template-node"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
   languageName: unknown
   linkType: soft
 
@@ -10404,7 +10404,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-starter@workspace:create-leo-app/template-node-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10416,7 +10416,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "node-ts-transfer-private-starter@workspace:create-leo-app/template-private-transaction-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -10428,7 +10428,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nodenext@workspace:e2e/nodenext"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
@@ -13792,7 +13792,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-nextjs@workspace:create-leo-app/template-nextjs-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
     "@types/react-dom": "npm:^19.0.3"
@@ -13808,7 +13808,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-credits-aleo-functions-ts@workspace:create-leo-app/template-node-credits-aleo-functions-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13820,7 +13820,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-dynamic-dispatch-proving-ts@workspace:create-leo-app/template-node-dynamic-dispatch-proving-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13832,7 +13832,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-dynamic-dispatch-ts@workspace:create-leo-app/template-node-dynamic-dispatch-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
     rollup-plugin-typescript2: "npm:^0.36.0"
@@ -13844,7 +13844,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "template-node-loyalty-program-ts@workspace:create-leo-app/template-node-loyalty-program-ts"
   dependencies:
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     dotenv: "npm:^16.4.5"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.59.0"
@@ -13861,7 +13861,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"
@@ -13899,7 +13899,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
-    "@provablehq/sdk": "npm:^0.11.3"
+    "@provablehq/sdk": "npm:^0.11.4"
     "@types/babel__generator": "npm:^7.6.8"
     "@types/node": "npm:^22.12.0"
     "@types/react": "npm:^19.0.8"


### PR DESCRIPTION
## Motivation

This PR Bumps the SDK version to v0.11.4 with the following changeset:

### Features
* Adds isArc20 and isArc22 to the program object to discover whether or not a program is Arc20 or Arc22 compliant
* Adds utilities for encrypting already serialized proving requests, preserving idempotencyin the case of retries
* When imports are specified, the SDK now instead of NOT finding imports, attempts to find any missing static imports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation-only changes with no SDK implementation edits in this diff; low risk aside from consumers picking up 0.11.4 behavior when they reinstall templates.
> 
> **Overview**
> **Release packaging for `@provablehq/sdk` v0.11.4:** bumps `create-leo-app` to **0.11.4** and pins every starter template’s `@provablehq/sdk` dependency from **^0.11.3** to **^0.11.4**.
> 
> **Devnode alignment:** the devnode JS template (and `ProgramManager` doc examples) now call `getOrInitConsensusVersionTestHeights` with heights **14–16** in addition to the previous set.
> 
> **API reference refresh** documents SDK **0.11.4** surface area, including `AleoNetworkClient` helpers (`setProverUri`, `setRecordScannerUri`, `getStatePaths`, `getProgramAmendmentCount`, `submitProvingRequestSafe` / proving response handling) and expanded **`ProgramManager`** docs (KeyStore/import resolution, `CallbackQuery`, `prepareInputs`, offline inclusion keys, proof verification helpers). Minor doc type tweaks (e.g. `Account` as inline type).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1076a41a61ee33dc484306f95db59dfebf166285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->