### PR TITLE
Expose snarkVM program import limit

### DIFF
--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -170,6 +170,7 @@ export {
     Value,
     VerifyingKey,
     ViewKey,
+    getMaxProgramImports,
     initThreadPool,
     getOrInitConsensusVersionTestHeights,
     setWasmLogLevel,

--- a/sdk/src/wasm.ts
+++ b/sdk/src/wasm.ts
@@ -54,6 +54,7 @@ export {
     Value,
     VerifyingKey,
     ViewKey,
+    getMaxProgramImports,
     initThreadPool,
     getOrInitConsensusVersionTestHeights,
     setWasmLogLevel,

--- a/sdk/tests/network-limits.test.ts
+++ b/sdk/tests/network-limits.test.ts
@@ -1,0 +1,8 @@
+import { expect } from "chai";
+import { getMaxProgramImports } from "../src/node.js";
+
+describe("Network limits", () => {
+    it("exposes the snarkVM program import limit", () => {
+        expect(getMaxProgramImports()).to.equal(64);
+    });
+});

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -181,6 +181,7 @@ pub use utilities::test;
 pub use utilities::{
     EncryptionToolkit,
     get,
+    get_max_program_imports,
     get_network,
     get_or_init_consensus_version_heights,
     get_program_from_network,

--- a/wasm/src/utilities/mod.rs
+++ b/wasm/src/utilities/mod.rs
@@ -21,7 +21,10 @@ pub mod encrypt;
 pub use encrypt::EncryptionToolkit;
 
 pub mod rest;
-use crate::{Field, types::native::IdentifierNative};
+use crate::{
+    Field,
+    types::native::{CurrentNetwork, IdentifierNative},
+};
 pub use rest::{
     get,
     get_network,
@@ -32,7 +35,7 @@ pub use rest::{
     latest_program_edition,
     latest_stateroot,
 };
-use snarkvm_console::prelude::ToField;
+use snarkvm_console::prelude::{Network, ToField};
 use std::str::FromStr;
 
 #[cfg(test)]
@@ -54,6 +57,20 @@ pub fn get_or_init_consensus_version_heights(heights: Option<String>) -> js_sys:
 
     // Map to just the heights (u32) and convert to JS array
     pairs.iter().map(|(_, height)| wasm_bindgen::JsValue::from_f64(*height as f64)).collect::<js_sys::Array>()
+}
+
+/// Returns the maximum number of imports allowed in a program by the
+/// snarkVM network implementation this SDK was built against.
+///
+/// @returns {number} The maximum number of program imports.
+///
+/// @example
+/// import { getMaxProgramImports } from '@provablehq/sdk';
+///
+/// const maxImports = getMaxProgramImports();
+#[wasm_bindgen::prelude::wasm_bindgen(js_name = getMaxProgramImports)]
+pub fn get_max_program_imports() -> u32 {
+    u32::try_from(CurrentNetwork::MAX_IMPORTS).expect("snarkVM MAX_IMPORTS must fit in a u32")
 }
 
 #[wasm_bindgen::prelude::wasm_bindgen(js_name = stringToField)]
@@ -78,5 +95,10 @@ mod tests {
     fn test_string_to_field() {
         assert_eq!(string_to_field("transfer_a").unwrap().to_string(), "459830232632696923845236field");
         assert_eq!(string_to_field("transfer_b").unwrap().to_string(), "464552599115566569058932field");
+    }
+
+    #[wasm_bindgen_test]
+    fn test_get_max_program_imports() {
+        assert_eq!(get_max_program_imports(), u32::try_from(CurrentNetwork::MAX_IMPORTS).unwrap());
     }
 }


### PR DESCRIPTION
## Motivation

Wallets and other SDK consumers currently have to duplicate snarkVM's `Network::MAX_IMPORTS` when they bound caller-supplied program import lists. That value can drift when the SDK updates its pinned snarkVM revision.

Expose the limit from the `CurrentNetwork` implementation that the SDK was actually built against, so consumers can combine the protocol limit with their own security policy.

## Changes

- Add `getMaxProgramImports()` to the WASM bindings, derived from `CurrentNetwork::MAX_IMPORTS`.
- Re-export it from the public browser and Node SDK entry points.
- Add Rust and SDK-level coverage for the exported value.

## Test Plan

- `cargo check --no-default-features --features browser,testnet`
- `cargo check --no-default-features --features browser,mainnet`
- `cargo clippy --no-default-features --features browser,testnet --lib` (passes with existing warnings)
- `cargo fmt --all`

The SDK integration test is included for the generated WASM binding and will run in CI after the workspace build.

## Related PRs

- https://github.com/ProvableHQ/shield-core/issues/252 tracks consuming this API as part of an effective dApp import-resolution limit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only additive API with no changes to auth, transactions, or program execution paths.
> 
> **Overview**
> Adds **`getMaxProgramImports()`** so wallets and other SDK consumers can read the protocol’s program-import cap from the **snarkVM network build the SDK was compiled against**, instead of hard-coding `Network::MAX_IMPORTS` and risking drift on SDK upgrades.
> 
> The WASM layer implements it from `CurrentNetwork::MAX_IMPORTS` and exports it as `getMaxProgramImports`; the browser and Node entry points re-export the binding. Rust and SDK tests assert the value (currently **64**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb627471f97b66d123723333a1bf615b6e05651e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->