### PR TITLE
Enforce sequential use of prepared program contexts

### DIFF
--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -133,6 +133,36 @@ interface PrepareProgramOptions {
 
 const preparedProgramBuilders = new WeakMap<object, ProgramImportsBuilder>();
 
+const busyPreparedPrograms = new WeakSet<object>();
+
+/**
+ * Run `action` while holding exclusive use of `preparedProgram`.
+ *
+ * The prepared snarkVM process is shared state (the WASM builder clones are
+ * reference-counted handles to one process), so concurrent calls would race on
+ * it and abort the WASM module with a borrow panic. This guard turns that into
+ * a catchable error instead.
+ */
+async function withPreparedProgram<T>(
+    preparedProgram: PreparedProgram | undefined,
+    action: () => Promise<T>,
+): Promise<T> {
+    if (!preparedProgram) {
+        return action();
+    }
+    if (busyPreparedPrograms.has(preparedProgram)) {
+        throw new Error(
+            "Prepared program is already in use; calls sharing a prepared program must be sequential",
+        );
+    }
+    busyPreparedPrograms.add(preparedProgram);
+    try {
+        return await action();
+    } finally {
+        busyPreparedPrograms.delete(preparedProgram);
+    }
+}
+
 function clonePreparedProgramBuilder(
     preparedProgram: PreparedProgram,
 ): ProgramImportsBuilder {
@@ -162,8 +192,9 @@ function programImportsFromBuilder(
  * A reusable program context created by {@link ProgramManager.prepareProgram}.
  *
  * The context is scoped to one program function. Calls using it must be
- * sequential. The caller owns the context and should call {@link free} when it
- * is no longer needed.
+ * sequential — a call made while another call is still using the context is
+ * rejected with an error. The caller owns the context and should call
+ * {@link free} when it is no longer needed.
  */
 class PreparedProgram {
     readonly programName: string;
@@ -1800,6 +1831,13 @@ class ProgramManager {
     async buildAuthorization(
         options: AuthorizationOptions,
     ): Promise<Authorization> {
+        return withPreparedProgram(options.preparedProgram, () =>
+            this.buildAuthorizationInner(options));
+    }
+
+    private async buildAuthorizationInner(
+        options: AuthorizationOptions,
+    ): Promise<Authorization> {
         // Destructure the options object to access the parameters.
         const {
             functionName,
@@ -1909,6 +1947,13 @@ class ProgramManager {
      * });
      */
     async buildAuthorizationUnchecked(
+        options: AuthorizationOptions,
+    ): Promise<Authorization> {
+        return withPreparedProgram(options.preparedProgram, () =>
+            this.buildAuthorizationUncheckedInner(options));
+    }
+
+    private async buildAuthorizationUncheckedInner(
         options: AuthorizationOptions,
     ): Promise<Authorization> {
         // Destructure the options object to access the parameters.
@@ -2023,6 +2068,13 @@ class ProgramManager {
      * });
      */
     async provingRequest(
+        options: ProvingRequestOptions,
+    ): Promise<ProvingRequest> {
+        return withPreparedProgram(options.preparedProgram, () =>
+            this.provingRequestInner(options));
+    }
+
+    private async provingRequestInner(
         options: ProvingRequestOptions,
     ): Promise<ProvingRequest> {
         // Destructure the options object to access the parameters.

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1675,6 +1675,93 @@ describe("ProgramImportsBuilder", () => {
 
             expect(error?.message).to.equal("Prepared program has already been freed");
         });
+
+        it("should reject a concurrent call while a prepared context is in use", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const privateKey = new PrivateKey();
+            const preparedProgram = await pm.prepareProgram({
+                programName: "multiply_test.aleo",
+                functionName: "multiply",
+                programSource: MULTIPLY_PROGRAM,
+                edition: 1,
+            });
+
+            const authorizationOptions = {
+                programName: "multiply_test.aleo",
+                functionName: "multiply",
+                inputs: ["2u32", "3u32"],
+                privateKey,
+                preparedProgram,
+            };
+
+            try {
+                const firstCall = pm.buildAuthorizationUnchecked(authorizationOptions);
+
+                let error: Error | undefined;
+                try {
+                    await pm.buildAuthorizationUnchecked(authorizationOptions);
+                } catch (e) {
+                    error = e as Error;
+                }
+                expect(error?.message).to.equal(
+                    "Prepared program is already in use; calls sharing a prepared program must be sequential",
+                );
+
+                // The in-flight call is unaffected by the rejected one.
+                const authorization = await firstCall;
+                expect(authorization.transitions().length).to.equal(1);
+                authorization.free();
+
+                // The context is released once the in-flight call settles.
+                const nextAuthorization = await pm.buildAuthorizationUnchecked(authorizationOptions);
+                expect(nextAuthorization.transitions().length).to.equal(1);
+                nextAuthorization.free();
+            } finally {
+                preparedProgram.free();
+            }
+        });
+
+        it("should release a prepared context when a call fails", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const privateKey = new PrivateKey();
+            const preparedProgram = await pm.prepareProgram({
+                programName: "multiply_test.aleo",
+                functionName: "multiply",
+                programSource: MULTIPLY_PROGRAM,
+                edition: 1,
+            });
+
+            try {
+                let error: Error | undefined;
+                try {
+                    await pm.buildAuthorizationUnchecked({
+                        programName: "multiply_test.aleo",
+                        functionName: "other",
+                        inputs: ["2u32", "3u32"],
+                        privateKey,
+                        preparedProgram,
+                    });
+                } catch (e) {
+                    error = e as Error;
+                }
+                expect(error?.message).to.contain("Prepared program is for multiply_test.aleo/multiply");
+
+                // The failed call must not leave the context marked as in use.
+                const authorization = await pm.buildAuthorizationUnchecked({
+                    programName: "multiply_test.aleo",
+                    functionName: "multiply",
+                    inputs: ["2u32", "3u32"],
+                    privateKey,
+                    preparedProgram,
+                });
+                expect(authorization.transitions().length).to.equal(1);
+                authorization.free();
+            } finally {
+                preparedProgram.free();
+            }
+        });
     });
 
     // =========================================================================


### PR DESCRIPTION
## Motivation

A `PreparedProgram`'s WASM builder clones are reference-counted handles to one shared snarkVM process (`Rc<RefCell<ProgramImportsInner>>`). The Rust side holds the `RefMut` guard from `prepare_for_execution` for the duration of an execution, so two calls using the same prepared context concurrently can hit a `RefCell` double-borrow panic — which aborts the entire WASM module rather than throwing a catchable error. The sequential-use contract is documented, but nothing enforces it, and a wallet firing two approvals in quick succession is a realistic path to that abort.

This adds a lightweight runtime guard: a module-level `WeakSet` marks a `PreparedProgram` as in use for the duration of any `buildAuthorization`, `buildAuthorizationUnchecked`, or `provingRequest` call that carries it. A second call arriving while the context is busy is rejected synchronously with a catchable error:

```
Prepared program is already in use; calls sharing a prepared program must be sequential
```

The guard is a synchronous `WeakSet` check around calls that take hundreds of milliseconds, so it adds no measurable overhead and no WASM round-trips. It does not serialize anything that was not already required to be sequential — it only converts the failure mode from a module-aborting panic into an error the caller can handle by queueing or retrying.

Implementation notes:

- The public methods became thin wrappers delegating to private `*Inner` methods, so the guard's `try`/`finally` covers the whole call (including `validatePreparedProgram`'s builder clone) without reindenting the method bodies.
- The busy flag always releases in `finally`, so failed calls (e.g. validation mismatches) do not poison the context.
- Calls without a `preparedProgram` bypass the guard entirely.

## Test Plan

- `yarn build:sdk`
- New tests in the prepared-programs suite, run for testnet and mainnet:
  - a concurrent call while a prepared context is in use is rejected with the busy error; the in-flight call is unaffected and the context is usable again after it settles
  - a failed call (context mismatch) releases the context for subsequent use
- Verified the concurrency test fails without the guard, and the release test fails if the `finally` release is removed
- Full bundled SDK test suite run locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SDK guard around prepared-program authorization paths; behavior change is rejecting illegal concurrency rather than changing successful execution semantics.
> 
> **Overview**
> **Enforces the documented sequential-use contract for `PreparedProgram`** so overlapping wallet-style calls fail with a catchable error instead of aborting the WASM module on a shared snarkVM `RefCell` borrow.
> 
> Adds `withPreparedProgram`, which marks a prepared context busy in a module-level `WeakSet` for the duration of the work and clears it in `finally`. `buildAuthorization`, `buildAuthorizationUnchecked`, and `provingRequest` are thin wrappers around existing `*Inner` implementations; calls without `preparedProgram` are unchanged.
> 
> `PreparedProgram` docs now state that a second call while one is in flight is rejected. Tests cover concurrent rejection (in-flight call still succeeds, context is reusable afterward) and release after validation failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334d4e42675ed4c3d73b4777b134e3cc0890e740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->