### PR TITLE
[Feature] Add reusable prepared program contexts

### DIFF
--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -109,7 +109,7 @@ async function initializeWasm() {
     logger.warn("initializeWasm is deprecated, you no longer need to use it");
 }
 
-export { ProgramManager, ProvingRequestOptions, ExecuteOptions, FeeAuthorizationOptions, AuthorizationOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof, programChecksum } from "./program-manager.js";
+export { ProgramManager, PreparedProgram, PrepareProgramOptions, ProvingRequestOptions, ExecuteOptions, FeeAuthorizationOptions, AuthorizationOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof, programChecksum } from "./program-manager.js";
 
 export { logAndThrow, TransportFunction, defaultTransport, cookieAffinityTransport } from "./utils/utils.js";
 

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -116,6 +116,71 @@ interface ExecuteOptions {
 }
 
 /**
+ * Options for preparing a program for later authorization or proving-request
+ * generation.
+ *
+ * Preparing resolves the program source, edition, and transitive imports and
+ * initializes the underlying snarkVM process. It does not require a private key
+ * and does not create an authorization.
+ */
+interface PrepareProgramOptions {
+    programName: string;
+    functionName: string;
+    programSource?: string | Program;
+    programImports?: ProgramImports;
+    edition?: number;
+}
+
+const preparedProgramBuilders = new WeakMap<object, ProgramImportsBuilder>();
+
+function clonePreparedProgramBuilder(
+    preparedProgram: PreparedProgram,
+): ProgramImportsBuilder {
+    const builder = preparedProgramBuilders.get(preparedProgram);
+    if (!builder) {
+        throw new Error("Prepared program has already been freed");
+    }
+    return builder.clone();
+}
+
+/**
+ * A reusable program context created by {@link ProgramManager.prepareProgram}.
+ *
+ * The context is scoped to one program function. Calls using it must be
+ * sequential. The caller owns the context and should call {@link free} when it
+ * is no longer needed.
+ */
+class PreparedProgram {
+    readonly programName: string;
+    readonly functionName: string;
+    readonly programSource: string;
+    readonly edition: number;
+
+    /**
+     * Instances are normally created through {@link ProgramManager.prepareProgram}.
+     */
+    constructor(
+        programName: string,
+        functionName: string,
+        programSource: string,
+        edition: number,
+    ) {
+        this.programName = programName;
+        this.functionName = functionName;
+        this.programSource = programSource;
+        this.edition = edition;
+    }
+
+    /**
+     * Release the prepared snarkVM process. This method is idempotent.
+     */
+    free(): void {
+        preparedProgramBuilders.get(this)?.free();
+        preparedProgramBuilders.delete(this);
+    }
+}
+
+/**
  * Options for building an Authorization for a function.
  *
  * @property {string} programName Name of the program containing the function to build the authorization for.
@@ -125,6 +190,7 @@ interface ExecuteOptions {
  * @property {PrivateKey} [privateKey] Optional private key to use to build the authorization.
  * @property {ProgramImports} [programImports] The other programs the program imports.
  * @property {edition} [edition]
+ * @property {PreparedProgram} [preparedProgram] A reusable context returned by ProgramManager.prepareProgram.
  */
 interface AuthorizationOptions {
     programName: string;
@@ -134,6 +200,7 @@ interface AuthorizationOptions {
     privateKey?: PrivateKey;
     programImports?: ProgramImports;
     edition?: number;
+    preparedProgram?: PreparedProgram;
 }
 
 /**
@@ -198,6 +265,7 @@ interface ExecuteAuthorizationOptions {
  * @property {boolean} unchecked - Whether to execute the transaction without checking the validity of the authorization (faster but may fail).
  * @property {number} [edition] - Edition of the program to execute the function in.
  * @property {boolean} [useFeeMaster] - Whether to use the FeeMaster account to execute the transaction.
+ * @property {PreparedProgram} [preparedProgram] - A reusable context returned by ProgramManager.prepareProgram.
  */
 interface ProvingRequestOptions {
     programName: string;
@@ -216,6 +284,7 @@ interface ProvingRequestOptions {
     edition?: number;
     useFeeMaster?: boolean;
     executionRequest?: ExecutionRequest;
+    preparedProgram?: PreparedProgram;
 }
 
 /**
@@ -389,6 +458,115 @@ class ProgramManager {
      */
     setKeyStore(keyStore: KeyStore) {
         this._keyStore = keyStore;
+    }
+
+    /**
+     * Prepare a program for later authorization or proving-request generation.
+     *
+     * This resolves the source, edition, and transitive imports and initializes
+     * the underlying snarkVM process without accessing a private key. Reuse the
+     * returned context through the `preparedProgram` option, then call `free()`
+     * when it is no longer needed.
+     *
+     * @param {PrepareProgramOptions} options Program and function to prepare.
+     * @returns {Promise<PreparedProgram>} A reusable, caller-owned context.
+     */
+    async prepareProgram(
+        options: PrepareProgramOptions,
+    ): Promise<PreparedProgram> {
+        let program = options.programSource;
+        if (program === undefined) {
+            try {
+                program = await this.networkClient.getProgram(options.programName);
+            } catch (e: any) {
+                logAndThrow(
+                    `Error finding ${options.programName}. Network response: '${e.message}'. Please ensure you're connected to a valid Aleo network the program is deployed to the network.`,
+                );
+            }
+        } else if (program instanceof Program) {
+            program = program.toString();
+        }
+
+        const parsedProgram = Program.fromString(program);
+        if (parsedProgram.id() !== options.programName) {
+            throw new Error(
+                `Program source ID '${parsedProgram.id()}' does not match requested program '${options.programName}'`,
+            );
+        }
+
+        const edition = options.edition
+            ?? (await this.resolveEditionAndAmendment(options.programName)).edition;
+        const { builder } = await this.buildProgramImports(
+            program,
+            options.programImports,
+            false,
+            options.functionName,
+        );
+
+        // Add the entry program as well as its imports so the snarkVM process is
+        // fully initialized before an authorization is requested.
+        builder.addProgram(options.programName, program, edition);
+
+        const preparedProgram = new PreparedProgram(
+            options.programName,
+            options.functionName,
+            program,
+            edition,
+        );
+        preparedProgramBuilders.set(preparedProgram, builder);
+        return preparedProgram;
+    }
+
+    private validatePreparedProgram(
+        preparedProgram: PreparedProgram,
+        options: {
+            programName: string;
+            functionName: string;
+            programSource?: string | Program;
+            programImports?: ProgramImports;
+            edition?: number;
+        },
+    ): void {
+        if (
+            preparedProgram.programName !== options.programName
+            || preparedProgram.functionName !== options.functionName
+        ) {
+            throw new Error(
+                `Prepared program is for ${preparedProgram.programName}/${preparedProgram.functionName}, not ${options.programName}/${options.functionName}`,
+            );
+        }
+
+        const providedSource = options.programSource instanceof Program
+            ? options.programSource.toString()
+            : options.programSource;
+        if (
+            providedSource !== undefined
+            && providedSource !== preparedProgram.programSource
+        ) {
+            throw new Error("Prepared program source does not match the supplied program source");
+        }
+
+        if (
+            options.edition !== undefined
+            && options.edition !== preparedProgram.edition
+        ) {
+            throw new Error("Prepared program edition does not match the supplied edition");
+        }
+
+        if (options.programImports) {
+            const builder = clonePreparedProgramBuilder(preparedProgram);
+            try {
+                for (const [name, source] of Object.entries(options.programImports)) {
+                    if (builder.getProgram(name) !== source.toString()) {
+                        throw new Error(
+                            `Prepared program import '${name}' does not match the supplied import`,
+                        );
+                    }
+                }
+            } finally {
+                builder.free();
+            }
+        }
     }
 
     /**
@@ -1608,11 +1786,16 @@ class ProgramManager {
             inputs,
         } = options;
 
+        const preparedProgram = options.preparedProgram;
+        if (preparedProgram) {
+            this.validatePreparedProgram(preparedProgram, options);
+        }
+
         const privateKey = options.privateKey;
-        let program = options.programSource;
-        let programName = options.programName;
-        let imports = options.programImports;
-        let edition = options.edition;
+        let program = preparedProgram?.programSource ?? options.programSource;
+        let programName = preparedProgram?.programName ?? options.programName;
+        const imports = options.programImports;
+        let edition = preparedProgram?.edition ?? options.edition;
 
         // Ensure the function exists on the network.
         if (program === undefined) {
@@ -1647,15 +1830,20 @@ class ProgramManager {
             throw "No private key provided and no private key set in the ProgramManager";
         }
 
-        const resolved = await this.resolveEditionAndAmendment(programName, edition);
-        edition = edition ?? resolved.edition;
+        if (!preparedProgram) {
+            const resolved = await this.resolveEditionAndAmendment(programName, edition);
+            edition = edition ?? resolved.edition;
+        }
 
         // Auto-convert bare string inputs to field elements where the function expects field type.
         const preparedInputs = this.prepareInputs(program, functionName, inputs);
 
         // Build ProgramImportsBuilder for import resolution (no key loading —
         // authorizations don't synthesize keys).
-        const { builder } = await this.buildProgramImports(program, imports, false, functionName);
+        const builder = preparedProgram
+            ? clonePreparedProgramBuilder(preparedProgram)
+            : (await this.buildProgramImports(program, imports, false, functionName)).builder;
+        const hasPreparedProcess = preparedProgram !== undefined;
         const hasImports = !builder.isEmpty();
 
         // Build and return an `Authorization` for the desired function.
@@ -1664,9 +1852,9 @@ class ProgramManager {
             program,
             functionName,
             preparedInputs,
-            hasImports ? undefined : imports,
+            hasPreparedProcess || hasImports ? undefined : imports,
             edition,
-            hasImports ? builder?.clone() : undefined,
+            hasPreparedProcess ? builder : hasImports ? builder.clone() : undefined,
         );
 
         return authorization;
@@ -1709,11 +1897,16 @@ class ProgramManager {
             inputs,
         } = options;
 
+        const preparedProgram = options.preparedProgram;
+        if (preparedProgram) {
+            this.validatePreparedProgram(preparedProgram, options);
+        }
+
         const privateKey = options.privateKey;
-        let program = options.programSource;
-        let programName = options.programName;
-        let imports = options.programImports;
-        let edition = options.edition;
+        let program = preparedProgram?.programSource ?? options.programSource;
+        let programName = preparedProgram?.programName ?? options.programName;
+        const imports = options.programImports;
+        let edition = preparedProgram?.edition ?? options.edition;
 
         // Ensure the function exists on the network.
         if (program === undefined) {
@@ -1748,15 +1941,20 @@ class ProgramManager {
             throw "No private key provided and no private key set in the ProgramManager";
         }
 
-        const resolved = await this.resolveEditionAndAmendment(programName, edition);
-        edition = edition ?? resolved.edition;
+        if (!preparedProgram) {
+            const resolved = await this.resolveEditionAndAmendment(programName, edition);
+            edition = edition ?? resolved.edition;
+        }
 
         // Auto-convert bare string inputs to field elements where the function expects field type.
         const preparedInputs = this.prepareInputs(program, functionName, inputs);
 
         // Build ProgramImportsBuilder for import resolution (no key loading —
         // authorizations don't synthesize keys).
-        const { builder } = await this.buildProgramImports(program, imports, false, functionName);
+        const builder = preparedProgram
+            ? clonePreparedProgramBuilder(preparedProgram)
+            : (await this.buildProgramImports(program, imports, false, functionName)).builder;
+        const hasPreparedProcess = preparedProgram !== undefined;
         const hasImports = !builder.isEmpty();
 
         // Build and return an `Authorization` for the desired function.
@@ -1765,9 +1963,9 @@ class ProgramManager {
             program,
             functionName,
             preparedInputs,
-            hasImports ? undefined : imports,
+            hasPreparedProcess || hasImports ? undefined : imports,
             edition,
-            hasImports ? builder?.clone() : undefined,
+            hasPreparedProcess ? builder : hasImports ? builder.clone() : undefined,
         );
 
         return authorization;
@@ -1818,14 +2016,19 @@ class ProgramManager {
             unchecked = false,
         } = options;
 
+        const preparedProgram = options.preparedProgram;
+        if (preparedProgram) {
+            this.validatePreparedProgram(preparedProgram, options);
+        }
+
         const baseFee = options.baseFee ? options.baseFee : 0;
         const privateKey = options.privateKey;
         const useFeeMaster = options.useFeeMaster ? options.useFeeMaster : false;
-        let program = options.programSource;
-        let programName = options.programName;
+        let program = preparedProgram?.programSource ?? options.programSource;
+        let programName = preparedProgram?.programName ?? options.programName;
         let feeRecord = options.feeRecord;
         let imports = options.programImports;
-        let edition = options.edition;
+        let edition = preparedProgram?.edition ?? options.edition;
 
         if (!inputs && !options.executionRequest) {
             throw new Error("Either function inputs or an execution request must be provided to form a proving request");
@@ -1851,8 +2054,10 @@ class ProgramManager {
             programName = Program.fromString(program).id();
         }
 
-        const resolved = await this.resolveEditionAndAmendment(programName, edition);
-        edition = edition ?? resolved.edition;
+        if (!preparedProgram) {
+            const resolved = await this.resolveEditionAndAmendment(programName, edition);
+            edition = edition ?? resolved.edition;
+        }
 
         // Get the private key from the account if it is not provided in the parameters.
         let executionPrivateKey = privateKey;
@@ -1866,7 +2071,7 @@ class ProgramManager {
 
         // Resolve the program imports if they exist.
         const numberOfImports = Program.fromString(program).getImports().length;
-        if (numberOfImports > 0 && !imports) {
+        if (!preparedProgram && numberOfImports > 0 && !imports) {
             try {
                 imports = <ProgramImports>(
                     await this.networkClient.getProgramImports(programName)
@@ -1910,7 +2115,10 @@ class ProgramManager {
         // Note: imports is kept for the Rust-side fee estimation fallback
         // (estimate_fee_for_authorization uses the legacy imports Object to avoid
         // a RefCell double-borrow — see proving_request.rs).
-        const { builder } = await this.buildProgramImports(program, imports, false, functionName);
+        const builder = preparedProgram
+            ? clonePreparedProgramBuilder(preparedProgram)
+            : (await this.buildProgramImports(program, imports, false, functionName)).builder;
+        const hasPreparedProcess = preparedProgram !== undefined;
         const hasImports = !builder.isEmpty();
 
         // Normalize imports to the full merged set from the builder so the
@@ -1918,9 +2126,10 @@ class ProgramManager {
         // caller's partial set. Use programNames + getProgram to avoid
         // serializing key bytes (toObject would serialize all proving/
         // verifying keys, which can be tens of MB).
-        if (hasImports) {
+        if (hasPreparedProcess || hasImports) {
             const merged: ProgramImports = {};
             for (const name of Array.from(builder.programNames())) {
+                if (name === programName) continue;
                 const src = builder.getProgram(name);
                 if (src) merged[name] = src;
             }
@@ -1936,7 +2145,7 @@ class ProgramManager {
                 edition,
                 imports, // kept for fee estimation in Rust
                 executionPrivateKey,
-                hasImports ? builder?.clone() : undefined,
+                hasPreparedProcess ? builder : hasImports ? builder.clone() : undefined,
             );
         } else {
             // Ensure the private key exists.
@@ -1966,7 +2175,7 @@ class ProgramManager {
                 unchecked,
                 edition,
                 useFeeMaster,
-                hasImports ? builder?.clone() : undefined,
+                hasPreparedProcess ? builder : hasImports ? builder.clone() : undefined,
             );
         }
     }
@@ -4384,4 +4593,4 @@ function programChecksum(program: string | Program): Uint8Array {
     }
 }
 
-export { ProgramManager, AuthorizationOptions, FeeAuthorizationOptions, ExecuteOptions, ProvingRequestOptions, ExternalSigningOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof, programChecksum };
+export { ProgramManager, PreparedProgram, PrepareProgramOptions, AuthorizationOptions, FeeAuthorizationOptions, ExecuteOptions, ProvingRequestOptions, ExternalSigningOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof, programChecksum };

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -145,6 +145,19 @@ function clonePreparedProgramBuilder(
     return builder.clone();
 }
 
+function programImportsFromBuilder(
+    builder: ProgramImportsBuilder,
+    entryProgramName: string,
+): ProgramImports {
+    const imports: ProgramImports = {};
+    for (const name of Array.from(builder.programNames())) {
+        if (name === entryProgramName) continue;
+        const source = builder.getProgram(name);
+        if (source) imports[name] = source;
+    }
+    return imports;
+}
+
 /**
  * A reusable program context created by {@link ProgramManager.prepareProgram}.
  *
@@ -2090,6 +2103,17 @@ class ProgramManager {
             }
         }
 
+        // A private-fee estimate runs before the prepared builder is passed to
+        // Rust, so materialize its complete import set for the estimate now.
+        if (preparedProgram) {
+            const preparedBuilder = clonePreparedProgramBuilder(preparedProgram);
+            try {
+                imports = programImportsFromBuilder(preparedBuilder, programName);
+            } finally {
+                preparedBuilder.free();
+            }
+        }
+
         // Get the fee record from the account if it is not provided in the parameters
         try {
             if (privateFee && !useFeeMaster && !options.executionRequest) {
@@ -2134,13 +2158,7 @@ class ProgramManager {
         // serializing key bytes (toObject would serialize all proving/
         // verifying keys, which can be tens of MB).
         if (hasPreparedProcess || hasImports) {
-            const merged: ProgramImports = {};
-            for (const name of Array.from(builder.programNames())) {
-                if (name === programName) continue;
-                const src = builder.getProgram(name);
-                if (src) merged[name] = src;
-            }
-            imports = merged;
+            imports = programImportsFromBuilder(builder, programName);
         }
 
         if (options.executionRequest instanceof ExecutionRequest) {

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -140,6 +140,8 @@ function clonePreparedProgramBuilder(
     if (!builder) {
         throw new Error("Prepared program has already been freed");
     }
+    // The WASM clone is a cheap shared Rc handle, not a deep copy. Mutations
+    // made while authorizing intentionally remain cached in the prepared context.
     return builder.clone();
 }
 
@@ -491,6 +493,11 @@ class ProgramManager {
         if (parsedProgram.id() !== options.programName) {
             throw new Error(
                 `Program source ID '${parsedProgram.id()}' does not match requested program '${options.programName}'`,
+            );
+        }
+        if (!parsedProgram.getFunctions().includes(options.functionName)) {
+            throw new Error(
+                `Function '${options.functionName}' does not exist in program '${options.programName}'`,
             );
         }
 

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -122,6 +122,16 @@ interface ExecuteOptions {
  * Preparing resolves the program source, edition, and transitive imports and
  * initializes the underlying snarkVM process. It does not require a private key
  * and does not create an authorization.
+ *
+ * @property programName Name of the program to prepare (e.g. "credits.aleo").
+ * @property functionName Function the prepared context is scoped to. Calls
+ *   using the context must target this function.
+ * @property programSource Optional program source. When omitted, the source
+ *   is fetched from the network, which requires the program to be deployed.
+ * @property programImports Optional import sources keyed by program name.
+ *   Missing transitive imports are fetched from the network.
+ * @property edition Optional program edition. Defaults to the edition
+ *   currently on-chain, resolved via a network call.
  */
 interface PrepareProgramOptions {
     programName: string;
@@ -483,8 +493,24 @@ class ProgramManager {
      * returned context through the `preparedProgram` option, then call `free()`
      * when it is no longer needed.
      *
-     * @param {PrepareProgramOptions} options Program and function to prepare.
-     * @returns {Promise<PreparedProgram>} A reusable, caller-owned context.
+     * @param options Program and function to prepare.
+     * @returns A reusable, caller-owned context.
+     *
+     * @example
+     * const prepared = await programManager.prepareProgram({
+     *     programName: "hello_hello.aleo",
+     *     functionName: "hello",
+     * });
+     * try {
+     *     const authorization = await programManager.buildAuthorization({
+     *         programName: "hello_hello.aleo",
+     *         functionName: "hello",
+     *         inputs: ["5u32", "5u32"],
+     *         preparedProgram: prepared,
+     *     });
+     * } finally {
+     *     prepared.free();
+     * }
      */
     async prepareProgram(
         options: PrepareProgramOptions,
@@ -2103,15 +2129,29 @@ class ProgramManager {
             }
         }
 
-        // A private-fee estimate runs before the prepared builder is passed to
-        // Rust, so materialize its complete import set for the estimate now.
-        if (preparedProgram) {
-            const preparedBuilder = clonePreparedProgramBuilder(preparedProgram);
-            try {
-                imports = programImportsFromBuilder(preparedBuilder, programName);
-            } finally {
-                preparedBuilder.free();
-            }
+        // Build ProgramImportsBuilder for import resolution (no key loading —
+        // proving requests don't synthesize keys).
+        const builder = preparedProgram
+            ? clonePreparedProgramBuilder(preparedProgram)
+            : (await this.buildProgramImports(program, imports, false, functionName)).builder;
+        const hasPreparedProcess = preparedProgram !== undefined;
+        const hasImports = !builder.isEmpty();
+
+        // Normalize imports once to the full merged set from the builder so
+        // both the private-fee estimate below and the Rust-side fee estimator
+        // (estimate_fee_for_authorization uses the legacy imports Object to
+        // avoid a RefCell double-borrow — see proving_request.rs) see all
+        // transitive imports, not just the caller's partial set. Use
+        // programNames + getProgram to avoid serializing key bytes (toObject
+        // would serialize all proving/verifying keys, which can be tens of
+        // MB). The prepared executionRequest path skips the copy: it passes
+        // the process builder directly and never estimates fees, so the
+        // imports Object goes unused there.
+        const importsObjectUnused =
+            hasPreparedProcess
+            && options.executionRequest instanceof ExecutionRequest;
+        if ((hasPreparedProcess || hasImports) && !importsObjectUnused) {
+            imports = programImportsFromBuilder(builder, programName);
         }
 
         // Get the fee record from the account if it is not provided in the parameters
@@ -2141,26 +2181,6 @@ class ProgramManager {
             );
         }
 
-        // Build ProgramImportsBuilder for import resolution (no key loading —
-        // proving requests don't synthesize keys).
-        // Note: imports is kept for the Rust-side fee estimation fallback
-        // (estimate_fee_for_authorization uses the legacy imports Object to avoid
-        // a RefCell double-borrow — see proving_request.rs).
-        const builder = preparedProgram
-            ? clonePreparedProgramBuilder(preparedProgram)
-            : (await this.buildProgramImports(program, imports, false, functionName)).builder;
-        const hasPreparedProcess = preparedProgram !== undefined;
-        const hasImports = !builder.isEmpty();
-
-        // Normalize imports to the full merged set from the builder so the
-        // Rust fee estimator sees all transitive imports, not just the
-        // caller's partial set. Use programNames + getProgram to avoid
-        // serializing key bytes (toObject would serialize all proving/
-        // verifying keys, which can be tens of MB).
-        if (hasPreparedProcess || hasImports) {
-            imports = programImportsFromBuilder(builder, programName);
-        }
-
         if (options.executionRequest instanceof ExecutionRequest) {
             return await WasmProgramManager.buildProvingRequestFromExecutionRequest(
                 options.executionRequest,
@@ -2168,7 +2188,9 @@ class ProgramManager {
                 unchecked,
                 broadcast,
                 edition,
-                imports, // kept for fee estimation in Rust
+                // The prepared process supersedes the legacy imports Object;
+                // without one, imports is kept for fee estimation in Rust.
+                hasPreparedProcess ? undefined : imports,
                 executionPrivateKey,
                 hasPreparedProcess ? builder : hasImports ? builder.clone() : undefined,
             );

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1524,6 +1524,61 @@ describe("ProgramImportsBuilder", () => {
             }
         });
 
+        it("should materialize prepared imports exactly once per proving request", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+
+            sinon.stub(pm.networkClient, "getProgramImports").resolves({
+                "multiply_test.aleo": MULTIPLY_PROGRAM,
+            });
+            sinon.stub(pm.networkClient, "getProgramAmendmentCount").resolves({
+                program_id: "multiply_test.aleo",
+                edition: 1,
+                amendment_count: 0,
+            });
+
+            const preparedProgram = await pm.prepareProgram({
+                programName: "double_test.aleo",
+                functionName: "double_it",
+                programSource: DOUBLE_PROGRAM,
+                programImports: {
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                },
+                edition: 1,
+            });
+            sinon.stub(pm, "estimateExecutionFee").resolves(1n);
+            sinon.stub(pm, "getCreditsRecord").resolves({} as any);
+            sinon.stub(ProgramManagerBase, "buildProvingRequest").resolves({} as any);
+
+            // Copying import sources out of WASM dominates the prepared-path
+            // overhead in provingRequest. programImportsFromBuilder walks
+            // programNames once per materialization, so one call proves the
+            // import set crossed the WASM boundary exactly once.
+            const programNamesSpy = sinon.spy(
+                ProgramImportsBuilder.prototype,
+                "programNames",
+            );
+            try {
+                await pm.provingRequest({
+                    programName: "double_test.aleo",
+                    functionName: "double_it",
+                    inputs: ["5u32"],
+                    priorityFee: 0,
+                    privateFee: true,
+                    privateKey: new PrivateKey(),
+                    broadcast: false,
+                    unchecked: true,
+                    useFeeMaster: false,
+                    preparedProgram,
+                });
+
+                expect(programNamesSpy.callCount).to.equal(1);
+            } finally {
+                programNamesSpy.restore();
+                preparedProgram.free();
+            }
+        });
+
         it("should reject preparing a function that does not exist", async () => {
             const keyProvider = createMockKeyProvider();
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1384,7 +1384,7 @@ describe("ProgramImportsBuilder", () => {
     describe("Prepared programs", function () {
         this.timeout(60_000);
 
-        it("should reuse a prepared process for proving-request generation", async () => {
+        it("should reuse a prepared process for fee-master and direct-fee proving requests", async () => {
             const keyProvider = createMockKeyProvider();
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
             const privateKey = new PrivateKey();
@@ -1448,10 +1448,52 @@ describe("ProgramImportsBuilder", () => {
 
                 expect(provingRequest.authorization().transitions().length).to.equal(2);
                 expect(provingRequest.feeAuthorization()).to.equal(undefined);
+
+                const directFeeProvingRequest = await pm.provingRequest({
+                    programName: "double_test.aleo",
+                    functionName: "double_it",
+                    inputs: ["5u32"],
+                    priorityFee: 0,
+                    privateFee: false,
+                    privateKey,
+                    programSource: DOUBLE_PROGRAM,
+                    programImports: {
+                        "multiply_test.aleo": MULTIPLY_PROGRAM,
+                    },
+                    edition: 1,
+                    broadcast: false,
+                    unchecked: true,
+                    useFeeMaster: false,
+                    preparedProgram,
+                });
+
+                expect(directFeeProvingRequest.authorization().transitions().length).to.equal(2);
+                expect(directFeeProvingRequest.feeAuthorization()).to.not.equal(undefined);
                 expect(buildImportsSpy.calledOnce).to.equal(true);
             } finally {
                 preparedProgram.free();
             }
+        });
+
+        it("should reject preparing a function that does not exist", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+
+            let error: Error | undefined;
+            try {
+                await pm.prepareProgram({
+                    programName: "multiply_test.aleo",
+                    functionName: "missing",
+                    programSource: MULTIPLY_PROGRAM,
+                    edition: 1,
+                });
+            } catch (e) {
+                error = e as Error;
+            }
+
+            expect(error?.message).to.equal(
+                "Function 'missing' does not exist in program 'multiply_test.aleo'",
+            );
         });
 
         it("should reject a prepared context for a different function", async () => {
@@ -1480,6 +1522,76 @@ describe("ProgramImportsBuilder", () => {
 
                 expect(error?.message).to.contain(
                     "Prepared program is for multiply_test.aleo/multiply",
+                );
+            } finally {
+                preparedProgram.free();
+            }
+        });
+
+        it("should reject source, edition, and import mismatches", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const privateKey = new PrivateKey();
+            const preparedProgram = await pm.prepareProgram({
+                programName: "double_test.aleo",
+                functionName: "double_it",
+                programSource: DOUBLE_PROGRAM,
+                programImports: {
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                },
+                edition: 1,
+            });
+
+            const expectValidationError = async (
+                action: () => Promise<unknown>,
+                expectedMessage: string,
+            ) => {
+                let error: Error | undefined;
+                try {
+                    await action();
+                } catch (e) {
+                    error = e as Error;
+                }
+                expect(error?.message).to.equal(expectedMessage);
+            };
+
+            try {
+                await expectValidationError(
+                    () => pm.buildAuthorizationUnchecked({
+                        programName: "double_test.aleo",
+                        functionName: "double_it",
+                        inputs: ["5u32"],
+                        privateKey,
+                        programSource: `${DOUBLE_PROGRAM}\n`,
+                        preparedProgram,
+                    }),
+                    "Prepared program source does not match the supplied program source",
+                );
+
+                await expectValidationError(
+                    () => pm.buildAuthorizationUnchecked({
+                        programName: "double_test.aleo",
+                        functionName: "double_it",
+                        inputs: ["5u32"],
+                        privateKey,
+                        edition: 2,
+                        preparedProgram,
+                    }),
+                    "Prepared program edition does not match the supplied edition",
+                );
+
+                await expectValidationError(
+                    () => pm.buildAuthorizationUnchecked({
+                        programName: "double_test.aleo",
+                        functionName: "double_it",
+                        inputs: ["5u32"],
+                        privateKey,
+                        programImports: {
+                            "multiply_test.aleo": ADD_PROGRAM,
+                        },
+                        preparedProgram,
+                    }),
+                    "Prepared program import 'multiply_test.aleo' does not match the supplied import",
                 );
             } finally {
                 preparedProgram.free();

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1381,6 +1381,141 @@ describe("ProgramImportsBuilder", () => {
         });
     });
 
+    describe("Prepared programs", function () {
+        this.timeout(60_000);
+
+        it("should reuse a prepared process for proving-request generation", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const privateKey = new PrivateKey();
+
+            sinon.stub(pm.networkClient, "getProgramImports").resolves({
+                "multiply_test.aleo": MULTIPLY_PROGRAM,
+            });
+            sinon.stub(pm.networkClient, "getProgramAmendmentCount").resolves({
+                program_id: "multiply_test.aleo",
+                edition: 1,
+                amendment_count: 0,
+            });
+            const buildImportsSpy = sinon.spy(pm as any, "buildProgramImports");
+
+            const preparedProgram = await pm.prepareProgram({
+                programName: "double_test.aleo",
+                functionName: "double_it",
+                programSource: DOUBLE_PROGRAM,
+                programImports: {
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                },
+                edition: 1,
+            });
+
+            expect(preparedProgram.programName).to.equal("double_test.aleo");
+            expect(preparedProgram.functionName).to.equal("double_it");
+
+            try {
+                const authorization = await pm.buildAuthorizationUnchecked({
+                    programName: "double_test.aleo",
+                    functionName: "double_it",
+                    inputs: ["5u32"],
+                    privateKey,
+                    programSource: DOUBLE_PROGRAM,
+                    programImports: {
+                        "multiply_test.aleo": MULTIPLY_PROGRAM,
+                    },
+                    edition: 1,
+                    preparedProgram,
+                });
+                expect(authorization.transitions().length).to.equal(2);
+                authorization.free();
+
+                const provingRequest = await pm.provingRequest({
+                    programName: "double_test.aleo",
+                    functionName: "double_it",
+                    inputs: ["5u32"],
+                    priorityFee: 0,
+                    privateFee: false,
+                    privateKey,
+                    programSource: DOUBLE_PROGRAM,
+                    programImports: {
+                        "multiply_test.aleo": MULTIPLY_PROGRAM,
+                    },
+                    edition: 1,
+                    broadcast: false,
+                    unchecked: true,
+                    useFeeMaster: true,
+                    preparedProgram,
+                });
+
+                expect(provingRequest.authorization().transitions().length).to.equal(2);
+                expect(provingRequest.feeAuthorization()).to.equal(undefined);
+                expect(buildImportsSpy.calledOnce).to.equal(true);
+            } finally {
+                preparedProgram.free();
+            }
+        });
+
+        it("should reject a prepared context for a different function", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const preparedProgram = await pm.prepareProgram({
+                programName: "multiply_test.aleo",
+                functionName: "multiply",
+                programSource: MULTIPLY_PROGRAM,
+                edition: 1,
+            });
+
+            try {
+                let error: Error | undefined;
+                try {
+                    await pm.buildAuthorizationUnchecked({
+                        programName: "multiply_test.aleo",
+                        functionName: "other",
+                        inputs: ["2u32", "3u32"],
+                        privateKey: new PrivateKey(),
+                        preparedProgram,
+                    });
+                } catch (e) {
+                    error = e as Error;
+                }
+
+                expect(error?.message).to.contain(
+                    "Prepared program is for multiply_test.aleo/multiply",
+                );
+            } finally {
+                preparedProgram.free();
+            }
+        });
+
+        it("should fail clearly after a prepared context is freed", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const preparedProgram = await pm.prepareProgram({
+                programName: "multiply_test.aleo",
+                functionName: "multiply",
+                programSource: MULTIPLY_PROGRAM,
+                edition: 1,
+            });
+
+            preparedProgram.free();
+            preparedProgram.free();
+
+            let error: Error | undefined;
+            try {
+                await pm.buildAuthorizationUnchecked({
+                    programName: "multiply_test.aleo",
+                    functionName: "multiply",
+                    inputs: ["2u32", "3u32"],
+                    privateKey: new PrivateKey(),
+                    preparedProgram,
+                });
+            } catch (e) {
+                error = e as Error;
+            }
+
+            expect(error?.message).to.equal("Prepared program has already been freed");
+        });
+    });
+
     // =========================================================================
     // Integration tests — require WASM execution (slow, ~10-20s each)
     // =========================================================================

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1475,6 +1475,55 @@ describe("ProgramImportsBuilder", () => {
             }
         });
 
+        it("should use prepared imports when estimating a private fee record", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+
+            sinon.stub(pm.networkClient, "getProgramImports").resolves({
+                "multiply_test.aleo": MULTIPLY_PROGRAM,
+            });
+            sinon.stub(pm.networkClient, "getProgramAmendmentCount").resolves({
+                program_id: "multiply_test.aleo",
+                edition: 1,
+                amendment_count: 0,
+            });
+
+            const preparedProgram = await pm.prepareProgram({
+                programName: "double_test.aleo",
+                functionName: "double_it",
+                programSource: DOUBLE_PROGRAM,
+                programImports: {
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                },
+                edition: 1,
+            });
+            const estimateFeeStub = sinon.stub(pm, "estimateExecutionFee").resolves(1n);
+            sinon.stub(pm, "getCreditsRecord").resolves({} as any);
+            sinon.stub(ProgramManagerBase, "buildProvingRequest").resolves({} as any);
+
+            try {
+                await pm.provingRequest({
+                    programName: "double_test.aleo",
+                    functionName: "double_it",
+                    inputs: ["5u32"],
+                    priorityFee: 0,
+                    privateFee: true,
+                    privateKey: new PrivateKey(),
+                    broadcast: false,
+                    unchecked: true,
+                    useFeeMaster: false,
+                    preparedProgram,
+                });
+
+                expect(estimateFeeStub.calledOnce).to.equal(true);
+                expect(estimateFeeStub.firstCall.args[0].imports).to.deep.equal({
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                });
+            } finally {
+                preparedProgram.free();
+            }
+        });
+
         it("should reject preparing a function that does not exist", async () => {
             const keyProvider = createMockKeyProvider();
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);


### PR DESCRIPTION
## Motivation

The high-level `ProgramManager` APIs currently create a new `ProgramImportsBuilder` and snarkVM process for every authorization and proving request. Wallets know the requested program, function, edition, and supplied dynamic imports while an approval screen is visible, but cannot prepare that process through the high-level API and reuse it after approval.

This adds an explicit, caller-owned prepared context:

- `ProgramManager.prepareProgram()` resolves the source, edition, transitive imports, and initializes the entry program in a reusable snarkVM process.
- Preparation fails fast if the requested function does not exist.
- `buildAuthorization`, `buildAuthorizationUnchecked`, and `provingRequest` accept the resulting `preparedProgram`.
- Reuse validates program/function identity plus any supplied source, edition, and imports to prevent stale-context mismatches.
- Preparation does not use a private key and does not create an authorization.
- `PreparedProgram.free()` provides explicit cleanup; calls sharing a context are documented as sequential.
- There is no automatic global cache or hidden invalidation policy.

Example:

```ts
const preparedProgram = await programManager.prepareProgram({
    programName,
    functionName,
    programSource,
    programImports,
    edition,
});

try {
    const request = await programManager.provingRequest({
        programName,
        functionName,
        inputs,
        priorityFee: 0,
        privateFee: false,
        privateKey,
        unchecked: true,
        useFeeMaster: true,
        preparedProgram,
    });
} finally {
    preparedProgram.free();
}
```

For the representative testnet swap transaction `at174kyef8hwfyv7v2tk67x3truvcc4zm2ldh0rwmdqn8an48l08u9q27xwsw`, the existing low-level builder reuse moved roughly 1.05–1.11 s of process/import setup ahead of authorization and reduced unchecked authorization after the click from about 1.37 s to 0.25–0.30 s. This PR makes that existing reuse available safely through the high-level API.

## Test Plan

- `yarn build:wasm` (unchanged WASM baseline)
- `yarn build:sdk`
- Prepared-context tests bundled and run for testnet and mainnet — 10 passed
- Tests cover fee-master and direct-fee proving requests, repeated authorization/proving-request reuse, missing-function and context-mismatch rejection, and idempotent cleanup

## Related PRs

- #1381 — skip unneeded fee work for fee-master proving requests
- ProvableHQ/shield-core#256 — request unchecked authorization for delegated proving

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core authorization/proving paths and WASM builder lifetime; validation reduces stale-context risk but incorrect reuse could still produce wrong fees or failed proofs.
> 
> **Overview**
> Adds **`ProgramManager.prepareProgram()`** and a caller-owned **`PreparedProgram`** type so wallets can resolve program source, edition, and imports and warm the snarkVM process **before** the user approves (no private key required), then reuse that work for authorization and proving.
> 
> **`buildAuthorization`**, **`buildAuthorizationUnchecked`**, and **`provingRequest`** accept an optional **`preparedProgram`**; reuse skips re-fetching edition/imports and re-building **`ProgramImportsBuilder`** when the prepared path is used. **`validatePreparedProgram`** rejects mismatched program/function, source, edition, or imports, and use after **`free()`** fails clearly.
> 
> **`provingRequest`** with a prepared context normalizes transitive imports once for private-fee estimation and passes the prepared WASM builder into Rust instead of the legacy imports object where appropriate. **`PreparedProgram`**, **`PrepareProgramOptions`**, and related types are exported from the public SDK entrypoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15a5d91de975a4399eeb4f35458eaaaeea8a0442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->