### PR TITLE
Skip fee estimation for fee-master proving requests

### DIFF
--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -31,6 +31,12 @@ use crate::{
 use js_sys::{Array, Object};
 use std::str::FromStr;
 
+fn requires_fee_authorization(program_id: &str, function_name: &str, use_fee_master: bool) -> bool {
+    !use_fee_master
+        && !(program_id == "credits.aleo"
+            && matches!(function_name, "split" | "upgrade" | "fee_public" | "fee_private"))
+}
+
 #[wasm_bindgen]
 impl ProgramManager {
     /// Create a `ProvingRequest` object. This object creates authorizations for the top level
@@ -69,44 +75,39 @@ impl ProgramManager {
         let edition = edition.unwrap_or(1);
 
         let mut resolved = ResolvedProcess::resolve(&program_imports, program, edition, imports.clone())?;
-        let program_native = resolved.program().clone();
+        let should_authorize_fee =
+            requires_fee_authorization(&resolved.program().id().to_string(), function_name, use_fee_master);
         let process = resolved.process_mut();
 
         let rng = &mut rand::rng();
 
-        // Convert the fee to microcredits.
-        let _base_fee_microcredits = (base_fee_credits * 1_000_000.0) as u64;
+        // Retained for API compatibility; the base fee is estimated from the
+        // authorization whenever a fee authorization is required.
+        let _ = base_fee_credits;
+
+        // Convert the priority fee to microcredits.
         let priority_fee_microcredits = (priority_fee_credits * 1_000_000.0) as u64;
 
         // Authorize the main program.
         let authorization =
             authorize!(process, process_inputs!(inputs), program, function_name, private_key, rng, unchecked, edition);
 
-        // Add base fee to the authorization.
-        // Note: We intentionally pass None for program_imports here to avoid a
-        // RefCell double-borrow panic. The inner_guard (from prepare_for_execution)
-        // still holds a mutable borrow on the builder's Rc<RefCell<>>, so passing
-        // the builder to estimate_fee_for_authorization would trigger a second
-        // borrow_mut(). The legacy imports Object path is used instead.
-        let base_fee_microcredits = ProgramManager::estimate_fee_for_authorization(
-            &crate::Authorization::from(&authorization),
-            program,
-            imports,
-            Some(edition),
-            None,
-        )?;
+        let fee_authorization = if should_authorize_fee {
+            // Estimate the base fee only when this request will include a fee
+            // authorization. Fee-master requests omit it entirely.
+            //
+            // We intentionally pass None for program_imports here to avoid a
+            // RefCell double-borrow panic. The inner guard still holds a mutable
+            // borrow on the builder, so the legacy imports Object path is used.
+            let base_fee_microcredits = ProgramManager::estimate_fee_for_authorization(
+                &crate::Authorization::from(&authorization),
+                program,
+                imports,
+                Some(edition),
+                None,
+            )?;
+            let execution_id = authorization.to_execution_id().map_err(|e| e.to_string())?;
 
-        // Authorize the fee.
-        let execution_id = authorization.to_execution_id().map_err(|e| e.to_string())?;
-        let fee_authorization = if (program_native.id().to_string().as_str() == "credits.aleo")
-            && (function_name == "split"
-                || function_name == "upgrade"
-                || function_name == "fee_public"
-                || function_name == "fee_private")
-            || use_fee_master
-        {
-            None
-        } else {
             Some(authorize_fee!(
                 process,
                 private_key,
@@ -116,6 +117,8 @@ impl ProgramManager {
                 fee_record,
                 rng
             ))
+        } else {
+            None
         };
 
         // Return the proving request.
@@ -171,6 +174,18 @@ mod tests {
     };
 
     use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    fn fee_authorization_requirement_matches_request_type() {
+        assert!(requires_fee_authorization("example.aleo", "run", false));
+        assert!(!requires_fee_authorization("example.aleo", "run", true));
+
+        for function_name in ["split", "upgrade", "fee_public", "fee_private"] {
+            assert!(!requires_fee_authorization("credits.aleo", function_name, false));
+        }
+
+        assert!(requires_fee_authorization("credits.aleo", "transfer_public", false));
+    }
 
     /// Build an ExecutionRequest for credits.aleo transfer_public for use in proving_request_from_execution_request test.
     fn transfer_public_execution_request() -> ExecutionRequest {


### PR DESCRIPTION
## Motivation

`buildProvingRequest` always estimated the execution fee and derived the execution ID after building the main authorization. It then discarded both results when the request used a fee master, or when the selected `credits.aleo` function intentionally had no fee authorization.

This moves fee estimation and execution-ID derivation into the branch that actually builds a fee authorization. The existing `useFeeMaster` option remains the public signal, so this introduces no new API or conflicting skip flag.

In a local benchmark of the representative testnet swap transaction `at174kyef8hwfyv7v2tk67x3truvcc4zm2ldh0rwmdqn8an48l08u9q27xwsw`, an unchecked fee-master proving request with a warm process dropped from roughly 1.41–1.48 s to 0.252–0.267 s. The removed fee estimate accounted for roughly 1.15–1.19 s. Authorization shape, transition count, absence of a fee authorization, and serialization round-trip remained unchanged.

## Test Plan

- `yarn build:wasm`
- `yarn build:sdk`
- `cargo fmt --manifest-path wasm/Cargo.toml -- --check`
- `cargo check --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown --features testnet`
- Targeted WASM test for fee-authorization requirements — 1 passed

## Related PRs

- #1382 — prepared-program/prewarm API
- ProvableHQ/shield-core#256 — request unchecked authorization for delegated proving

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change is limited to when fee work runs, but incorrect branching would break fee authorization for paying users; logic is covered by new unit tests and existing fee-master integration tests.
> 
> **Overview**
> **`buildProvingRequest`** no longer runs **`estimate_fee_for_authorization`** or derives the execution ID on every call. Those steps run only when the request will actually attach a fee authorization.
> 
> Fee-master requests (`use_fee_master`) and the existing **`credits.aleo`** exceptions (`split`, `upgrade`, `fee_public`, `fee_private`) skip that work entirely. The public API is unchanged: `base_fee_credits` is still accepted but ignored when no fee auth is built; the base fee is estimated inside the fee-auth branch as before.
> 
> A small **`requires_fee_authorization`** helper centralizes that decision, with a WASM unit test covering fee-master, credits exceptions, and normal programs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa0d2ad61142a90d89b1bda30d7dab7b3707124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->